### PR TITLE
Fix silent context-exhaustion wedge that stopped threads answering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "emoji-regex": "^10.6.0",
         "emojibase-data": "^17.0.0",
         "flubber": "^0.4.2",
+        "gpt-tokenizer": "^3.4.0",
         "hono": "^4.12.3",
         "hono-zod-openapi": "^1.1.1",
         "isbot": "^5.1.17",
@@ -1506,6 +1507,8 @@
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gpt-tokenizer": ["gpt-tokenizer@3.4.0", "", {}, "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
 		"emoji-regex": "^10.6.0",
 		"emojibase-data": "^17.0.0",
 		"flubber": "^0.4.2",
+		"gpt-tokenizer": "^3.4.0",
 		"hono": "^4.12.3",
 		"hono-zod-openapi": "^1.1.1",
 		"isbot": "^5.1.17",

--- a/workers/main/src/chat-thread-do.ts
+++ b/workers/main/src/chat-thread-do.ts
@@ -209,7 +209,8 @@ import {
   piModelContextWindow,
   piCompactionReserveTokens,
   capPiMainRequestOutput,
-  estimatePiCompactionTokens,
+  effectivePiContextTokens,
+  isPiLengthStopContextExhaustion,
   shouldCompactPiAfterAssistantUsage,
   loadPiCompleteSimple,
   findPiCompactionCutIndex,
@@ -217,6 +218,7 @@ import {
   createFallbackPiCompactionSummary,
   createPiSummaryMessage,
 } from "./chat-thread/pi-compaction";
+import { measurePiContextTokens } from "./chat-thread/pi-token-count";
 
 // Agent-eval helpers (timeout, result extraction, deployed-app collection).
 import {
@@ -5314,7 +5316,14 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     const contextWindow = piModelContextWindow(model);
     const reserveTokens = piCompactionReserveTokens(model);
     const keepRecentTokens = 20_000;
-    const tokens = estimatePiCompactionTokens(messages);
+    // Three sources, most trustworthy first: what the provider actually charged
+    // for everything up to the last turn (exact and free), plus a real BPE
+    // count of only the messages added since (accurate, and cheap because that
+    // tail is small). The character heuristic alone used to decide this, and it
+    // read 137,964 tokens for a request the provider billed at 216,184 — far
+    // enough under the threshold that compaction never ran while the thread was
+    // already too full to answer.
+    const tokens = await measurePiContextTokens(messages, contextWindow);
     if (!force && tokens < contextWindow - reserveTokens) {
       return messages;
     }
@@ -5328,7 +5337,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       }
     } else if (existing && existing.firstKeptIndex > 0 && existing.firstKeptIndex < messages.length) {
       const tail = messages.slice(existing.firstKeptIndex);
-      if (estimatePiCompactionTokens([
+      if (effectivePiContextTokens([
         createPiSummaryMessage(existing.summary),
         ...tail,
       ]) < contextWindow - reserveTokens) {
@@ -5369,6 +5378,48 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     }
   }
 
+  /**
+   * A turn whose input filled the context window stops with `length` before it
+   * can say anything. Left alone this reads to the user as the agent silently
+   * ignoring them — the case that wedged a production thread for five hours
+   * across eleven unanswered messages, with nothing in the error telemetry
+   * because a `length` stop is not a provider error. Record it and return text
+   * to surface, so the turn explains itself instead of rendering blank.
+   * Post-turn compaction (scheduled from the same `agent_end`) shrinks the
+   * history, so the user's next message has room to run.
+   */
+  private piContextExhaustionNotice(messages: AgentMessage[]): string {
+    const model = this.piSession?.state.model;
+    const contextWindow = piModelContextWindow(model);
+    const latest = latestPiAssistantMessage(messages);
+    if (!latest || !isPiLengthStopContextExhaustion(latest, contextWindow)) {
+      return "";
+    }
+
+    const usage = (latest as unknown as { usage?: { input?: unknown; cacheRead?: unknown } }).usage;
+    const inputTokens =
+      Math.max(0, Math.floor(Number(usage?.input ?? 0))) +
+      Math.max(0, Math.floor(Number(usage?.cacheRead ?? 0)));
+    this.recordChatThreadObservabilityEvent("chat_context_exhausted", {
+      operation: "pi_turn",
+      status: "context_exhausted",
+      severity: "error",
+      count: inputTokens,
+      size: contextWindow,
+      model: typeof model?.id === "string" ? model.id : null,
+      provider: this.piCurrentUsageProvider || null,
+      error: new Error(
+        `Pi turn stopped at length with no usable output: ${inputTokens} input tokens against a ${contextWindow} context window`,
+      ),
+    });
+
+    return (
+      "This conversation has grown past what the model can read in one go, so that turn had no room left to answer. " +
+      "I've just compacted the earlier history — send your message again and I'll pick it up. " +
+      "If it keeps happening, starting a fresh chat for this task will give me the most room to work."
+    );
+  }
+
   private maybeSchedulePiPostTurnCompaction(messages: AgentMessage[]): void {
     const latestAssistant = latestPiAssistantMessage(messages);
     if (!latestAssistant || !shouldCompactPiAfterAssistantUsage(latestAssistant, this.piSession?.state.model)) {
@@ -5385,9 +5436,21 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
   private async compactPiContextAfterTurn(triggerMessage: AgentMessage): Promise<void> {
     const resolver = this.piModelResolver;
     const session = this.piSession;
+    if (!resolver || !session) return;
+
+    // `agent_end` fires from inside the Pi run, and `isStreaming` is only
+    // cleared afterwards in the agent's `finally` (`finishRun`). Guarding on it
+    // here without waiting meant this method returned on its very first check
+    // every single time, so post-turn compaction never ran in production: a
+    // thread that outgrew its window stayed oversized forever and every later
+    // turn died with nothing to show the user. Wait for the run to settle
+    // first. Safe to await because the caller schedules this via `waitUntil`
+    // and does not block `agent_end` on it — awaiting inside the listener
+    // itself would deadlock, since `waitForIdle` only resolves after listeners
+    // settle.
+    await session.waitForIdle();
+
     if (
-      !resolver ||
-      !session ||
       session.state.isStreaming ||
       !shouldCompactPiAfterAssistantUsage(triggerMessage, session.state.model)
     ) {
@@ -6074,7 +6137,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
           ? this.ensurePiUserStopMessage(event.messages, stoppedByUserAtMs)
           : this.ensurePiAssistantTextMessage(
               event.messages,
-              this.piAssistantText,
+              this.piAssistantText || this.piContextExhaustionNotice(event.messages),
             ),
       );
       this.maybeSchedulePiPostTurnCompaction(newMessages);

--- a/workers/main/src/chat-thread/pi-compaction.ts
+++ b/workers/main/src/chat-thread/pi-compaction.ts
@@ -90,6 +90,42 @@ export function shouldCompactPiAfterAssistantUsage(
   return contextTokens >= contextWindow - piCompactionReserveTokens(model);
 }
 
+/**
+ * A `length` stop that produced no usable answer means the input filled the
+ * window and left no room to generate. Pi's own `isContextOverflow` covers this
+ * (its "Xiaomi MiMo" case) but only for `output === 0` at `>= 99%` of the
+ * window. Real exhaustion routinely misses both bars: a reasoning model emits a
+ * token or two of thinking before the budget runs out, and providers that
+ * reserve their own headroom stop short of 99%. A camelCode thread wedged
+ * permanently at `input: 216149 / 220000` (98.25%) with `output: 1` — one
+ * reasoning token — and every later turn repeated it, because neither bar was
+ * met so nothing forced compaction. Keep Pi's check and widen it: no usable
+ * output plus a near-full window is exhaustion regardless of the exact counts.
+ */
+const PI_LENGTH_STOP_MAX_USABLE_OUTPUT_TOKENS = 16;
+const PI_LENGTH_STOP_CONTEXT_FRACTION = 0.9;
+
+export function isPiLengthStopContextExhaustion(
+  message: AgentMessage,
+  contextWindow: number,
+): boolean {
+  const record = message as unknown as {
+    role?: unknown;
+    stopReason?: unknown;
+    usage?: { input?: unknown; cacheRead?: unknown; output?: unknown };
+  };
+  if (record.role !== "assistant") return false;
+  if (record.stopReason !== "length") return false;
+  if (!contextWindow || contextWindow <= 0) return false;
+  const usage = record.usage;
+  if (!usage || typeof usage !== "object") return false;
+  const output = Math.max(0, Math.floor(Number(usage.output ?? 0)));
+  if (output > PI_LENGTH_STOP_MAX_USABLE_OUTPUT_TOKENS) return false;
+  const input = Math.max(0, Math.floor(Number(usage.input ?? 0)));
+  const cacheRead = Math.max(0, Math.floor(Number(usage.cacheRead ?? 0)));
+  return input + cacheRead >= contextWindow * PI_LENGTH_STOP_CONTEXT_FRACTION;
+}
+
 export function isPiContextOverflowMessage(message: AgentMessage, contextWindow: number): boolean {
   const record = message as unknown as {
     role?: unknown;
@@ -100,6 +136,7 @@ export function isPiContextOverflowMessage(message: AgentMessage, contextWindow:
     timestamp?: unknown;
   };
   if (record.role !== "assistant") return false;
+  if (isPiLengthStopContextExhaustion(message, contextWindow)) return true;
   return isContextOverflow(record as Parameters<typeof isContextOverflow>[0], contextWindow);
 }
 
@@ -116,6 +153,50 @@ export function estimatePiContextTokens(messages: AgentMessage[]): number {
 }
 
 /**
+ * The character heuristic only sees `messages`. The real request also carries
+ * the system prompt and every tool schema, and no char-count models a
+ * provider's tokenizer exactly — measured against a wedged production thread
+ * the estimate came in at 154,520 tokens for a request the provider billed at
+ * 216,184, a 1.40x undercount that kept the pre-turn check below its threshold
+ * while the real context was already too full to answer.
+ *
+ * Each assistant turn reports what the provider actually counted, so use that
+ * as a floor: the last assistant `input + cacheRead` covers everything up to
+ * that message (system prompt and tools included), and only the messages after
+ * it need estimating. Returns 0 when no turn has reported usage yet.
+ */
+export function observedPiContextTokens(messages: AgentMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const record = messages[index] as unknown as {
+      role?: unknown;
+      usage?: { input?: unknown; cacheRead?: unknown };
+    };
+    if (record.role !== "assistant") continue;
+    const usage = record.usage;
+    if (!usage || typeof usage !== "object") continue;
+    const input = Math.max(0, Math.floor(Number(usage.input ?? 0)));
+    const cacheRead = Math.max(0, Math.floor(Number(usage.cacheRead ?? 0)));
+    const reported = input + cacheRead;
+    if (reported <= 0) continue;
+    // Everything from this assistant message onward is new input for the next
+    // request: the assistant's own output plus any later user/tool messages.
+    return reported + estimatePiContextTokens(messages.slice(index));
+  }
+  return 0;
+}
+
+/**
+ * Best available size for the next request: the char estimate, floored by what
+ * the provider last reported. Ground truth wins whenever we have it.
+ */
+export function effectivePiContextTokens(messages: AgentMessage[]): number {
+  return Math.max(
+    estimatePiCompactionTokens(messages),
+    observedPiContextTokens(messages),
+  );
+}
+
+/**
  * Base64 is much less token-dense than ordinary prose for the models we use.
  * In particular, `take_screenshot({ include_image_data_url: true })` places a
  * data URL inside a text tool result. Counting all characters at 4 chars/token
@@ -124,38 +205,74 @@ export function estimatePiContextTokens(messages: AgentMessage[]): number {
  * conservatively while retaining the ordinary heuristic for the surrounding
  * JSON/text.
  */
+/**
+ * Long unbroken high-entropy runs (base64, hex) are charged separately from
+ * prose. Two things to know about this rule:
+ *
+ * 1. It matches any such run, not just `data:` URLs. The common case is an
+ *    agent moving a generated file around, which puts raw base64 into tool
+ *    arguments and results with no `data:` prefix at all.
+ * 2. The per-character rate is deliberately pessimistic, NOT an estimate of
+ *    true density. Measured with o200k, real base64 runs about 5.4 chars/token
+ *    — slightly *cheaper* than prose, not "near one token per character" as
+ *    this rule originally assumed. The rate is kept high on purpose: this
+ *    heuristic's only remaining job is to decide whether a precise count is
+ *    worth taking (see ./pi-token-count), and over-counting merely buys an
+ *    accurate measurement, while under-counting silently skips compaction.
+ *
+ * Anything that actually depends on the number, rather than on "are we close",
+ * should use the tokenizer or the provider-reported count instead.
+ */
+const PI_DENSE_BLOB_MIN_LENGTH = 256;
+const PI_DENSE_BLOB_TOKENS_PER_CHAR = 0.75;
+const PI_DENSE_BLOB_PATTERN = new RegExp(
+  `[A-Za-z0-9+/_=-]{${PI_DENSE_BLOB_MIN_LENGTH},}`,
+  "g",
+);
+
 export function estimatePiTextTokens(text: string): number {
-  const dataUrl = /data:[^,\s"']+;base64,([A-Za-z0-9+/_=-]+)/g;
   let tokens = 0;
   let offset = 0;
-  for (const match of text.matchAll(dataUrl)) {
+  for (const match of text.matchAll(PI_DENSE_BLOB_PATTERN)) {
     const start = match.index ?? offset;
+    // Overlapping matches cannot happen with a global regex, but a blob that
+    // begins before the current offset (already counted) must not double-count.
+    if (start < offset) continue;
     tokens += Math.ceil((start - offset) / 4);
-    // Base64's high-entropy alphabet tokenizes much closer to one token per
-    // character than natural language. 0.75 is deliberately conservative.
-    tokens += Math.ceil((match[1]?.length ?? 0) * 0.75);
+    tokens += Math.ceil(match[0].length * PI_DENSE_BLOB_TOKENS_PER_CHAR);
     offset = start + match[0].length;
   }
   tokens += Math.ceil((text.length - offset) / 4);
   return tokens;
 }
 
+/**
+ * The text a message contributes to the context, as both the character
+ * heuristic and the real tokenizer in ./pi-token-count see it. Shared so the
+ * two measurements always agree on *what* is being counted and differ only in
+ * how.
+ */
+export function stringifyPiMessageForTokenCount(message: AgentMessage): string {
+  const record = message as unknown as { role?: unknown; content?: unknown };
+  if (record.role === "user") {
+    return stringifyPiUserContentForCompaction(record.content);
+  }
+  if (record.role === "assistant") {
+    return stringifyPiAssistantContentForCompaction(record.content);
+  }
+  if (record.role === "toolResult") {
+    return stringifyPiToolResultContentForCompaction(record.content);
+  }
+  try {
+    return JSON.stringify(message);
+  } catch {
+    return String(message);
+  }
+}
+
 export function estimatePiMessageTokens(message: AgentMessage): number {
   const record = message as unknown as { role?: unknown; content?: unknown };
-  let text = "";
-  if (record.role === "user") {
-    text = stringifyPiUserContentForCompaction(record.content);
-  } else if (record.role === "assistant") {
-    text = stringifyPiAssistantContentForCompaction(record.content);
-  } else if (record.role === "toolResult") {
-    text = stringifyPiToolResultContentForCompaction(record.content);
-  } else {
-    try {
-      text = JSON.stringify(message);
-    } catch {
-      text = String(message);
-    }
-  }
+  const text = stringifyPiMessageForTokenCount(message);
   return estimatePiTextTokens(text) + estimatePiImageMemoryTokens(record.content);
 }
 

--- a/workers/main/src/chat-thread/pi-token-count.ts
+++ b/workers/main/src/chat-thread/pi-token-count.ts
@@ -1,0 +1,187 @@
+// Precise context measurement for Pi compaction decisions.
+//
+// The character heuristic in ./pi-compaction is cheap and always available, but
+// it is a guess: measured against a wedged production thread it read 137,964
+// tokens for a request the provider billed at 216,184. Deciding whether to
+// compact on a guess that loose is how a thread ends up too big to answer with
+// nothing to show the user.
+//
+// This module counts with a real BPE tokenizer instead. o200k_base is used as a
+// universal estimate for every model, not just OpenAI's: on that same thread it
+// counted 212,055 tokens against a true 216,149 — within 1.9%, and the residual
+// is the system prompt and tool schemas, which are in the request but not in
+// `messages`. Other vocabularies differ, but not nearly enough to matter
+// against the compaction reserve, and one accurate-enough number for every
+// provider beats maintaining five.
+//
+// COST. Tokenizing a full 560KB context takes ~117ms, and this runs from
+// `transformContext` — once per provider request, so 25+ times in a single
+// agent-loop turn. Doing it naively would add seconds of CPU per turn. It is
+// avoided almost entirely by only ever measuring what the provider has NOT
+// already priced: every assistant message carries the provider's own exact
+// input count for everything before it, so only the messages after the last one
+// need tokenizing. In an agent loop that tail is usually a single tool result —
+// 0.06ms for a small one, ~3ms for a 52KB one. The full-context path only runs
+// before any turn has reported usage, when the context is small anyway.
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import {
+  estimatePiContextTokens,
+  stringifyPiMessageForTokenCount,
+} from "./pi-compaction";
+
+/**
+ * Fraction of the context window above which a precise count is worth its CPU
+ * on the no-usage-yet path. Below this the cheap estimate cannot plausibly be
+ * hiding an overflow.
+ */
+const PI_PRECISE_COUNT_TRIGGER_FRACTION = 0.5;
+
+export function shouldMeasurePiContextPrecisely(
+  estimatedTokens: number,
+  contextWindow: number,
+): boolean {
+  if (!contextWindow || contextWindow <= 0) return false;
+  return estimatedTokens >= contextWindow * PI_PRECISE_COUNT_TRIGGER_FRACTION;
+}
+
+export interface PiPricedContextSplit {
+  /** Index of the assistant message whose usage priced everything before it. */
+  index: number;
+  /** Provider-reported input tokens: exact, and free to obtain. */
+  reported: number;
+}
+
+/**
+ * The most recent assistant message that reported real input usage. Everything
+ * before it is already priced exactly by the provider; everything from it
+ * onward is the only part still needing measurement.
+ */
+export function findLastPricedContextSplit(
+  messages: AgentMessage[],
+): PiPricedContextSplit | null {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const record = messages[index] as unknown as {
+      role?: unknown;
+      usage?: { input?: unknown; cacheRead?: unknown };
+    };
+    if (record.role !== "assistant") continue;
+    const usage = record.usage;
+    if (!usage || typeof usage !== "object") continue;
+    const input = Math.max(0, Math.floor(Number(usage.input ?? 0)));
+    const cacheRead = Math.max(0, Math.floor(Number(usage.cacheRead ?? 0)));
+    const reported = input + cacheRead;
+    if (reported > 0) return { index, reported };
+  }
+  return null;
+}
+
+/**
+ * Dynamic import rather than a module-level cache: the ES module registry
+ * already memoizes this, so repeat calls are cheap without introducing
+ * cross-request singleton state in a Worker isolate. Mirrors the
+ * loadPiCompleteSimple pattern in ./pi-compaction.
+ */
+async function loadO200kEncoder(): Promise<((text: string) => number[]) | null> {
+  try {
+    const { encode } = await import("gpt-tokenizer/encoding/o200k_base");
+    return typeof encode === "function" ? encode : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * BPE merging degrades quadratically on long runs of one repeated character.
+ * Measured on o200k: 10K repeated chars take 33ms, 50K take 739ms, 100K take
+ * 4.3s, and 400K did not finish inside a 115s test timeout — while 100K of real
+ * high-entropy base64 takes 2.9ms. This is not a synthetic worry: a screenshot
+ * with a large solid-colour region base64-encodes to exactly such a run, and a
+ * single oversized tool result would otherwise stall the Durable Object.
+ *
+ * Runs are collapsed to a short sample before tokenizing and their cost added
+ * arithmetically. Repeated characters measured a consistent 8 chars/token at
+ * every length tested, so the substituted arithmetic tracks what the tokenizer
+ * would have returned.
+ */
+const PI_REPEATED_RUN_MIN_LENGTH = 64;
+const PI_REPEATED_RUN_CHARS_PER_TOKEN = 8;
+const PI_REPEATED_RUN_PATTERN = /(.)\1{63,}/gs;
+
+/**
+ * Absolute backstop on how much text one message hands the tokenizer, in case
+ * some other input shape is pathological in a way runs-collapsing misses.
+ * Beyond this the measured rate of the sampled prefix is extrapolated.
+ */
+const PI_MAX_TOKENIZED_CHARS_PER_MESSAGE = 262_144;
+
+export function collapsePiRepeatedRuns(text: string): {
+  text: string;
+  addedTokens: number;
+} {
+  if (text.length < PI_REPEATED_RUN_MIN_LENGTH) return { text, addedTokens: 0 };
+  let addedTokens = 0;
+  const collapsed = text.replace(PI_REPEATED_RUN_PATTERN, (run: string, char: string) => {
+    addedTokens += Math.ceil(
+      (run.length - PI_REPEATED_RUN_MIN_LENGTH) / PI_REPEATED_RUN_CHARS_PER_TOKEN,
+    );
+    return char.repeat(PI_REPEATED_RUN_MIN_LENGTH);
+  });
+  return { text: collapsed, addedTokens };
+}
+
+function countTextTokens(encode: (text: string) => number[], raw: string): number {
+  const { text, addedTokens } = collapsePiRepeatedRuns(raw);
+  if (text.length <= PI_MAX_TOKENIZED_CHARS_PER_MESSAGE) {
+    return encode(text).length + addedTokens;
+  }
+  const sample = text.slice(0, PI_MAX_TOKENIZED_CHARS_PER_MESSAGE);
+  const sampled = encode(sample).length;
+  const scaled = Math.ceil(sampled * (text.length / sample.length));
+  return scaled + addedTokens;
+}
+
+/**
+ * Token count for `messages` using a real tokenizer. Resolves to null when the
+ * tokenizer cannot be loaded, so callers fall back to the heuristic rather than
+ * failing a turn over a measurement.
+ */
+export async function countPiContextTokensPrecise(
+  messages: AgentMessage[],
+): Promise<number | null> {
+  const encode = await loadO200kEncoder();
+  if (!encode) return null;
+  try {
+    let total = 0;
+    for (const message of messages) {
+      total += countTextTokens(encode, stringifyPiMessageForTokenCount(message));
+    }
+    return total;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best available measurement of what the next request will cost, in order of
+ * trust: what the provider actually charged (exact, free), a real tokenizer
+ * over the remainder (accurate, cheap because the remainder is small), then the
+ * character heuristic (loose, but never worse than what we had).
+ */
+export async function measurePiContextTokens(
+  messages: AgentMessage[],
+  contextWindow: number,
+): Promise<number> {
+  const split = findLastPricedContextSplit(messages);
+  if (split) {
+    const tail = messages.slice(split.index);
+    const measured = await countPiContextTokensPrecise(tail);
+    return split.reported + (measured ?? estimatePiContextTokens(tail));
+  }
+
+  // Nothing priced yet — this is the opening of a thread, so the whole context
+  // is normally small. Only reach for the tokenizer if the estimate suggests
+  // otherwise (a very large first message or attachment).
+  const heuristic = estimatePiContextTokens(messages);
+  if (!shouldMeasurePiContextPrecisely(heuristic, contextWindow)) return heuristic;
+  return (await countPiContextTokensPrecise(messages)) ?? heuristic;
+}

--- a/workers/main/src/chat-thread/pi-tools.ts
+++ b/workers/main/src/chat-thread/pi-tools.ts
@@ -193,9 +193,16 @@ function extractCapabilitySources(text: string): Array<{ url: string }> {
 // and discoverable through `tools.search()` / `tools.help()`; we simply stop spending
 // per-turn context on their schemas (the executor-style "search → describe → call"
 // approach). These are long-tail, rarely-needed tools the agent reliably rediscovers
-// by category; the app/project lifecycle and agent categories intentionally STAY
-// top-level, because dropping them led the agent to
+// by category; the app/project lifecycle, analysis, and agent categories
+// intentionally STAY top-level, because dropping them led the agent to
 // guess tool names on complex build+deploy tasks instead of searching.
+//
+// "analysis" (run_notebook / run_code / analysis_exec / add_python_dependency)
+// is top-level for exactly that reason. Those tools used to be filed under
+// "connections" and were therefore hidden, so a data-analysis request burned
+// turns on `Tool run_notebook not found` / `Tool analysis_exec not found`
+// before the agent rediscovered them through js_exec — run_notebook is the
+// primary data-analysis path and has to be visible where the agent looks.
 const TOP_LEVEL_EXCLUDED_CATEGORIES = new Set<string>([
   "workflows",
   "schedules",

--- a/workers/main/src/code-mode-tools.ts
+++ b/workers/main/src/code-mode-tools.ts
@@ -139,6 +139,10 @@ type CodeModeToolCategory =
   | "domains"
   | "web"
   | "agents"
+  // Notebook/python/shell execution in the analysis sandbox. Split out of
+  // "connections" so the primary data-analysis path is not filed under, and
+  // hidden with, the connection-management long tail.
+  | "analysis"
   | "connections";
 
 interface CodeModeToolOptions {
@@ -883,7 +887,7 @@ const CODE_MODE_TOOL_REGISTRY: CodeModeToolRegistration[] = [
       timeoutMs: Type.Optional(Type.Number()),
     }),
     {
-      category: "connections",
+      category: "analysis",
       sideEffect: true,
     },
   ),
@@ -895,7 +899,7 @@ const CODE_MODE_TOOL_REGISTRY: CodeModeToolRegistration[] = [
       params: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
     }),
     {
-      category: "connections",
+      category: "analysis",
     },
   ),
   codeModePassthroughTool(
@@ -909,7 +913,7 @@ const CODE_MODE_TOOL_REGISTRY: CodeModeToolRegistration[] = [
       timeoutMs: Type.Optional(Type.Number()),
     }),
     {
-      category: "connections",
+      category: "analysis",
       sideEffect: true,
     },
   ),
@@ -922,7 +926,7 @@ const CODE_MODE_TOOL_REGISTRY: CodeModeToolRegistration[] = [
       dev: Type.Optional(Type.Boolean()),
     }),
     {
-      category: "connections",
+      category: "analysis",
       sideEffect: true,
     },
   ),

--- a/workers/main/tests/chat-thread-pi-turn.test.ts
+++ b/workers/main/tests/chat-thread-pi-turn.test.ts
@@ -12,9 +12,21 @@ import {
   piCompactionReserveTokens,
   piModelContextWindow,
   capPiMainRequestOutput,
+  effectivePiContextTokens,
+  observedPiContextTokens,
+  estimatePiCompactionTokens,
+  isPiLengthStopContextExhaustion,
+  isPiContextOverflowMessage,
+  shouldCompactPiAfterAssistantUsage,
   PI_MAIN_REQUEST_DEFAULT_OUTPUT_TOKENS,
   PI_MAIN_REQUEST_MAX_OUTPUT_TOKENS,
 } from '../src/chat-thread/pi-compaction';
+import {
+  countPiContextTokensPrecise,
+  findLastPricedContextSplit,
+  measurePiContextTokens,
+  shouldMeasurePiContextPrecisely,
+} from '../src/chat-thread/pi-token-count';
 import { extractToolContent } from '../src/chat-thread/pi-message-helpers';
 import { PiCoreMessageStore } from '../src/chat-thread/pi-core-store';
 import {
@@ -38,6 +50,44 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
 });
+
+/**
+ * Deterministic varied prose, for fixtures that need to weigh what real
+ * conversation history weighs. `'y'.repeat(n)` does not: a run of one character
+ * collapses to roughly n/8 tokens, so padding with it understates a context by
+ * several times once token counts are measured rather than estimated.
+ */
+function syntheticProse(length: number): string {
+  const words = [
+    'restoration', 'excavator', 'schedule', 'peat', 'dam', 'contractor',
+    'estimate', 'linear', 'hectare', 'reprofiling', 'bund', 'plant',
+    'labour', 'materials', 'tender', 'rate', 'output', 'ground',
+  ];
+  let seed = 987_654;
+  let out = '';
+  while (out.length < length) {
+    seed = (seed * 1_103_515_245 + 12_345) & 0x7fff_ffff;
+    out += `${words[seed % words.length]} `;
+  }
+  return out.slice(0, length);
+}
+
+/**
+ * Deterministic high-entropy base64, for fixtures that need to weigh what a real
+ * inline image payload weighs. Built from a random block that is then tiled:
+ * BPE merges locally, so tiling keeps the per-block token cost instead of
+ * collapsing the way a single repeated character does.
+ */
+function syntheticBase64(length: number): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  let seed = 12_345;
+  let block = '';
+  for (let i = 0; i < 4_096; i++) {
+    seed = (seed * 1_103_515_245 + 12_345) & 0x7fff_ffff;
+    block += alphabet[seed % 64];
+  }
+  return block.repeat(Math.ceil(length / block.length)).slice(0, length);
+}
 
 describe('child agent progress labels', () => {
   it('keeps concrete child tool names and adds useful arguments', () => {
@@ -3423,7 +3473,7 @@ describe('ChatThreadDO Pi turn handling', () => {
     const fake = Object.create(ChatThreadDO.prototype) as any;
     const messages = [
       { role: 'user', content: 'old context', timestamp: 1 },
-      { role: 'assistant', content: [{ type: 'text', text: `recent context ${'y'.repeat(80_000)}` }], timestamp: 2 },
+      { role: 'assistant', content: [{ type: 'text', text: `recent context ${syntheticProse(120_000)}` }], timestamp: 2 },
     ];
     fake.loadPiCoreCompaction = vi.fn(() => null);
     fake.persistPiCoreCompaction = vi.fn();
@@ -3449,7 +3499,10 @@ describe('ChatThreadDO Pi turn handling', () => {
 
   it('preflights compaction for inline base64 tool output before it exhausts the provider context', async () => {
     const fake = Object.create(ChatThreadDO.prototype) as any;
-    const screenshot = `data:image/jpeg;base64,${'A'.repeat(250_000)}`;
+    // Genuine base64 entropy, not a repeated character. `'A'.repeat(n)` merges
+    // into a handful of BPE tokens, so it understates a real screenshot payload
+    // by roughly 6x and only looked large to the character heuristic.
+    const screenshot = `data:image/jpeg;base64,${syntheticBase64(1_100_000)}`;
     const messages = [
       { role: 'toolResult', toolCallId: 'shot', toolName: 'take_screenshot', content: [{ type: 'text', text: screenshot }], timestamp: 1 },
       { role: 'assistant', content: [{ type: 'text', text: 'I will fix the game.' }], timestamp: 2 },
@@ -3487,7 +3540,7 @@ describe('ChatThreadDO Pi turn handling', () => {
     const messages = [
       createPiSummaryMessage(existing.summary, 100),
       { role: 'user', content: 'raw row 2', timestamp: 200 },
-      { role: 'assistant', content: [{ type: 'text', text: `raw row 3 ${'y'.repeat(80_000)}` }], timestamp: 300 },
+      { role: 'assistant', content: [{ type: 'text', text: `raw row 3 ${syntheticProse(120_000)}` }], timestamp: 300 },
       { role: 'user', content: 'raw row 4', timestamp: 400 },
     ];
     fake.loadPiCoreCompaction = vi.fn(() => existing);
@@ -3519,7 +3572,7 @@ describe('ChatThreadDO Pi turn handling', () => {
     const fake = Object.create(ChatThreadDO.prototype) as any;
     const messages = [
       { role: 'user', content: 'old context', timestamp: 1 },
-      { role: 'assistant', content: [{ type: 'text', text: `recent context ${'y'.repeat(80_000)}` }], timestamp: 2 },
+      { role: 'assistant', content: [{ type: 'text', text: `recent context ${syntheticProse(120_000)}` }], timestamp: 2 },
     ];
     fake.loadPiCoreCompaction = vi.fn(() => null);
     fake.persistPiCoreCompaction = vi.fn();
@@ -3604,6 +3657,7 @@ describe('ChatThreadDO Pi turn handling', () => {
         model: { contextWindow: 1_000_000 },
         messages: beforeMessages,
       },
+      waitForIdle: vi.fn(async () => {}),
     };
     fake.loadPiCompleteSimple = vi.fn(async () => vi.fn());
     fake.compactPiContext = vi.fn(async () => compactedMessages);
@@ -3624,6 +3678,283 @@ describe('ChatThreadDO Pi turn handling', () => {
     });
     expect(fake.clearPiCoreCompaction).toHaveBeenCalled();
     expect(fake.piMainBaselineIndex).toBe(compactedMessages.length);
+  });
+
+  // Regression cluster for the context-exhaustion wedge. A production camelCode
+  // thread stopped answering for five hours across eleven unanswered user
+  // messages: every turn came back `stopReason: "length"` with `input: 216149`
+  // of a 220000 window and a single reasoning token of output. Nothing was
+  // logged (a length stop is not a provider error) and nothing compacted, so
+  // the thread could never recover. These numbers are taken from that thread.
+  describe('context exhaustion wedge', () => {
+    const WEDGED_CONTEXT_WINDOW = 220_000;
+    const wedgedAssistantMessage = () => ({
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: 'The' }],
+      api: 'openai-completions',
+      provider: 'cloudflare-ai-gateway',
+      model: 'dynamic/deepseek-v4-auto',
+      usage: {
+        input: 216_149,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 216_150,
+      },
+      stopReason: 'length',
+      timestamp: 1_784_926_541_156,
+    }) as any;
+
+    it('treats a length stop with no usable output as context exhaustion', () => {
+      const message = wedgedAssistantMessage();
+
+      // Pi's own isContextOverflow misses this by a hair on both axes: it wants
+      // output === 0 (this emitted one reasoning token) and input >= 99% of the
+      // window (216149 is 98.25%, short by 1651 tokens).
+      expect(isPiLengthStopContextExhaustion(message, WEDGED_CONTEXT_WINDOW)).toBe(true);
+      expect(isPiContextOverflowMessage(message, WEDGED_CONTEXT_WINDOW)).toBe(true);
+      expect(
+        shouldCompactPiAfterAssistantUsage(message, {
+          contextWindow: WEDGED_CONTEXT_WINDOW,
+          maxTokens: 262_144,
+        } as any),
+      ).toBe(true);
+    });
+
+    it('does not mistake an ordinary length stop for exhaustion', () => {
+      // A real max-output truncation: plenty of room on the input side.
+      expect(
+        isPiLengthStopContextExhaustion(
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'a long answer' }],
+            usage: { input: 5_000, output: 900, cacheRead: 0 },
+            stopReason: 'length',
+          } as any,
+          WEDGED_CONTEXT_WINDOW,
+        ),
+      ).toBe(false);
+
+      // Same token counts, but the turn actually completed.
+      expect(
+        isPiLengthStopContextExhaustion(
+          { ...wedgedAssistantMessage(), stopReason: 'stop' },
+          WEDGED_CONTEXT_WINDOW,
+        ),
+      ).toBe(false);
+    });
+
+    it('counts raw base64 blobs densely, not as prose', () => {
+      // Agents moving a generated file around embed bare base64 in tool args
+      // and results, with no data: URL header to key off.
+      const blob = 'UEsDBBQAAAAIAAig+FxGx01IlQAAAM0AAAAQAAAAZG9jUHJvcHMv'.repeat(20);
+      // Ordinary prose of the same length still uses the 4-chars/token rule;
+      // only unbroken high-entropy runs are treated as dense.
+      const prose = 'the quick brown fox jumps over the lazy dog '.repeat(
+        Math.ceil(blob.length / 44),
+      ).slice(0, blob.length);
+
+      expect(estimatePiTextTokens(prose)).toBeCloseTo(blob.length / 4, -1);
+      expect(estimatePiTextTokens(blob)).toBeGreaterThan(estimatePiTextTokens(prose) * 2);
+    });
+
+    it('floors the character estimate with the provider-reported input count', () => {
+      // The estimate cannot see the system prompt or tool schemas, so on its own
+      // it undercounts the real request. The last assistant turn reports what the
+      // provider actually charged; that is the floor.
+      const messages = [
+        { role: 'user', content: 'earlier work', timestamp: 0 },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          usage: { input: 200_000, output: 10, cacheRead: 0 },
+          stopReason: 'stop',
+          timestamp: 1,
+        },
+        { role: 'user', content: 'follow up', timestamp: 2 },
+      ] as any;
+
+      expect(estimatePiCompactionTokens(messages)).toBeLessThan(200_000);
+      expect(observedPiContextTokens(messages)).toBeGreaterThanOrEqual(200_000);
+      expect(effectivePiContextTokens(messages)).toBeGreaterThanOrEqual(200_000);
+    });
+
+    it('counts context with a real tokenizer inside the Worker runtime', async () => {
+      // Also proves the o200k BPE ranks load under workerd, not just in the
+      // bundler: the import is dynamic, so a runtime failure would otherwise
+      // only show up in production as a silent fall back to the heuristic.
+      const messages = [
+        { role: 'user', content: 'the quick brown fox jumps over the lazy dog', timestamp: 0 },
+      ] as any;
+
+      const precise = await countPiContextTokensPrecise(messages);
+
+      expect(precise).not.toBeNull();
+      // Nine short English words tokenize to roughly one token each.
+      expect(precise).toBeGreaterThan(5);
+      expect(precise).toBeLessThan(20);
+    });
+
+    it('identifies the prefix the provider has already priced', () => {
+      const messages = [
+        { role: 'user', content: 'first', timestamp: 0 },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'older' }],
+          usage: { input: 100, output: 5, cacheRead: 0 },
+          timestamp: 1,
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'newer' }],
+          usage: { input: 900, output: 5, cacheRead: 100 },
+          timestamp: 2,
+        },
+        { role: 'user', content: 'latest', timestamp: 3 },
+      ] as any;
+
+      // Most recent priced turn wins, and cacheRead counts as input.
+      expect(findLastPricedContextSplit(messages)).toEqual({ index: 2, reported: 1_000 });
+      expect(findLastPricedContextSplit([{ role: 'user', content: 'hi' }] as any)).toBeNull();
+    });
+
+    it('measures only the unpriced tail rather than re-tokenizing the history', async () => {
+      // The CPU guard. transformContext runs once per provider request — 25+
+      // times in one agent-loop turn — and a full 560KB context takes ~117ms to
+      // tokenize. Only the messages after the last priced turn are measured, so
+      // the cost tracks new content instead of total history size.
+      const hugePricedPrefix = {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'x'.repeat(400_000) }],
+        usage: { input: 150_000, output: 10, cacheRead: 0 },
+        stopReason: 'stop',
+        timestamp: 1,
+      };
+      const messages = [
+        { role: 'user', content: 'y'.repeat(400_000), timestamp: 0 },
+        hugePricedPrefix,
+        { role: 'user', content: 'one short follow-up', timestamp: 2 },
+      ] as any;
+
+      const measured = await measurePiContextTokens(messages, 220_000);
+
+      // 150k reported + the assistant's own output + a short user message.
+      // A full recount of ~800KB of history would land far above this.
+      expect(measured).toBeGreaterThan(150_000);
+      expect(measured).toBeLessThan(275_000);
+    });
+
+    it('only pays for tokenization when the cheap estimate is near the limit', () => {
+      expect(shouldMeasurePiContextPrecisely(10_000, 220_000)).toBe(false);
+      expect(shouldMeasurePiContextPrecisely(150_000, 220_000)).toBe(true);
+      expect(shouldMeasurePiContextPrecisely(10_000, 0)).toBe(false);
+    });
+
+    it('never returns less than the provider-reported floor', async () => {
+      const messages = [
+        { role: 'user', content: 'short', timestamp: 0 },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          usage: { input: 200_000, output: 2, cacheRead: 0 },
+          stopReason: 'stop',
+          timestamp: 1,
+        },
+      ] as any;
+
+      await expect(
+        measurePiContextTokens(messages, 220_000),
+      ).resolves.toBeGreaterThanOrEqual(200_000);
+    });
+
+    it('falls back to the character estimate before any turn reports usage', () => {
+      const messages = [{ role: 'user', content: 'first message', timestamp: 0 }] as any;
+
+      expect(observedPiContextTokens(messages)).toBe(0);
+      expect(effectivePiContextTokens(messages)).toBe(
+        estimatePiCompactionTokens(messages),
+      );
+    });
+
+    it('compacts after a turn even though agent_end fires while isStreaming is still set', async () => {
+      // The wedge itself. `agent_end` is emitted from inside the Pi run and
+      // `isStreaming` is only cleared afterwards, in the agent's `finally`. The
+      // guard used to run before any await, so this method returned on its first
+      // check every time and post-turn compaction never executed in production.
+      const trigger = wedgedAssistantMessage();
+      const beforeMessages = [{ role: 'user', content: 'old', timestamp: 0 }, trigger] as any;
+      const compactedMessages = [{ role: 'user', content: '[summary] old', timestamp: 2 }] as any;
+
+      const fake = Object.create(ChatThreadDO.prototype) as any;
+      const state = {
+        isStreaming: true, // still streaming, exactly as at agent_end
+        model: { contextWindow: WEDGED_CONTEXT_WINDOW, maxTokens: 262_144 },
+        messages: beforeMessages,
+      };
+      fake.piSession = {
+        state,
+        // Resolves once the run settles, which is when finishRun clears the flag.
+        waitForIdle: vi.fn(async () => {
+          state.isStreaming = false;
+        }),
+      };
+      fake.piModelResolver = vi.fn(async () => ({
+        model: { contextWindow: WEDGED_CONTEXT_WINDOW, maxTokens: 262_144, id: 'deepseek-v4-auto' },
+        apiKey: 'token',
+      }));
+      fake.loadPiCompleteSimple = vi.fn(async () => vi.fn());
+      fake.compactPiContext = vi.fn(async () => compactedMessages);
+      fake.replacePiCoreMessages = vi.fn();
+      fake.clearPiCoreCompaction = vi.fn();
+      fake.recordChatThreadObservabilityEvent = vi.fn();
+      fake.piMainBaselineIndex = beforeMessages.length;
+
+      await ChatThreadDO.prototype['compactPiContextAfterTurn'].call(fake, trigger);
+
+      expect(fake.piSession.waitForIdle).toHaveBeenCalled();
+      expect(fake.compactPiContext).toHaveBeenCalled();
+      expect(fake.piSession.state.messages).toBe(compactedMessages);
+    });
+
+    it('surfaces context exhaustion to the user and to error telemetry', () => {
+      const fake = Object.create(ChatThreadDO.prototype) as any;
+      fake.piSession = {
+        state: { model: { contextWindow: WEDGED_CONTEXT_WINDOW, id: 'deepseek-v4-auto' } },
+      };
+      fake.piCurrentUsageProvider = 'compat';
+      fake.recordChatThreadObservabilityEvent = vi.fn();
+
+      const notice = ChatThreadDO.prototype['piContextExhaustionNotice'].call(fake, [
+        { role: 'user', content: 'is it ready yet?', timestamp: 0 },
+        wedgedAssistantMessage(),
+      ]);
+
+      // The turn must say something rather than render blank.
+      expect(notice).not.toBe('');
+      expect(fake.recordChatThreadObservabilityEvent).toHaveBeenCalledWith(
+        'chat_context_exhausted',
+        expect.objectContaining({ status: 'context_exhausted', error: expect.any(Error) }),
+      );
+    });
+
+    it('stays silent when the turn ended normally', () => {
+      const fake = Object.create(ChatThreadDO.prototype) as any;
+      fake.piSession = { state: { model: { contextWindow: WEDGED_CONTEXT_WINDOW } } };
+      fake.recordChatThreadObservabilityEvent = vi.fn();
+
+      const notice = ChatThreadDO.prototype['piContextExhaustionNotice'].call(fake, [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'here is your spreadsheet' }],
+          usage: { input: 1_000, output: 50, cacheRead: 0 },
+          stopReason: 'stop',
+          timestamp: 1,
+        },
+      ]);
+
+      expect(notice).toBe('');
+      expect(fake.recordChatThreadObservabilityEvent).not.toHaveBeenCalled();
+    });
   });
 
   it('caps the main Pi request output without mutating catalog metadata', () => {
@@ -3836,6 +4167,7 @@ describe('ChatThreadDO Pi turn handling', () => {
         model,
         messages: before,
       },
+      waitForIdle: vi.fn(async () => {}),
     };
     fake.piModelResolver = vi.fn(async () => ({
       model,
@@ -3887,6 +4219,7 @@ describe('ChatThreadDO Pi turn handling', () => {
         model,
         messages: before,
       },
+      waitForIdle: vi.fn(async () => {}),
     };
     fake.piModelResolver = vi.fn(async () => ({
       model,

--- a/workers/main/tests/evals/analysis-tools-reachable-live.test.ts
+++ b/workers/main/tests/evals/analysis-tools-reachable-live.test.ts
@@ -1,0 +1,225 @@
+import { env } from "cloudflare:test";
+import { describe, it } from "vitest";
+
+import { createOrg, createUser, type TestEnv } from "../test-helpers";
+import {
+  assertPassFailCriteria,
+  buildEvalCriteriaSummary,
+  buildNoAssistantErrorCriterion,
+  buildResultEventCriterion,
+  buildRuntimeEventsCriterion,
+  buildSessionCompletedCriterion,
+  passFailCriterion,
+  scoreSignalEfficiency,
+} from "./eval-criteria";
+import { emitEvalTranscript } from "./eval-transcript";
+import {
+  evaluateAgentEvalSignal,
+  getEvalSignalThresholds,
+  type EvalSignalEnv,
+} from "./eval-signal";
+import {
+  configureEvalModel,
+  getEvalTimeoutMs,
+  type EvalModelEnv,
+} from "./model-config";
+import type { ChatThreadDO } from "../../src/chat-thread-do";
+import { usedTool } from "./project-eval-helpers";
+
+// Regression eval for analysis-tool reachability.
+//
+// run_notebook / run_code / analysis_exec / add_python_dependency used to carry
+// `category: "connections"`, which is one of the categories dropped from the
+// model's top-level tool list. The agent was told elsewhere (system prompt,
+// data-analysis skill, run_notebook's own description) that run_notebook is the
+// primary data-analysis path, so it called them directly and got back
+// `Tool run_notebook not found` / `Tool analysis_exec not found`. A production
+// thread burned several turns on that before rediscovering them inside js_exec.
+//
+// The point of this eval is NOT which analysis tool the agent picks — any of
+// them is a fine way to answer. It is that reaching for the analysis surface by
+// name must not dead-end in a not-found error.
+type AnalysisToolsEvalEnv = TestEnv & EvalModelEnv & EvalSignalEnv & {
+  CHAT_THREAD: DurableObjectNamespace<ChatThreadDO>;
+  RUN_AGENT_EVALS?: string;
+};
+
+const testEnv = env as unknown as AnalysisToolsEvalEnv;
+const maybeIt = testEnv.RUN_AGENT_EVALS === "1" ? it : it.skip;
+const SESSION_TIMEOUT_MS = getEvalTimeoutMs(testEnv, 240_000);
+
+const ANALYSIS_TOOL_NAMES = [
+  "run_notebook",
+  "run_code",
+  "analysis_exec",
+  "add_python_dependency",
+];
+
+/**
+ * Find `Tool <name> not found` style rejections for the analysis tools anywhere
+ * in the transcript. This is deliberately string-based: the failure it guards
+ * against is the harness refusing a tool the model was told it has, which shows
+ * up as tool-result text rather than as a typed error.
+ */
+function findAnalysisToolNotFound(
+  result: { events: Array<Record<string, unknown>>; messages: unknown[] },
+): string[] {
+  const haystack = `${JSON.stringify(result.events)}\n${JSON.stringify(result.messages)}`;
+  const hits: string[] = [];
+  for (const name of ANALYSIS_TOOL_NAMES) {
+    const pattern = new RegExp(
+      `(?:Tool\\s+)?${name}(?:\\s+tool)?\\s+(?:was\\s+)?not\\s+found|not\\s+found[^"]{0,40}${name}`,
+      "i",
+    );
+    if (pattern.test(haystack)) hits.push(name);
+  }
+  return hits;
+}
+
+describe("analysis tools reachable agent eval", () => {
+  maybeIt(
+    "reaches the analysis sandbox by name without a not-found dead end",
+    async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const email = `analysis-tools-eval-${suffix}@example.com`;
+      const { userId } = await createUser(
+        testEnv,
+        email,
+        "password123",
+        "Analysis Tools Eval",
+      );
+      const { org, defaultWorkspaceId } = await createOrg(
+        testEnv,
+        `Analysis Tools Eval ${suffix}`,
+        userId,
+      );
+
+      const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+      await configureEvalModel(testEnv, orgStub, userId);
+      const thread = await orgStub.createThread(
+        defaultWorkspaceId,
+        "Analysis tools reachable eval",
+        userId,
+        undefined,
+        testEnv.EVAL_MODEL,
+      );
+
+      const chatThread = testEnv.CHAT_THREAD.get(
+        testEnv.CHAT_THREAD.idFromName(thread.id),
+      );
+      const result = await chatThread.runAgentEvalSession({
+        threadId: thread.id,
+        workspaceId: defaultWorkspaceId,
+        orgId: org.id,
+        userId,
+        userName: "Analysis Tools Eval",
+        userEmail: email,
+        messageSource: "eval",
+        timeoutMs: SESSION_TIMEOUT_MS,
+        message: [
+          "Use the Python analysis sandbox to work out the answer to this, rather than doing the arithmetic yourself.",
+          "I have three excavators running 8.5 hours a day for 12 days at 145.50 per hour,",
+          "and two dumpers running 6 hours a day over the same 12 days at 88.25 per hour.",
+          "Compute the total plant cost for each machine type and the combined total,",
+          "then tell me the three figures.",
+        ].join(" "),
+      });
+
+      const signal = evaluateAgentEvalSignal(
+        result,
+        getEvalSignalThresholds(testEnv, {
+          maxAssistantTurns: 8,
+          maxBadToolCalls: 1,
+        }),
+      );
+
+      const notFoundTools = findAnalysisToolNotFound(result);
+      const reachedAnalysisSurface = ANALYSIS_TOOL_NAMES.some((name) =>
+        usedTool(result.events, name),
+      );
+
+      // Ground truth: 3 * 8.5 * 12 * 145.50 = 44523; 2 * 6 * 12 * 88.25 = 12708.
+      const answerText = JSON.stringify(result.messages);
+      const reportedExcavators = /44[,.]?523/.test(answerText);
+      const reportedDumpers = /12[,.]?708/.test(answerText);
+      const reportedTotal = /57[,.]?231/.test(answerText);
+
+      const evaluation = buildEvalCriteriaSummary({
+        passFail: [
+          buildSessionCompletedCriterion(result),
+          passFailCriterion({
+            id: "no_analysis_tool_not_found",
+            label: "No analysis tool was rejected as not found",
+            passed: notFoundTools.length === 0,
+            reason:
+              notFoundTools.length === 0
+                ? undefined
+                : `Harness rejected analysis tools as not found: ${notFoundTools.join(", ")}.`,
+            details: { notFoundTools, toolCallsByName: signal.toolCallsByName },
+          }),
+          passFailCriterion({
+            id: "reached_analysis_surface",
+            label: "Agent reached an analysis execution tool",
+            passed: reachedAnalysisSurface,
+            reason: reachedAnalysisSurface
+              ? undefined
+              : "Agent never called run_notebook, run_code, analysis_exec, or add_python_dependency.",
+            details: { toolCallsByName: signal.toolCallsByName },
+          }),
+          passFailCriterion({
+            id: "reported_correct_totals",
+            label: "Agent reported the correct plant costs",
+            passed: reportedExcavators && reportedDumpers && reportedTotal,
+            reason:
+              reportedExcavators && reportedDumpers && reportedTotal
+                ? undefined
+                : "Expected 44523 (excavators), 12708 (dumpers), and 57231 (combined) in the reply.",
+            details: { reportedExcavators, reportedDumpers, reportedTotal },
+          }),
+          buildNoAssistantErrorCriterion(result),
+          buildRuntimeEventsCriterion(result),
+          buildResultEventCriterion(result),
+        ],
+        scorecard: [
+          scoreSignalEfficiency(signal, {
+            maxPoints: 4,
+            fallbackPoints: 1,
+            tiers: [
+              { maxAssistantTurns: 6, maxBadToolCalls: 0, points: 4 },
+              { maxAssistantTurns: 10, maxBadToolCalls: 1, points: 3 },
+              { maxAssistantTurns: 16, maxBadToolCalls: 2, points: 2 },
+            ],
+          }),
+        ],
+      });
+
+      emitEvalTranscript({
+        status: result.status,
+        evaluation,
+        error: result.error,
+        model: testEnv.EVAL_MODEL,
+        signal,
+        result: result.result,
+        events: result.events,
+        messages: result.messages,
+        runtimeAssertions: {
+          notFoundTools,
+          reachedAnalysisSurface,
+          reportedExcavators,
+          reportedDumpers,
+          reportedTotal,
+          toolCallsByName: signal.toolCallsByName,
+          failures: [
+            ...(notFoundTools.length
+              ? [`analysis tools rejected as not found: ${notFoundTools.join(", ")}`]
+              : []),
+            ...(reachedAnalysisSurface ? [] : ["agent never reached an analysis execution tool"]),
+          ],
+        },
+      });
+
+      assertPassFailCriteria(evaluation);
+    },
+    SESSION_TIMEOUT_MS + 60_000,
+  );
+});

--- a/workers/main/tests/evals/manifest.json
+++ b/workers/main/tests/evals/manifest.json
@@ -193,6 +193,11 @@
       "tier": "hard"
     },
     {
+      "id": "analysis-tools-reachable-live",
+      "description": "Reach the analysis sandbox by name without a not-found dead end, and report ground-truth totals",
+      "kind": "unit"
+    },
+    {
       "id": "metrics-ground-truth-notebook-live",
       "description": "Analyze a seeded CSV with explicit provenance, avoid deployment, and report findings checked against computed ground truth",
       "kind": "skill",


### PR DESCRIPTION
## What happened

A production camelCode thread ([64f6c780](https://camelai.dev/qaml-backdoor/chat-explorer?thread=64f6c780-d884-45a4-b3eb-b02fc46ea09e)) stopped responding for five hours across **eleven unanswered user messages**. The user opened a second thread ([617147e3](https://camelai.dev/chat/617147e3-2929-4e0a-b881-e4188ee77418?adminReadonly=1)) to ask why, and that one wedged the same way.

The raw `pi_core` rows show it exactly:

```json
{"usage":{"input":216149,"output":1,"totalTokens":216150},
 "stopReason":"length","responseModel":"DeepSeek-V4-Flash"}
```

Input filled 216,149 of a 220,000-token window, leaving no room to answer. The model emitted one reasoning token (`"The"`) and stopped. Every later message repeated it — input crept up only by the size of each new user message, proving nothing ever compacted. `query_chat_errors` shows **nothing** after 16:12 while the thread kept dying until 20:56, because a `length` stop is not a provider error.

## Four faults, all required

**1. Post-turn compaction was dead code.** `agent_end` is emitted from inside the Pi run; `isStreaming` is only cleared afterwards in the agent's `finally` (`finishRun`). `compactPiContextAfterTurn` guarded on that flag *before its first `await`*, so it returned immediately every time. Tests never caught it — they mock `compactPiContextAfterTurn` out, and the one test that exercises it hand-sets `isStreaming: false`.

**2. The token estimate undercounted by 1.40x.** Running the real `estimatePiCompactionTokens` over the real 138-message history returns **154,520** where the provider billed **216,184**. It also cannot see the system prompt or tool schemas at all. The pre-turn threshold is 188,000, so it never fired either.

**3. Detection missed by a hair on both axes.** Pi's `isContextOverflow` has a case for precisely this, but wants `output === 0` (this emitted one reasoning token) and input `>= 99%` of the window (216,149 is 98.25% — short by 1,651 tokens).

**4. `run_notebook` was hidden.** It, `run_code`, `analysis_exec`, and `add_python_dependency` carried `category: "connections"` — one of the categories dropped from the top-level tool list. The agent was told elsewhere that `run_notebook` is "the PRIMARY data-analysis path", called it, and got `Tool run_notebook not found`. Thread 1 burned ~10 turns on that.

## Measurement approach

Measurement now prefers what the provider actually charged — exact, free, and reported on every assistant message — and tokenizes only the messages added since, using `o200k_base` as a universal estimate across all providers.

| Method | Result vs true 216,184 |
| --- | --- |
| Old character heuristic | 137,964 (−36%) |
| o200k tokenizer | 212,055 (−1.9%) |
| Provider-reported + tokenized tail | 216,218 (+0.02%) |

**CPU is the reason it measures only the tail.** `transformContext` runs once per provider request — 25+ times in one agent-loop turn — and a full 560KB pass takes ~117ms (~2.9s/turn). Measuring only the unpriced tail costs **0.06ms** for a typical one.

BPE also degrades quadratically on long runs of one repeated character, which a screenshot of a solid-colour region base64-encodes to for real:

| Input | Before guard | After |
| --- | --- | --- |
| 100K repeated chars | 4,321ms | ~0ms |
| 400K repeated chars | >115,000ms (test timeout) | 0.4ms |
| 100K real base64 | 2.9ms | 2.9ms |

Runs are collapsed and costed arithmetically at their measured 8 chars/token, which reproduces the tokenizer's answer exactly (6,250 tokens on a 50K sample).

Bundle cost is +1.08MB gzip as a lazily-imported chunk; total deployed size 5.83MB against Cloudflare's 10MB limit.

## Note on fixtures

Test fixtures padding with `'y'.repeat(n)` to fake a large context were understating it several times over once tokens are measured rather than guessed — a run of one character collapses to ~n/8 tokens. They now use realistic prose and base64 helpers. Relatedly, the old comment claiming base64 "tokenizes near one token per character" is wrong: measured, it is ~5.4 chars/token, *cheaper* than prose.

## Verification

- `bun run test:workers` — 1,677 passed, 40 skipped
- `bun run test:run` — 2,407 passed, 6 skipped
- `bun run typecheck`, `bun run lint` (one pre-existing warning in `pi-core-store.ts`, untouched), `bun run build`
- The `isStreaming` regression test was confirmed to **fail** without the fix and pass with it

## Not fixed here

There is no supported way to hand a generated binary file to the user. The agent had a valid `.xlsx` in the sandbox at message #75 of thread 1 and could never deliver it — it tried `shutil`, base64-through-R2 (which corrupts, since `write` is text-only), and finally **deployed a whole Cloudflare Worker to serve the file**. That is why the user saw "a gaming app" in their preview pane and a download link reading "site does not exist". Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)