### PR TITLE
Improve locked model access and exhausted-credit recovery

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -4457,6 +4457,7 @@ export default function Chat({
                     onOpenUsage={() => navigate("/settings/organization/usage")}
                     onTopUp={openBillingTopUp}
                     canTopUp={Boolean(isAdmin)}
+                    pauseReason={effectiveHostedCreditsPaused?.reason ?? null}
                     userId={user?.id ?? null}
                     orgId={currentOrg?.id ?? null}
                     className="mb-2 shrink-0"

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -137,6 +137,7 @@ import {
   getBillingDialogIdentityKey,
   getWelcomeAutoOpenState,
   hasActiveBillingDialog,
+  shouldNavigateToBillingForPausedModel,
   transitionBillingDialogState,
   type BillingDialogState,
 } from "@/lib/billing-dialog-state";
@@ -188,10 +189,16 @@ import {
   type OrgScopedByokCredential,
 } from "@/lib/byok-credential-state";
 import { modelCatalogEntriesForIds } from "@/lib/model-catalog";
-import type { ModelPickerOption } from "@/lib/chat-do.server";
+import {
+  deriveHostedCreditPause,
+  type HostedCreditPauseBilling,
+  type ModelPausedReason,
+  type ModelPickerOption,
+} from "@/lib/model-picker-access";
 import { resolveDefaultModelForChat } from "@/lib/model-picker-config";
 import { getRecentModel, type RecentModelScope } from "@/lib/recent-model";
 import {
+  resolveDisplayedBillingCreditStatus,
   resolveRefreshedThreadModel,
   shouldSwitchExhaustedThreadToCamelCode,
   type BillingCreditStatus,
@@ -307,6 +314,9 @@ interface ChatProps {
   effectivePickerDefaultModel?: LlmModel | null;
   hasEffectivePickerDefault?: boolean;
   billingAccessMode?: ChatBillingAccessMode | null;
+  canUnlockPremiumModels?: boolean;
+  hostedCreditsPaused?: { reason: ModelPausedReason } | null;
+  allowOpenAiSubscription?: boolean;
   isOrgAdmin?: boolean;
   recentModelScope?: RecentModelScope | null;
   billingCreditStatus?: BillingCreditStatus | null;
@@ -670,6 +680,9 @@ export default function Chat({
   effectivePickerDefaultModel = null,
   hasEffectivePickerDefault = false,
   billingAccessMode = null,
+  canUnlockPremiumModels = false,
+  hostedCreditsPaused = null,
+  allowOpenAiSubscription = false,
   isOrgAdmin = false,
   recentModelScope,
   billingCreditStatus,
@@ -959,9 +972,6 @@ export default function Chat({
     transitionBillingDialog,
     user?.id,
   ]);
-  const openUnlockPremium = useCallback((triggerModel: LlmModel | null) => {
-    transitionBillingDialog({ kind: "unlock", triggerModel });
-  }, [transitionBillingDialog]);
   const openPlanUpgrade = useCallback(() => {
     transitionBillingDialog({ kind: "plans" });
   }, [transitionBillingDialog]);
@@ -1281,7 +1291,7 @@ export default function Chat({
   const authoritativeThreadModelRef = useRef<AuthoritativeThreadModel | null>(
     null,
   );
-  const availableThreadModels = useMemo<ModelPickerOption[]>(() => {
+  const baseAvailableThreadModels = useMemo<ModelPickerOption[]>(() => {
     if (Array.isArray(modelOptions)) {
       return [...modelOptions];
     }
@@ -1292,29 +1302,20 @@ export default function Chat({
     const options = getVisibleLlmModelOptions(
       experimentalSettings,
       threadModel ?? getDefaultLlmModel(llmProvider),
-      { orgProvider: llmProvider },
+      {
+        orgProvider: llmProvider,
+        allowOpenAiSubscription,
+      },
     );
     return modelCatalogEntriesForIds(options.map((option) => option.value));
   }, [
     allowedThreadModels,
+    allowOpenAiSubscription,
     experimentalSettings,
     llmProvider,
     modelOptions,
     threadModel,
   ]);
-  const availableThreadModelIds = useMemo(
-    () =>
-      new Set(
-        availableThreadModels
-          .filter((entry) => !entry.locked)
-          .map((entry) => entry.id),
-      ),
-    [availableThreadModels],
-  );
-  const selectableThreadModels = useMemo(
-    () => availableThreadModels.filter((entry) => !entry.locked),
-    [availableThreadModels],
-  );
   // A camelCode model supplied by the loader is a billing decision, not a
   // generic platform fallback. Do not let a stale premium recent-model choice
   // replace it for a zero-credit new chat.
@@ -1339,17 +1340,13 @@ export default function Chat({
       threadModel,
       allowedThreadModels,
       llmProvider,
-      availableThreadModels,
+      availableThreadModels: baseAvailableThreadModels,
       effectivePickerDefaultModel,
       hasEffectivePickerDefault,
     }),
   );
   const selectedThreadModelRef = useRef<LlmModel>(selectedThreadModel);
   const locationSearchRef = useRef(locationSearch);
-  const noModelsMessage =
-    selectableThreadModels.length === 0 && !(threadId && threadModel)
-      ? "No models are available. Ask an admin to add a model in Settings > Models."
-      : null;
 
   useEffect(() => {
     selectedThreadModelRef.current = selectedThreadModel;
@@ -1370,10 +1367,77 @@ export default function Chat({
     selectedThreadModelRef,
     locationSearchRef,
   });
-  const displayedBillingCreditStatus =
-    selectedThreadModel === CAMEL_CODE_LLM_MODEL
-      ? null
-      : currentBillingCreditStatus;
+  const liveHostedCreditPause = useMemo(
+    () =>
+      deriveHostedCreditPause({
+        modelOptions: baseAvailableThreadModels,
+        billingAccessMode,
+        llmProvider: llmProvider ?? null,
+        allowOpenAiSubscription,
+        billing: currentBillingCreditStatus
+          ? ({
+              billingStatus: currentBillingCreditStatus.billingStatus,
+              availableCreditsCents:
+                currentBillingCreditStatus.availableCreditsCents,
+            } satisfies HostedCreditPauseBilling)
+          : null,
+      }),
+    [
+      allowOpenAiSubscription,
+      baseAvailableThreadModels,
+      billingAccessMode,
+      currentBillingCreditStatus,
+      llmProvider,
+    ],
+  );
+  const availableThreadModels = liveHostedCreditPause.modelOptions;
+  const effectiveHostedCreditsPaused = currentBillingCreditStatus
+    ? liveHostedCreditPause.hostedCreditsPaused
+    : hostedCreditsPaused;
+  const availableThreadModelIds = useMemo(
+    () =>
+      new Set(
+        availableThreadModels
+          .filter((entry) => !entry.locked)
+          .map((entry) => entry.id),
+      ),
+    [availableThreadModels],
+  );
+  const selectableThreadModels = useMemo(
+    () => availableThreadModels.filter((entry) => !entry.locked),
+    [availableThreadModels],
+  );
+  const noModelsMessage =
+    selectableThreadModels.length === 0 && !(threadId && threadModel)
+      ? "No models are available. Ask an admin to add a model in Settings > Models."
+      : null;
+  const openUnlockPremium = useCallback(
+    (triggerModel: LlmModel | null) => {
+      if (
+        shouldNavigateToBillingForPausedModel(
+          effectiveHostedCreditsPaused?.reason,
+          isOrgAdmin,
+        )
+      ) {
+        navigate("/settings/organization/billing");
+        return;
+      }
+      transitionBillingDialog({ kind: "unlock", triggerModel });
+    },
+    [
+      effectiveHostedCreditsPaused?.reason,
+      isOrgAdmin,
+      navigate,
+      transitionBillingDialog,
+    ],
+  );
+  const displayedBillingCreditStatus = resolveDisplayedBillingCreditStatus(
+    currentBillingCreditStatus,
+    selectedThreadModel,
+    Boolean(effectiveHostedCreditsPaused),
+    llmProvider,
+    allowOpenAiSubscription,
+  );
 
   const lastAppliedWelcomeInputRef = useRef(initialWelcomeInput ?? "");
   const [showScrollButton, setShowScrollButton] = useState(false);
@@ -3700,6 +3764,8 @@ export default function Chat({
       !shouldSwitchExhaustedThreadToCamelCode(
         currentBillingCreditStatus,
         selectedThreadModel,
+        llmProvider,
+        allowOpenAiSubscription,
       )
     ) {
       return;
@@ -3707,8 +3773,10 @@ export default function Chat({
     handleThreadModelChange(CAMEL_CODE_LLM_MODEL);
   }, [
     availableThreadModelIds,
+    allowOpenAiSubscription,
     currentBillingCreditStatus,
     handleThreadModelChange,
+    llmProvider,
     readOnly,
     refreshedThreadModel,
     selectedThreadModel,
@@ -4424,6 +4492,8 @@ export default function Chat({
                   isOrgAdmin={isOrgAdmin}
                   onLockedModelSelect={openUnlockPremium}
                   onUnlockRequest={() => openUnlockPremium(null)}
+                  showMoreModelsCta={canUnlockPremiumModels}
+                  pausedSection={effectiveHostedCreditsPaused}
                   recentModelScope={modelRecentScope}
                   textareaRef={composerTextareaRef}
                   mentionables={mentionEntities}
@@ -4583,6 +4653,8 @@ export default function Chat({
                   isOrgAdmin={isOrgAdmin}
                   onLockedModelSelect={openUnlockPremium}
                   onUnlockRequest={() => openUnlockPremium(null)}
+                  showMoreModelsCta={canUnlockPremiumModels}
+                  pausedSection={effectiveHostedCreditsPaused}
                   recentModelScope={modelRecentScope}
                   noModelsMessage={noModelsMessage}
                 />
@@ -4612,6 +4684,12 @@ export default function Chat({
           onTopUp={openBillingTopUp}
           onAddKey={openByokDialog}
           onOpenAiSignIn={openOpenAiSignIn}
+          variant={
+            effectiveHostedCreditsPaused?.reason ===
+            "subscription_unavailable"
+              ? "unlock"
+              : effectiveHostedCreditsPaused?.reason ?? "unlock"
+          }
         />
       ) : null}
       <PlanUpgradeDialog

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -86,6 +86,7 @@ import { PlanUpgradeDialog } from "@/components/billing/plan-upgrade-dialog";
 import { OpenAiSignInDialog } from "@/components/billing/openai-sign-in-dialog";
 import { ByokKeyDialog } from "@/components/onboarding/byok-key-dialog";
 import { CamelCodeWelcomeDialog } from "@/components/camel-code-welcome-dialog";
+import { CamelCodePickerAlert } from "@/components/camel-code-picker-alert";
 import { ModelFallbackBanner } from "@/components/model-fallback-banner";
 import { ChatErrorNotice } from "@/components/chat-error-notice";
 import { ChatMessagesView } from "@/components/chat-messages-view";
@@ -191,6 +192,8 @@ import {
 import { modelCatalogEntriesForIds } from "@/lib/model-catalog";
 import {
   deriveHostedCreditPause,
+  findCheapestSelectableModel,
+  shouldPromptToAddCamelCode,
   type HostedCreditPauseBilling,
   type ModelPausedReason,
   type ModelPickerOption,
@@ -200,7 +203,7 @@ import { getRecentModel, type RecentModelScope } from "@/lib/recent-model";
 import {
   resolveDisplayedBillingCreditStatus,
   resolveRefreshedThreadModel,
-  shouldSwitchExhaustedThreadToCamelCode,
+  shouldSwitchExhaustedThreadModel,
   type BillingCreditStatus,
 } from "@/lib/chat-credit-status";
 import {
@@ -316,6 +319,7 @@ interface ChatProps {
   billingAccessMode?: ChatBillingAccessMode | null;
   canUnlockPremiumModels?: boolean;
   hostedCreditsPaused?: { reason: ModelPausedReason } | null;
+  modelPickerSettingsHref?: string;
   allowOpenAiSubscription?: boolean;
   isOrgAdmin?: boolean;
   recentModelScope?: RecentModelScope | null;
@@ -682,6 +686,7 @@ export default function Chat({
   billingAccessMode = null,
   canUnlockPremiumModels = false,
   hostedCreditsPaused = null,
+  modelPickerSettingsHref = "/settings/organization/models",
   allowOpenAiSubscription = false,
   isOrgAdmin = false,
   recentModelScope,
@@ -1407,10 +1412,20 @@ export default function Chat({
     () => availableThreadModels.filter((entry) => !entry.locked),
     [availableThreadModels],
   );
+  const cheapestSelectableModel = useMemo(
+    () => findCheapestSelectableModel(availableThreadModels),
+    [availableThreadModels],
+  );
+  const shouldAddCamelCodeToPicker = shouldPromptToAddCamelCode(
+    availableThreadModels,
+    effectiveHostedCreditsPaused,
+  );
   const noModelsMessage =
-    selectableThreadModels.length === 0 && !(threadId && threadModel)
-      ? "No models are available. Ask an admin to add a model in Settings > Models."
-      : null;
+    shouldAddCamelCodeToPicker
+      ? "Add camelCode to the model picker to continue for free."
+      : selectableThreadModels.length === 0 && !(threadId && threadModel)
+        ? "No models are available. Ask an admin to add a model in Settings > Models."
+        : null;
   const openUnlockPremium = useCallback(
     (triggerModel: LlmModel | null) => {
       if (
@@ -3750,7 +3765,8 @@ export default function Chat({
   // The Durable Object persists hosted-credit fallback and normally broadcasts
   // the new model through Agent state. Reconcile from the independent
   // post-turn billing refresh as well so a missed state frame cannot leave the
-  // picker showing (or re-persisting) an exhausted premium model.
+  // picker showing (or re-persisting) an exhausted premium model. Custom
+  // pickers fall back to their cheapest credential-covered model.
   useEffect(() => {
     if (
       !threadId ||
@@ -3760,8 +3776,8 @@ export default function Chat({
         refreshedThreadModel,
       ) !== null ||
       updateThreadModelFetcher.state !== "idle" ||
-      !availableThreadModelIds.has(CAMEL_CODE_LLM_MODEL) ||
-      !shouldSwitchExhaustedThreadToCamelCode(
+      !cheapestSelectableModel ||
+      !shouldSwitchExhaustedThreadModel(
         currentBillingCreditStatus,
         selectedThreadModel,
         llmProvider,
@@ -3770,10 +3786,10 @@ export default function Chat({
     ) {
       return;
     }
-    handleThreadModelChange(CAMEL_CODE_LLM_MODEL);
+    handleThreadModelChange(cheapestSelectableModel.id);
   }, [
-    availableThreadModelIds,
     allowOpenAiSubscription,
+    cheapestSelectableModel,
     currentBillingCreditStatus,
     handleThreadModelChange,
     llmProvider,
@@ -4436,11 +4452,17 @@ export default function Chat({
                     )}
                   </div>
                 )}
-                {noModelsMessage && (
+                {shouldAddCamelCodeToPicker ? (
+                  <CamelCodePickerAlert
+                    isOrgAdmin={isOrgAdmin}
+                    settingsHref={modelPickerSettingsHref}
+                    className="mb-2 shrink-0"
+                  />
+                ) : noModelsMessage ? (
                   <p className="mb-3 text-sm text-muted-foreground">
                     {noModelsMessage}
                   </p>
-                )}
+                ) : null}
                 <ModelFallbackBanner
                   notice={modelFallbackNotice}
                   activeModel={selectedThreadModel}
@@ -4451,7 +4473,8 @@ export default function Chat({
                   onOpenAiSignIn={openOpenAiSignIn}
                   className="mb-2 shrink-0"
                 />
-                {displayedBillingCreditStatus ? (
+                {displayedBillingCreditStatus &&
+                !shouldAddCamelCodeToPicker ? (
                   <BillingCreditNotice
                     status={displayedBillingCreditStatus}
                     onOpenUsage={() => navigate("/settings/organization/usage")}
@@ -4658,6 +4681,14 @@ export default function Chat({
                   pausedSection={effectiveHostedCreditsPaused}
                   recentModelScope={modelRecentScope}
                   noModelsMessage={noModelsMessage}
+                  noModelsNotice={
+                    shouldAddCamelCodeToPicker ? (
+                      <CamelCodePickerAlert
+                        isOrgAdmin={isOrgAdmin}
+                        settingsHref={modelPickerSettingsHref}
+                      />
+                    ) : null
+                  }
                 />
               </div>
             </>

--- a/src/components/billing/unlock-premium-modal.tsx
+++ b/src/components/billing/unlock-premium-modal.tsx
@@ -13,6 +13,12 @@ import { MODEL_CATALOG } from "@/lib/model-catalog";
 import { isLlmModelCoveredByOpenAiSubscription } from "@/lib/llm-provider-config";
 import type { LlmModel } from "@/types";
 
+export type UnlockPremiumModalVariant =
+  | "unlock"
+  | "payg_credits_exhausted"
+  | "included_credits_exhausted"
+  | "trial_credits_exhausted";
+
 export interface UnlockPremiumModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -23,6 +29,7 @@ export interface UnlockPremiumModalProps {
   onTopUp: () => void;
   onAddKey: () => void;
   onOpenAiSignIn: () => void;
+  variant?: UnlockPremiumModalVariant;
 }
 
 function AdminAction({
@@ -62,6 +69,7 @@ export function UnlockPremiumModal({
   onTopUp,
   onAddKey,
   onOpenAiSignIn,
+  variant = "unlock",
 }: UnlockPremiumModalProps) {
   const isOpenAiSubscriptionTrigger = Boolean(
     triggerModel && isLlmModelCoveredByOpenAiSubscription(triggerModel),
@@ -69,15 +77,83 @@ export function UnlockPremiumModal({
   const triggerLabel = triggerModel
     ? (MODEL_CATALOG[triggerModel]?.label ?? triggerModel)
     : "Claude and GPT";
+  const dialogCopy = {
+    unlock: {
+      title: "Unlock premium models",
+      description: (
+        <>
+          camelCode is always included. Premium models like {triggerLabel} need
+          one of these:
+        </>
+      ),
+    },
+    payg_credits_exhausted: {
+      title: "Out of credits",
+      description: (
+        <>
+          You&apos;ve used all your camelAI credits. Add more to keep using
+          premium models like {triggerLabel}.
+        </>
+      ),
+    },
+    included_credits_exhausted: {
+      title: "Monthly credits used",
+      description: (
+        <>
+          You&apos;ve used this month&apos;s included credits. They reset when
+          your plan renews. Add credits to keep using {triggerLabel} now.
+        </>
+      ),
+    },
+    trial_credits_exhausted: {
+      title: "Trial credits used",
+      description: (
+        <>
+          You&apos;ve used your trial credits. Subscribe or add credits to keep
+          using premium models like {triggerLabel}.
+        </>
+      ),
+    },
+  }[variant];
+  const subscribeMethod = {
+    testId: "unlock-method-subscribe",
+    title:
+      variant === "included_credits_exhausted" ? "Upgrade plan" : "Subscribe",
+    meta:
+      variant === "included_credits_exhausted" ? null : "from $10/mo",
+    description:
+      variant === "included_credits_exhausted"
+        ? "Higher plans include more monthly credits."
+        : "Monthly model credits matching your plan price, plus more apps, automations, and storage.",
+    label: "See plans",
+    onClick: onSeePlans,
+  };
+  const creditsMethod = {
+    testId: "unlock-method-credits",
+    title: "Buy credits",
+    meta: null,
+    description:
+      variant === "included_credits_exhausted"
+        ? "Extra credits on top of your plan. Available immediately."
+        : "Prepaid, pay as you go. No subscription.",
+    label: "Top up",
+    onClick: onTopUp,
+  };
+  const creditsRecommended =
+    variant === "payg_credits_exhausted" ||
+    variant === "included_credits_exhausted";
+  const recommendedMethod = creditsRecommended
+    ? creditsMethod
+    : subscribeMethod;
+  const otherMethod = creditsRecommended ? subscribeMethod : creditsMethod;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[calc(100svh-2rem)] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Unlock premium models</DialogTitle>
+          <DialogTitle>{dialogCopy.title}</DialogTitle>
           <DialogDescription>
-            camelCode is always included. Premium models like {triggerLabel} need
-            one of these:
+            {dialogCopy.description}
           </DialogDescription>
         </DialogHeader>
 
@@ -95,25 +171,28 @@ export function UnlockPremiumModal({
               </Badge>
               <Card
                 className="py-0 ring-2 ring-primary"
-                data-testid="unlock-method-subscribe"
+                data-testid={recommendedMethod.testId}
               >
                 <CardContent className="flex items-start gap-3 p-4">
                   <div className="min-w-0 flex-1 space-y-1">
                     <div className="flex flex-wrap items-center gap-2">
-                      <p className="text-sm font-medium">Subscribe</p>
-                      <span className="text-xs text-muted-foreground">
-                        from $10/mo
-                      </span>
+                      <p className="text-sm font-medium">
+                        {recommendedMethod.title}
+                      </p>
+                      {recommendedMethod.meta ? (
+                        <span className="text-xs text-muted-foreground">
+                          {recommendedMethod.meta}
+                        </span>
+                      ) : null}
                     </div>
                     <p className="text-sm text-muted-foreground">
-                      Monthly model credits matching your plan price, plus more
-                      apps, automations, and storage.
+                      {recommendedMethod.description}
                     </p>
                   </div>
                   <AdminAction
                     isOrgAdmin={isOrgAdmin}
-                    label="See plans"
-                    onClick={onSeePlans}
+                    label={recommendedMethod.label}
+                    onClick={recommendedMethod.onClick}
                     recommended
                   />
                 </CardContent>
@@ -122,18 +201,25 @@ export function UnlockPremiumModal({
 
             <div
               className="flex items-start justify-between gap-3 px-1"
-              data-testid="unlock-method-credits"
+              data-testid={otherMethod.testId}
             >
               <div className="min-w-0 space-y-1">
-                <p className="text-sm font-medium">Buy credits</p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-sm font-medium">{otherMethod.title}</p>
+                  {otherMethod.meta ? (
+                    <span className="text-xs text-muted-foreground">
+                      {otherMethod.meta}
+                    </span>
+                  ) : null}
+                </div>
                 <p className="text-sm text-muted-foreground">
-                  Prepaid, pay as you go. No subscription.
+                  {otherMethod.description}
                 </p>
               </div>
               <AdminAction
                 isOrgAdmin={isOrgAdmin}
-                label="Top up"
-                onClick={onTopUp}
+                label={otherMethod.label}
+                onClick={otherMethod.onClick}
               />
             </div>
           </div>

--- a/src/components/camel-code-picker-alert.tsx
+++ b/src/components/camel-code-picker-alert.tsx
@@ -1,0 +1,38 @@
+import { CircleAlert } from "lucide-react";
+import { Link } from "react-router";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function CamelCodePickerAlert({
+  isOrgAdmin,
+  settingsHref,
+  className,
+}: {
+  isOrgAdmin: boolean;
+  settingsHref: string;
+  className?: string;
+}) {
+  return (
+    <Alert className={cn("px-3 py-2 text-sm", className)}>
+      <CircleAlert className="h-4 w-4 text-muted-foreground" />
+      <AlertTitle className="text-sm">Premium models are paused</AlertTitle>
+      <AlertDescription className="space-y-2 text-sm text-muted-foreground">
+        <p>
+          {isOrgAdmin
+            ? "Add camelCode to this picker to continue for free."
+            : "Ask an organization admin to add camelCode to this picker."}
+        </p>
+        {isOrgAdmin ? (
+          <Button asChild size="sm" className="h-7">
+            <Link to={settingsHref}>Open model settings</Link>
+          </Button>
+        ) : null}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/chat-billing-credit-notice.tsx
+++ b/src/components/chat-billing-credit-notice.tsx
@@ -245,7 +245,7 @@ export function BillingCreditNotice({
               >
                 View usage
               </Button>
-              {canTopUp ? (
+              {canTopUp && pauseReason !== "subscription_unavailable" ? (
                 <Button
                   type="button"
                   size="sm"

--- a/src/components/chat-billing-credit-notice.tsx
+++ b/src/components/chat-billing-credit-notice.tsx
@@ -8,6 +8,7 @@ import {
   shouldShowLowCreditAlert,
   type BillingCreditStatus,
 } from "@/lib/chat-credit-status";
+import type { ModelPausedReason } from "@/lib/model-picker-access";
 import { cn } from "@/lib/utils";
 
 const DISMISSED_TIER_KEY_PREFIX = "low_credits_alert_dismissed_tier:";
@@ -27,6 +28,36 @@ function formatCreditLabel(cents: number): string {
 function storageKey(userId: string, orgId: string): string {
   return `${DISMISSED_TIER_KEY_PREFIX}${userId}:${orgId}`;
 }
+
+const hostedCreditPauseCopy = {
+  payg_credits_exhausted: {
+    title: "Out of hosted credits",
+    admin: "camelCode is still available. Add credits to restore premium models.",
+    member: "camelCode is still available. Ask an admin to add credits.",
+  },
+  included_credits_exhausted: {
+    title: "Plan credits used",
+    admin:
+      "camelCode is still available. Premium models return at renewal or after adding credits.",
+    member:
+      "camelCode is still available. Premium models return at renewal or after an admin adds credits.",
+  },
+  trial_credits_exhausted: {
+    title: "Trial credits used",
+    admin:
+      "camelCode is still available. Upgrade or add credits to restore premium models.",
+    member:
+      "camelCode is still available. Ask an admin to upgrade or add credits.",
+  },
+  subscription_unavailable: {
+    title: "Payment issue",
+    admin: "camelCode is still available. Fix payment to restore premium models.",
+    member: "camelCode is still available. Ask an admin to fix payment.",
+  },
+} satisfies Record<
+  ModelPausedReason,
+  { title: string; admin: string; member: string }
+>;
 
 function parseStoredDismissedTier(value: string | null): number | null {
   if (!value) return null;
@@ -76,6 +107,7 @@ export function BillingCreditNotice({
   onOpenUsage,
   onTopUp,
   canTopUp = true,
+  pauseReason = null,
   userId = null,
   orgId = null,
   className,
@@ -84,6 +116,7 @@ export function BillingCreditNotice({
   onOpenUsage: () => void;
   onTopUp: () => void;
   canTopUp?: boolean;
+  pauseReason?: ModelPausedReason | null;
   userId?: string | null;
   orgId?: string | null;
   className?: string;
@@ -168,13 +201,22 @@ export function BillingCreditNotice({
   );
 
   if (status.isExhausted) {
-    const description = status.hasByokProvider
+    const pauseCopy = pauseReason ? hostedCreditPauseCopy[pauseReason] : null;
+    const title = pauseCopy?.title ?? "You're out of hosted credits";
+    const pauseDescription = pauseCopy
       ? canTopUp
-        ? "This thread uses a hosted model that isn't covered by your API key. Top up to keep going, or switch to a model your key supports."
-        : "This thread uses a hosted model that isn't covered by your API key. Ask an organization admin to top up credits, or switch to a model your key supports."
-      : canTopUp
-        ? "Top up to keep going, or use your own API key."
-        : "Ask an organization admin to top up credits, or use your own API key.";
+        ? pauseCopy.admin
+        : pauseCopy.member
+      : null;
+    const description =
+      pauseDescription ??
+      (status.hasByokProvider
+        ? canTopUp
+          ? "This thread uses a hosted model that isn't covered by your API key. Top up to keep going, or switch to a model your key supports."
+          : "This thread uses a hosted model that isn't covered by your API key. Ask an organization admin to top up credits, or switch to a model your key supports."
+        : canTopUp
+          ? "Top up to keep going, or use your own API key."
+          : "Ask an organization admin to top up credits, or use your own API key.");
 
     return (
       <div
@@ -187,7 +229,7 @@ export function BillingCreditNotice({
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0">
               <p className="text-sm font-semibold">
-                You&apos;re out of hosted credits this month
+                {title}
               </p>
               <p className="mt-0.5 text-xs text-background/80">
                 {description}

--- a/src/components/model-picker.tsx
+++ b/src/components/model-picker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Fragment, useEffect, useRef, useState } from 'react';
-import { Check, Lock, LockOpen } from 'lucide-react';
+import { Check, Hourglass, Lock, LockOpen } from 'lucide-react';
 import { Link } from 'react-router';
 import { ModelLogo } from '@/components/model-logo';
 import {
@@ -29,7 +29,10 @@ import {
 } from '@/lib/recent-model';
 import { cn } from '@/lib/utils';
 import type { LlmModel } from '@/types';
-import type { ModelPickerOption } from '@/lib/chat-do.server';
+import type {
+  ModelPausedReason,
+  ModelPickerOption,
+} from '@/lib/model-picker-access';
 
 interface ModelPickerProps {
   value: LlmModel;
@@ -41,6 +44,8 @@ interface ModelPickerProps {
   recentModelScope?: RecentModelScope | null;
   disabled?: boolean;
   manageModelsHref?: string;
+  showMoreModelsCta?: boolean;
+  pausedSection?: { reason: ModelPausedReason } | null;
 }
 
 const RATING_MAX = 5;
@@ -144,13 +149,27 @@ function RatingRow({
 }
 
 function ModelMetadataCard({ entry }: { entry: ModelPickerOption }) {
-  const unlockCopy = entry.locked
-    ? entry.unlockHint === 'openai'
-      ? 'Unlock with a plan, credits, an API key — or your OpenAI account.'
-      : 'Unlock with a plan, credits, or an API key.'
-    : entry.id === CAMEL_CODE_LLM_MODEL
-      ? "Free and always included. Text-only."
-      : null;
+  const pausedCopy = entry.pausedReason
+    ? {
+        payg_credits_exhausted:
+          'Add credits to use this model.',
+        included_credits_exhausted:
+          'Available again when your plan renews, or add credits now.',
+        trial_credits_exhausted:
+          'Upgrade or add credits to use this model.',
+        subscription_unavailable:
+          'Fix your payment to use this model.',
+      }[entry.pausedReason]
+    : null;
+  const unlockCopy =
+    pausedCopy ??
+    (entry.locked
+      ? entry.unlockHint === 'openai'
+        ? 'Unlock with a plan, credits, an API key — or your OpenAI account.'
+        : 'Unlock with a plan, credits, or an API key.'
+      : entry.id === CAMEL_CODE_LLM_MODEL
+        ? "Free and always included. Text-only."
+        : null);
 
   return (
     <HoverCardContent side="right" align="start" sideOffset={8} className="w-64">
@@ -190,6 +209,8 @@ export function ModelPicker({
   recentModelScope,
   disabled = false,
   manageModelsHref = '/settings/organization/models',
+  showMoreModelsCta = false,
+  pausedSection = null,
 }: ModelPickerProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [openModelId, setOpenModelId] = useState<LlmModel | null>(null);
@@ -197,10 +218,45 @@ export function ModelPicker({
   const selectedEntry =
     options.find((option) => option.id === value) ?? MODEL_CATALOG[value];
   const unlockedOptions = options.filter((option) => !option.locked);
-  const lockedOptions = options.filter((option) => option.locked);
-  const orderedOptions = [...unlockedOptions, ...lockedOptions];
-  const firstLockedIndex = unlockedOptions.length;
-  const hasLockedOptions = lockedOptions.length > 0;
+  const pausedOptions = options.filter((option) => option.pausedReason);
+  const upsellLockedOptions = options.filter(
+    (option) => option.locked && !option.pausedReason,
+  );
+  const orderedOptions = [
+    ...unlockedOptions,
+    ...pausedOptions,
+    ...upsellLockedOptions,
+  ];
+  const firstPausedIndex =
+    pausedOptions.length > 0 ? unlockedOptions.length : -1;
+  const firstUpsellLockedIndex =
+    upsellLockedOptions.length > 0
+      ? unlockedOptions.length + pausedOptions.length
+      : -1;
+  const hasUpsellLockedOptions = upsellLockedOptions.length > 0;
+  const pausedReason = pausedSection?.reason ?? pausedOptions[0]?.pausedReason;
+  const pausedSectionCopy = pausedReason
+    ? {
+        payg_credits_exhausted: {
+          header: 'Out of credits',
+          description: 'Add credits to keep using these models.',
+        },
+        included_credits_exhausted: {
+          header: 'Monthly credits used',
+          description:
+            'Resets when your plan renews. Add credits to keep going now.',
+        },
+        trial_credits_exhausted: {
+          header: 'Trial credits used',
+          description:
+            'Upgrade or add credits to keep using these models.',
+        },
+        subscription_unavailable: {
+          header: 'Payment issue',
+          description: 'Fix payment to restore these models.',
+        },
+      }[pausedReason]
+    : null;
 
   function clearPendingOpen() {
     if (openTimerRef.current === null) return;
@@ -270,7 +326,18 @@ export function ModelPicker({
           const isSelected = entry.id === value;
           return (
             <Fragment key={entry.id}>
-              {index === firstLockedIndex ? (
+              {index === firstPausedIndex && pausedSectionCopy ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="py-1 text-[0.65rem] font-medium uppercase tracking-wider">
+                    <span className="block">{pausedSectionCopy.header}</span>
+                    <span className="block normal-case font-normal text-muted-foreground">
+                      {pausedSectionCopy.description}
+                    </span>
+                  </DropdownMenuLabel>
+                </>
+              ) : null}
+              {index === firstUpsellLockedIndex ? (
                 <>
                   <DropdownMenuSeparator />
                   <DropdownMenuLabel className="py-1 text-[0.65rem] font-medium uppercase tracking-wider">
@@ -313,7 +380,12 @@ export function ModelPicker({
                     <span className="min-w-0 flex-1 truncate">
                       {entry.label}
                     </span>
-                    {entry.locked ? (
+                    {entry.pausedReason === 'included_credits_exhausted' ? (
+                      <Hourglass
+                        className="ml-auto size-3.5"
+                        aria-label="Out of credits"
+                      />
+                    ) : entry.locked ? (
                       <Lock className="ml-auto size-3.5" aria-label="Locked" />
                     ) : isSelected ? (
                       <Check className="ml-auto size-3.5" />
@@ -325,7 +397,7 @@ export function ModelPicker({
             </Fragment>
           );
         })}
-        {hasLockedOptions ? (
+        {hasUpsellLockedOptions || showMoreModelsCta ? (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem
@@ -336,12 +408,16 @@ export function ModelPicker({
               }}
             >
               <LockOpen className="size-3.5" />
-              <span className="flex-1">Unlock premium models</span>
+              <span className="flex-1">
+                {hasUpsellLockedOptions
+                  ? 'Unlock premium models'
+                  : 'More models'}
+              </span>
               <span aria-hidden="true">→</span>
             </DropdownMenuItem>
           </>
         ) : null}
-        {isOrgAdmin && (
+        {isOrgAdmin && !hasUpsellLockedOptions && !showMoreModelsCta && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild className="text-xs text-muted-foreground">

--- a/src/components/prompt-input.tsx
+++ b/src/components/prompt-input.tsx
@@ -19,7 +19,10 @@ import { ModelPicker } from '@/components/model-picker';
 import {
   modelCatalogEntriesForIds,
 } from '@/lib/model-catalog';
-import type { ModelPickerOption } from '@/lib/chat-do.server';
+import type {
+  ModelPausedReason,
+  ModelPickerOption,
+} from '@/lib/model-picker-access';
 import type { RecentModelScope } from '@/lib/recent-model';
 import type { AtMentionEntity, LlmModel } from '@/types';
 import { AtMentionMenu, mentionItemValue } from '@/components/at-mention-menu';
@@ -64,6 +67,8 @@ interface PromptInputProps {
   isOrgAdmin?: boolean;
   onLockedModelSelect?: (model: LlmModel) => void;
   onUnlockRequest?: () => void;
+  showMoreModelsCta?: boolean;
+  pausedSection?: { reason: ModelPausedReason } | null;
   recentModelScope?: RecentModelScope | null;
   // Ref for programmatic focus
   textareaRef?: React.RefObject<HTMLTextAreaElement | null>;
@@ -141,6 +146,8 @@ export function PromptInput({
   isOrgAdmin = false,
   onLockedModelSelect,
   onUnlockRequest,
+  showMoreModelsCta = false,
+  pausedSection = null,
   recentModelScope,
   textareaRef,
   mentionables,
@@ -622,6 +629,8 @@ export function PromptInput({
                       isOrgAdmin={isOrgAdmin}
                       onLockedModelSelect={onLockedModelSelect}
                       onUnlockRequest={onUnlockRequest}
+                      showMoreModelsCta={showMoreModelsCta}
+                      pausedSection={pausedSection}
                       recentModelScope={recentModelScope}
                       disabled={modelDisabled || disabled}
                     />

--- a/src/components/welcome-screen/index.tsx
+++ b/src/components/welcome-screen/index.tsx
@@ -40,7 +40,10 @@ import { GroupNewChatHeader } from './group-new-chat-header';
 import { RecentlyUsedInGroup } from './recently-used-in-group';
 import { STARTER_PROMPTS, pickStarterPrompts } from './starter-prompt-catalog';
 import { useResolvedList } from './use-resolved-list';
-import type { ModelPickerOption } from '@/lib/chat-do.server';
+import type {
+  ModelPausedReason,
+  ModelPickerOption,
+} from '@/lib/model-picker-access';
 import type { RecentModelScope } from '@/lib/recent-model';
 
 interface WelcomeScreenProps {
@@ -72,6 +75,8 @@ interface WelcomeScreenProps {
   isOrgAdmin?: boolean;
   onLockedModelSelect?: (model: LlmModel) => void;
   onUnlockRequest?: () => void;
+  showMoreModelsCta?: boolean;
+  pausedSection?: { reason: ModelPausedReason } | null;
   recentModelScope?: RecentModelScope | null;
   noModelsMessage?: string | null;
 }
@@ -206,6 +211,8 @@ export function WelcomeScreen({
   isOrgAdmin = false,
   onLockedModelSelect,
   onUnlockRequest,
+  showMoreModelsCta = false,
+  pausedSection = null,
   recentModelScope,
   noModelsMessage,
 }: WelcomeScreenProps) {
@@ -316,6 +323,8 @@ export function WelcomeScreen({
             isOrgAdmin={isOrgAdmin}
             onLockedModelSelect={onLockedModelSelect}
             onUnlockRequest={onUnlockRequest}
+            showMoreModelsCta={showMoreModelsCta}
+            pausedSection={pausedSection}
             recentModelScope={recentModelScope}
             mentionables={mentionEntities}
             mentionMenuSide="top"

--- a/src/components/welcome-screen/index.tsx
+++ b/src/components/welcome-screen/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import { Await, useNavigate } from 'react-router';
 import { ChevronUp, Plus } from 'lucide-react';
 import type {
@@ -79,6 +80,7 @@ interface WelcomeScreenProps {
   pausedSection?: { reason: ModelPausedReason } | null;
   recentModelScope?: RecentModelScope | null;
   noModelsMessage?: string | null;
+  noModelsNotice?: ReactNode;
 }
 
 const EMPTY_INTEGRATIONS: Integration[] = [];
@@ -215,6 +217,7 @@ export function WelcomeScreen({
   pausedSection = null,
   recentModelScope,
   noModelsMessage,
+  noModelsNotice,
 }: WelcomeScreenProps) {
   const navigate = useNavigate();
   const [referenceTime] = useState(() => renderedAt ?? Date.now());
@@ -343,11 +346,13 @@ export function WelcomeScreen({
         <div>
           {promptComposer}
 
-          {noModelsMessage && (
+          {noModelsNotice ? (
+            <div className="mt-2">{noModelsNotice}</div>
+          ) : noModelsMessage ? (
             <p className="mt-2 text-sm text-muted-foreground">
               {noModelsMessage}
             </p>
-          )}
+          ) : null}
         </div>
 
         <RecentlyUsedInGroup
@@ -372,11 +377,13 @@ export function WelcomeScreen({
 
       {promptComposer}
 
-      {noModelsMessage && (
+      {noModelsNotice ? (
+        <div className="-mt-8">{noModelsNotice}</div>
+      ) : noModelsMessage ? (
         <p className="-mt-8 text-sm text-muted-foreground">
           {noModelsMessage}
         </p>
-      )}
+      ) : null}
 
       <Suspense fallback={<RecentChatsFallback />}>
         <Await resolve={recentThreads}>

--- a/src/lib/billing-dialog-state.ts
+++ b/src/lib/billing-dialog-state.ts
@@ -1,4 +1,5 @@
 import type { LlmModel } from "@/types";
+import type { ModelPausedReason } from "@/lib/model-picker-access";
 
 export type BillingDialogState =
   | { kind: "none" }
@@ -54,4 +55,11 @@ export function hasActiveBillingDialog(
   isExternalDialogOpen: boolean,
 ): boolean {
   return current.kind !== "none" || isExternalDialogOpen;
+}
+
+export function shouldNavigateToBillingForPausedModel(
+  reason: ModelPausedReason | null | undefined,
+  isOrgAdmin: boolean,
+): boolean {
+  return isOrgAdmin && reason === "subscription_unavailable";
 }

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -101,7 +101,7 @@ export function getBillingStatusDescription(
     case "enterprise":
       return "Your organization is billed outside Stripe and does not need a subscription or credits.";
     case "past_due":
-      return "Your subscription needs attention before chat can continue.";
+      return "Your payment is past due. Fix it to restore premium models.";
     case "canceled":
       return "Your subscription was canceled.";
     case "inactive":

--- a/src/lib/chat-credit-status.ts
+++ b/src/lib/chat-credit-status.ts
@@ -84,7 +84,7 @@ export function resolveDisplayedBillingCreditStatus(
   return status ?? null;
 }
 
-export function shouldSwitchExhaustedThreadToCamelCode(
+export function shouldSwitchExhaustedThreadModel(
   status: BillingCreditStatus | null | undefined,
   threadModel: LlmModel | null | undefined,
   byokProvider?: string | null,

--- a/src/lib/chat-credit-status.ts
+++ b/src/lib/chat-credit-status.ts
@@ -2,14 +2,16 @@ import type { OrgBillingOverview } from '@/lib/billing.server';
 import {
   isCreditFreeHostedModel,
   isLlmModelCoveredByByokProvider,
+  isLlmModelCoveredByOpenAiSubscription,
 } from '@/lib/llm-provider-config';
-import type { LlmModel } from '@/types';
+import type { BillingStatus, LlmModel } from '@/types';
 
 export interface BillingCreditStatus {
   availableCreditsCents: number;
   totalCreditLimitCents: number;
   isExhausted: boolean;
   hasByokProvider: boolean;
+  billingStatus?: BillingStatus | null;
 }
 
 export const LOW_CREDIT_THRESHOLDS_CENTS = [500, 250, 100, 50] as const;
@@ -45,38 +47,58 @@ export function shouldShowLowCreditAlert(
 export function buildBillingCreditStatus(
   overview: OrgBillingOverview | null,
   byokProvider: string | null | undefined | boolean,
-  threadModel?: LlmModel | null,
+  _threadModel?: LlmModel | null,
 ): BillingCreditStatus | null {
   if (!overview || overview.billing_status === 'enterprise') {
     return null;
   }
-  if (isCreditFreeHostedModel(threadModel)) {
-    return null;
-  }
   const hasByokProvider = Boolean(byokProvider);
-  if (
-    typeof byokProvider === 'string' &&
-    isLlmModelCoveredByByokProvider(threadModel, byokProvider)
-  ) {
-    return null;
-  }
 
   return {
     availableCreditsCents: overview.available_credits_cents,
     totalCreditLimitCents: overview.total_credit_limit_cents,
     isExhausted: overview.available_credits_cents <= 0,
     hasByokProvider,
+    billingStatus: overview.billing_status,
   };
+}
+
+export function resolveDisplayedBillingCreditStatus(
+  status: BillingCreditStatus | null | undefined,
+  threadModel: LlmModel | null | undefined,
+  hostedCreditsPaused: boolean,
+  byokProvider?: string | null,
+  allowOpenAiSubscription = false,
+): BillingCreditStatus | null {
+  if (isCreditFreeHostedModel(threadModel) && !hostedCreditsPaused) {
+    return null;
+  }
+  if (
+    isLlmModelCoveredByByokProvider(threadModel, byokProvider) ||
+    (threadModel &&
+      allowOpenAiSubscription &&
+      isLlmModelCoveredByOpenAiSubscription(threadModel))
+  ) {
+    return null;
+  }
+  return status ?? null;
 }
 
 export function shouldSwitchExhaustedThreadToCamelCode(
   status: BillingCreditStatus | null | undefined,
   threadModel: LlmModel | null | undefined,
+  byokProvider?: string | null,
+  allowOpenAiSubscription = false,
 ): boolean {
   return Boolean(
     status?.isExhausted &&
       threadModel &&
-      !isCreditFreeHostedModel(threadModel),
+      !isCreditFreeHostedModel(threadModel) &&
+      !isLlmModelCoveredByByokProvider(threadModel, byokProvider) &&
+      !(
+        allowOpenAiSubscription &&
+        isLlmModelCoveredByOpenAiSubscription(threadModel)
+      ),
   );
 }
 
@@ -134,7 +156,13 @@ export function applyDevBillingCreditStatusOverride(
   status: BillingCreditStatus | null,
   searchParams: URLSearchParams,
 ): BillingCreditStatus | null {
-  return getDevBillingCreditStatus(searchParams) ?? status;
+  const override = getDevBillingCreditStatus(searchParams);
+  return override
+    ? {
+        ...override,
+        billingStatus: status?.billingStatus ?? null,
+      }
+    : status;
 }
 
 export function getDevChatInitialError(searchParams: URLSearchParams): string | null {

--- a/src/lib/chat-do.server.ts
+++ b/src/lib/chat-do.server.ts
@@ -21,12 +21,14 @@ import { OrgDO, type OrgThread } from "../../workers/main/src/auth";
 import { WorkspaceDO } from "../../workers/main/src/workspace";
 import {
   CAMEL_CODE_LLM_MODEL,
+  CUSTOM_LLM_MODEL,
   type CustomLlmProviderApi,
   type LlmProviderConfigRecord,
   getDefaultLlmModel,
   getStoredCustomLlmProviderApi,
   getStoredCustomLlmProviderModelId,
   getStoredBedrockAwsRegion,
+  isLlmModelCoveredByByokProvider,
   isLlmModelCoveredByOpenAiSubscription,
   isLlmModelAllowedForNewThread,
   isLlmModel,
@@ -36,8 +38,17 @@ import { getEffectiveLlmProviderConfig } from "./selfhost-ai-provider";
 import {
   MODEL_CATALOG,
   resolveModelPickerCatalog,
-  type ModelCatalogEntry,
 } from "./model-catalog";
+import {
+  deriveHostedCreditPause,
+  type HostedCreditPauseBilling,
+  type ModelPausedReason,
+  type ModelPickerOption,
+} from "./model-picker-access";
+export type {
+  ModelPausedReason,
+  ModelPickerOption,
+} from "./model-picker-access";
 import { parseChannelIndicatorKindsJson } from "./channel-kinds";
 import {
   resolveDefaultModelForChat,
@@ -176,12 +187,73 @@ export interface WorkspaceModelPickerState {
   effectivePickerDefaultModel: LlmModel | null;
   hasEffectivePickerDefault: boolean;
   defaultModel: LlmModel | null;
+  canUnlockPremiumModels: boolean;
+  hostedCreditsPaused: { reason: ModelPausedReason } | null;
 }
 
-export type ModelPickerOption = ModelCatalogEntry & {
-  locked?: boolean;
-  unlockHint?: "openai" | "generic";
-};
+const UNLOCKABLE_CATALOG_IDS = (
+  Object.keys(MODEL_CATALOG) as LlmModel[]
+).filter(
+  (id) =>
+    id !== CUSTOM_LLM_MODEL &&
+    id !== CAMEL_CODE_LLM_MODEL,
+);
+
+export function isBillingLockedModel(
+  modelId: LlmModel,
+  args: { isFreeMode: boolean; allowOpenAiSubscription: boolean },
+): boolean {
+  if (!args.isFreeMode || modelId === CAMEL_CODE_LLM_MODEL) {
+    return false;
+  }
+  return !(
+    args.allowOpenAiSubscription &&
+    isLlmModelCoveredByOpenAiSubscription(modelId)
+  );
+}
+
+export function applyHostedCreditPause(
+  pickerState: WorkspaceModelPickerState,
+  billing: HostedCreditPauseBilling | null,
+): WorkspaceModelPickerState {
+  const pause = deriveHostedCreditPause({
+    modelOptions: pickerState.modelOptions,
+    billingAccessMode: pickerState.billingAccessMode,
+    llmProvider: pickerState.llmProvider,
+    allowOpenAiSubscription: pickerState.allowOpenAiSubscription,
+    billing,
+  });
+  if (!pause.hostedCreditsPaused) {
+    return {
+      ...pickerState,
+      hostedCreditsPaused: null,
+    };
+  }
+
+  const { modelOptions } = pause;
+  const allowedThreadModels = modelOptions
+    .filter((entry) => !entry.locked)
+    .map((entry) => entry.id);
+  const lockedIds = new Set(
+    modelOptions.filter((entry) => entry.locked).map((entry) => entry.id),
+  );
+
+  return {
+    ...pickerState,
+    modelOptions,
+    allowedThreadModels,
+    effectivePickerDefaultModel:
+      pickerState.effectivePickerDefaultModel &&
+      lockedIds.has(pickerState.effectivePickerDefaultModel)
+        ? CAMEL_CODE_LLM_MODEL
+        : pickerState.effectivePickerDefaultModel,
+    defaultModel:
+      pickerState.defaultModel && lockedIds.has(pickerState.defaultModel)
+        ? CAMEL_CODE_LLM_MODEL
+        : pickerState.defaultModel,
+    hostedCreditsPaused: pause.hostedCreditsPaused,
+  };
+}
 
 async function getOrgModelPickerConfigCompat(
   orgStub: OrgDO,
@@ -296,13 +368,11 @@ async function getWorkspaceModelPickerStateForOrg(
       ? [MODEL_CATALOG[CAMEL_CODE_LLM_MODEL], ...resolvedCatalog]
       : resolvedCatalog;
   const modelOptions: ModelPickerOption[] = visibleCatalog.map((entry) => {
-    const isOpenAiCovered =
-      allowOpenAiSubscription &&
-      isLlmModelCoveredByOpenAiSubscription(entry.id);
     if (
-      !isFreeMode ||
-      entry.id === CAMEL_CODE_LLM_MODEL ||
-      isOpenAiCovered
+      !isBillingLockedModel(entry.id, {
+        isFreeMode,
+        allowOpenAiSubscription,
+      })
     ) {
       return entry;
     }
@@ -315,6 +385,26 @@ async function getWorkspaceModelPickerStateForOrg(
     };
   });
   const selectableCatalog = modelOptions.filter((entry) => !entry.locked);
+  const hasNonCamelCodeUnlocked = modelOptions.some(
+    (entry) => !entry.locked && entry.id !== CAMEL_CODE_LLM_MODEL,
+  );
+  const visibleModelOptions = hasNonCamelCodeUnlocked
+    ? modelOptions.filter((entry) => !entry.locked)
+    : modelOptions;
+  const unlockedIds = new Set(selectableCatalog.map((entry) => entry.id));
+  const canUnlockPremiumModels =
+    (billingAccessMode === "camel_free" || billingAccessMode === "byok") &&
+    UNLOCKABLE_CATALOG_IDS.some(
+      (id) =>
+        !unlockedIds.has(id) &&
+        !(
+          billingAccessMode === "byok" &&
+          isLlmModelCoveredByByokProvider(
+            id,
+            effectiveLlmProviderConfig?.provider,
+          )
+        ),
+    );
   const configuredDefault = effectiveConfig.default_model;
   const configuredDefaultIsLocked = modelOptions.some(
     (entry) => entry.id === configuredDefault && entry.locked,
@@ -342,11 +432,13 @@ async function getWorkspaceModelPickerStateForOrg(
     allowOpenAiSubscription,
     billingAccessMode,
     experimentalSettings,
-    modelOptions,
+    modelOptions: visibleModelOptions,
     allowedThreadModels: selectableCatalog.map((entry) => entry.id),
     effectivePickerDefaultModel,
     hasEffectivePickerDefault: effectivePickerDefaultModel !== null,
     defaultModel,
+    canUnlockPremiumModels,
+    hostedCreditsPaused: null,
   };
 }
 

--- a/src/lib/chat-do.server.ts
+++ b/src/lib/chat-do.server.ts
@@ -41,6 +41,7 @@ import {
 } from "./model-catalog";
 import {
   deriveHostedCreditPause,
+  findCheapestSelectableModel,
   type HostedCreditPauseBilling,
   type ModelPausedReason,
   type ModelPickerOption,
@@ -189,6 +190,7 @@ export interface WorkspaceModelPickerState {
   defaultModel: LlmModel | null;
   canUnlockPremiumModels: boolean;
   hostedCreditsPaused: { reason: ModelPausedReason } | null;
+  modelPickerSettingsHref: string;
 }
 
 const UNLOCKABLE_CATALOG_IDS = (
@@ -237,20 +239,18 @@ export function applyHostedCreditPause(
   const lockedIds = new Set(
     modelOptions.filter((entry) => entry.locked).map((entry) => entry.id),
   );
+  const fallbackModel = findCheapestSelectableModel(modelOptions)?.id ?? null;
+  const replaceLockedDefault = (model: LlmModel | null): LlmModel | null =>
+    model && lockedIds.has(model) ? fallbackModel ?? model : model;
 
   return {
     ...pickerState,
     modelOptions,
     allowedThreadModels,
-    effectivePickerDefaultModel:
-      pickerState.effectivePickerDefaultModel &&
-      lockedIds.has(pickerState.effectivePickerDefaultModel)
-        ? CAMEL_CODE_LLM_MODEL
-        : pickerState.effectivePickerDefaultModel,
-    defaultModel:
-      pickerState.defaultModel && lockedIds.has(pickerState.defaultModel)
-        ? CAMEL_CODE_LLM_MODEL
-        : pickerState.defaultModel,
+    effectivePickerDefaultModel: replaceLockedDefault(
+      pickerState.effectivePickerDefaultModel,
+    ),
+    defaultModel: replaceLockedDefault(pickerState.defaultModel),
     hostedCreditsPaused: pause.hostedCreditsPaused,
   };
 }
@@ -362,8 +362,10 @@ async function getWorkspaceModelPickerStateForOrg(
     awsRegion,
     allowOpenAiSubscription,
   });
+  const isCustomPicker = effectiveConfig.use_platform_defaults === false;
   const visibleCatalog =
     isFreeMode &&
+    !isCustomPicker &&
     !resolvedCatalog.some((entry) => entry.id === CAMEL_CODE_LLM_MODEL)
       ? [MODEL_CATALOG[CAMEL_CODE_LLM_MODEL], ...resolvedCatalog]
       : resolvedCatalog;
@@ -409,8 +411,9 @@ async function getWorkspaceModelPickerStateForOrg(
   const configuredDefaultIsLocked = modelOptions.some(
     (entry) => entry.id === configuredDefault && entry.locked,
   );
+  const fallbackModel = findCheapestSelectableModel(modelOptions)?.id ?? null;
   const effectivePickerDefaultModel = configuredDefaultIsLocked
-    ? CAMEL_CODE_LLM_MODEL
+    ? fallbackModel ?? configuredDefault
     : configuredDefault;
   const defaultModel = resolveDefaultModelForChat({
     effectiveDefaultModel: effectivePickerDefaultModel,
@@ -439,6 +442,10 @@ async function getWorkspaceModelPickerStateForOrg(
     defaultModel,
     canUnlockPremiumModels,
     hostedCreditsPaused: null,
+    modelPickerSettingsHref:
+      effectiveConfig.source === "workspace"
+        ? `/settings/organization/models?scope=ws&workspaceId=${encodeURIComponent(workspaceId)}`
+        : "/settings/organization/models",
   };
 }
 

--- a/src/lib/model-picker-access.ts
+++ b/src/lib/model-picker-access.ts
@@ -1,0 +1,152 @@
+import {
+  CAMEL_CODE_LLM_MODEL,
+  isCreditFreeHostedModel,
+  isLlmModelCoveredByByokProvider,
+  isLlmModelCoveredByOpenAiSubscription,
+} from "@/lib/llm-provider-config";
+import {
+  MODEL_CATALOG,
+  type ModelCatalogEntry,
+} from "@/lib/model-catalog";
+import type { BillingStatus, LlmProvider } from "@/types";
+
+export type ModelPausedReason =
+  | "payg_credits_exhausted"
+  | "included_credits_exhausted"
+  | "trial_credits_exhausted"
+  | "subscription_unavailable";
+
+export type ModelPickerOption = ModelCatalogEntry & {
+  locked?: boolean;
+  unlockHint?: "openai" | "generic";
+  pausedReason?: ModelPausedReason;
+};
+
+export type ModelPickerBillingAccessMode =
+  | "enterprise"
+  | "subscription"
+  | "byok"
+  | "credits"
+  | "selfhost"
+  | "camel_free";
+
+export interface HostedCreditPauseBilling {
+  billingStatus?: BillingStatus | null;
+  availableCreditsCents: number | null;
+}
+
+interface HostedCreditPauseResult {
+  modelOptions: ModelPickerOption[];
+  hostedCreditsPaused: { reason: ModelPausedReason } | null;
+}
+
+function clearHostedCreditPause(
+  entry: ModelPickerOption,
+): ModelPickerOption {
+  if (!entry.pausedReason) return entry;
+  const {
+    locked: _locked,
+    pausedReason: _pausedReason,
+    ...unpausedEntry
+  } = entry;
+  return unpausedEntry;
+}
+
+/**
+ * Applies the hosted-credit pause to a picker catalog. This is shared by the
+ * route loaders and the live chat credit refresh so rows lock immediately when
+ * the balance crosses zero, without waiting for a route revalidation.
+ */
+export function deriveHostedCreditPause(args: {
+  modelOptions: ReadonlyArray<ModelPickerOption>;
+  billingAccessMode: ModelPickerBillingAccessMode | null;
+  llmProvider: LlmProvider | null;
+  allowOpenAiSubscription: boolean;
+  billing: HostedCreditPauseBilling | null;
+}): HostedCreditPauseResult {
+  if (
+    !args.billing ||
+    (args.billingAccessMode !== "subscription" &&
+      args.billingAccessMode !== "credits")
+  ) {
+    return {
+      modelOptions: [...args.modelOptions],
+      hostedCreditsPaused: null,
+    };
+  }
+
+  // A fresh positive balance should also clear pause-only locks from loader
+  // data that predates the live credit refresh.
+  const modelOptions = args.modelOptions.map(clearHostedCreditPause);
+  let reason: ModelPausedReason | null = null;
+  if (
+    args.billing.billingStatus === "past_due" ||
+    args.billing.billingStatus === "canceled"
+  ) {
+    reason = "subscription_unavailable";
+  } else if (
+    args.billing.availableCreditsCents !== null &&
+    args.billing.availableCreditsCents <= 0
+  ) {
+    reason =
+      args.billing.billingStatus === "trialing"
+        ? "trial_credits_exhausted"
+        : args.billing.billingStatus === "active" ||
+            args.billingAccessMode === "subscription"
+          ? "included_credits_exhausted"
+          : "payg_credits_exhausted";
+  }
+  if (!reason) {
+    return {
+      modelOptions,
+      hostedCreditsPaused: null,
+    };
+  }
+
+  // Keep this chargeability mirror aligned with checkHostedPiModelAccess in
+  // workers/main/src/chat-thread/pi-model-config.ts.
+  const pausedModelOptions = modelOptions.map((entry) => {
+    const coveredByByok =
+      args.llmProvider &&
+      isLlmModelCoveredByByokProvider(entry.id, args.llmProvider);
+    const coveredByOpenAi =
+      args.allowOpenAiSubscription &&
+      isLlmModelCoveredByOpenAiSubscription(entry.id);
+    if (
+      isCreditFreeHostedModel(entry.id) ||
+      coveredByByok ||
+      coveredByOpenAi
+    ) {
+      return entry;
+    }
+    return {
+      ...entry,
+      locked: true,
+      pausedReason: reason,
+    };
+  });
+  const hasPausedModel = pausedModelOptions.some(
+    (entry) => entry.pausedReason === reason,
+  );
+  if (!hasPausedModel) {
+    return {
+      modelOptions: pausedModelOptions,
+      hostedCreditsPaused: null,
+    };
+  }
+  const selectableModelOptions = pausedModelOptions.some(
+    (entry) => !entry.locked,
+  )
+    ? pausedModelOptions
+    : [
+        MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
+        ...pausedModelOptions.filter(
+          (entry) => entry.id !== CAMEL_CODE_LLM_MODEL,
+        ),
+      ];
+
+  return {
+    modelOptions: selectableModelOptions,
+    hostedCreditsPaused: { reason },
+  };
+}

--- a/src/lib/model-picker-access.ts
+++ b/src/lib/model-picker-access.ts
@@ -4,10 +4,7 @@ import {
   isLlmModelCoveredByByokProvider,
   isLlmModelCoveredByOpenAiSubscription,
 } from "@/lib/llm-provider-config";
-import {
-  MODEL_CATALOG,
-  type ModelCatalogEntry,
-} from "@/lib/model-catalog";
+import type { ModelCatalogEntry } from "@/lib/model-catalog";
 import type { BillingStatus, LlmProvider } from "@/types";
 
 export type ModelPausedReason =
@@ -50,6 +47,34 @@ function clearHostedCreditPause(
     ...unpausedEntry
   } = entry;
   return unpausedEntry;
+}
+
+function modelCostRank(entry: ModelPickerOption): number {
+  return entry.cost === "Free" ? 0 : entry.cost.length;
+}
+
+export function findCheapestSelectableModel(
+  modelOptions: ReadonlyArray<ModelPickerOption>,
+): ModelPickerOption | null {
+  return modelOptions.reduce<ModelPickerOption | null>((cheapest, entry) => {
+    if (entry.locked) return cheapest;
+    if (!cheapest || modelCostRank(entry) < modelCostRank(cheapest)) {
+      return entry;
+    }
+    return cheapest;
+  }, null);
+}
+
+export function shouldPromptToAddCamelCode(
+  modelOptions: ReadonlyArray<ModelPickerOption>,
+  hostedCreditsPaused: { reason: ModelPausedReason } | null,
+): boolean {
+  const hasBillingLockedModel = modelOptions.some((entry) => entry.locked);
+  return Boolean(
+    (hostedCreditsPaused || hasBillingLockedModel) &&
+    !modelOptions.some((entry) => !entry.locked) &&
+    !modelOptions.some((entry) => entry.id === CAMEL_CODE_LLM_MODEL),
+  );
 }
 
 /**
@@ -134,19 +159,9 @@ export function deriveHostedCreditPause(args: {
       hostedCreditsPaused: null,
     };
   }
-  const selectableModelOptions = pausedModelOptions.some(
-    (entry) => !entry.locked,
-  )
-    ? pausedModelOptions
-    : [
-        MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
-        ...pausedModelOptions.filter(
-          (entry) => entry.id !== CAMEL_CODE_LLM_MODEL,
-        ),
-      ];
 
   return {
-    modelOptions: selectableModelOptions,
+    modelOptions: pausedModelOptions,
     hostedCreditsPaused: { reason },
   };
 }

--- a/src/lib/model-picker-access.ts
+++ b/src/lib/model-picker-access.ts
@@ -89,9 +89,13 @@ export function deriveHostedCreditPause(args: {
   allowOpenAiSubscription: boolean;
   billing: HostedCreditPauseBilling | null;
 }): HostedCreditPauseResult {
+  const subscriptionUnavailable =
+    args.billing?.billingStatus === "past_due" &&
+    args.billingAccessMode !== "selfhost";
   if (
     !args.billing ||
-    (args.billingAccessMode !== "subscription" &&
+    (!subscriptionUnavailable &&
+      args.billingAccessMode !== "subscription" &&
       args.billingAccessMode !== "credits")
   ) {
     return {
@@ -104,10 +108,7 @@ export function deriveHostedCreditPause(args: {
   // data that predates the live credit refresh.
   const modelOptions = args.modelOptions.map(clearHostedCreditPause);
   let reason: ModelPausedReason | null = null;
-  if (
-    args.billing.billingStatus === "past_due" ||
-    args.billing.billingStatus === "canceled"
-  ) {
+  if (subscriptionUnavailable) {
     reason = "subscription_unavailable";
   } else if (
     args.billing.availableCreditsCents !== null &&

--- a/src/routes/_app.chat.$id.tsx
+++ b/src/routes/_app.chat.$id.tsx
@@ -620,6 +620,7 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
       billingAccessMode: null,
       canUnlockPremiumModels: false,
       hostedCreditsPaused: null,
+      modelPickerSettingsHref: "/settings/organization/models",
       allowOpenAiSubscription: false,
       experimentalSettings: DEFAULT_ORG_EXPERIMENTAL_SETTINGS,
       billingCreditStatus: null,
@@ -655,6 +656,7 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
       billingAccessMode: null,
       canUnlockPremiumModels: false,
       hostedCreditsPaused: null,
+      modelPickerSettingsHref: "/settings/organization/models",
       allowOpenAiSubscription: false,
       experimentalSettings: DEFAULT_ORG_EXPERIMENTAL_SETTINGS,
       billingCreditStatus: null,
@@ -932,6 +934,9 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
     canUnlockPremiumModels:
       pausedPickerState?.canUnlockPremiumModels ?? false,
     hostedCreditsPaused: pausedPickerState?.hostedCreditsPaused ?? null,
+    modelPickerSettingsHref:
+      pausedPickerState?.modelPickerSettingsHref ??
+      "/settings/organization/models",
     allowOpenAiSubscription:
       pausedPickerState?.allowOpenAiSubscription ?? false,
     experimentalSettings:
@@ -976,6 +981,7 @@ export default function ChatPage() {
     billingAccessMode,
     canUnlockPremiumModels,
     hostedCreditsPaused,
+    modelPickerSettingsHref,
     allowOpenAiSubscription,
     experimentalSettings,
     billingCreditStatus,
@@ -1335,6 +1341,7 @@ export default function ChatPage() {
             billingAccessMode={billingAccessMode}
             canUnlockPremiumModels={canUnlockPremiumModels}
             hostedCreditsPaused={hostedCreditsPaused}
+            modelPickerSettingsHref={modelPickerSettingsHref}
             allowOpenAiSubscription={allowOpenAiSubscription}
             experimentalSettings={experimentalSettings}
             billingCreditStatus={billingCreditStatus}

--- a/src/routes/_app.chat.$id.tsx
+++ b/src/routes/_app.chat.$id.tsx
@@ -734,12 +734,11 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
   }
 
   const selfhostRuntime = isSelfhostRuntime(env);
+  // Do not convert a failed hosted billing read to null: null bypasses the
+  // credit pause and would expose models the Worker may reject.
   const billingOverviewPromise = selfhostRuntime
     ? Promise.resolve(null)
-    : getOrgBillingOverview(env, authContext.currentOrg).catch((error) => {
-        console.warn("Failed to load billing overview for chat:", error);
-        return null;
-      });
+    : getOrgBillingOverview(env, authContext.currentOrg);
   const threadPromise = chatDO.getThread(context, params.id, workspaceId, {
     orgId: authContext.currentOrg.id,
   });

--- a/src/routes/_app.chat.$id.tsx
+++ b/src/routes/_app.chat.$id.tsx
@@ -27,6 +27,7 @@ import { getOrgBillingOverview } from "@/lib/billing.server";
 import {
   applyDevBillingCreditStatusOverride,
   buildBillingCreditStatus,
+  getDevBillingCreditStatus,
   getDevChatInitialError,
 } from "@/lib/chat-credit-status";
 import {
@@ -617,6 +618,9 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
       effectivePickerDefaultModel: null,
       hasEffectivePickerDefault: false,
       billingAccessMode: null,
+      canUnlockPremiumModels: false,
+      hostedCreditsPaused: null,
+      allowOpenAiSubscription: false,
       experimentalSettings: DEFAULT_ORG_EXPERIMENTAL_SETTINGS,
       billingCreditStatus: null,
       initialChatError: null,
@@ -649,6 +653,9 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
       effectivePickerDefaultModel: null,
       hasEffectivePickerDefault: false,
       billingAccessMode: null,
+      canUnlockPremiumModels: false,
+      hostedCreditsPaused: null,
+      allowOpenAiSubscription: false,
       experimentalSettings: DEFAULT_ORG_EXPERIMENTAL_SETTINGS,
       billingCreditStatus: null,
       initialChatError: getDevChatInitialError(url.searchParams),
@@ -762,6 +769,20 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
     threadPromise,
     pickerStatePromise,
   ]);
+  const devCreditStatus = getDevBillingCreditStatus(url.searchParams);
+  const pausedPickerState = pickerState
+    ? chatDO.applyHostedCreditPause(
+        pickerState,
+        billingOverview
+          ? {
+              billingStatus: billingOverview.billing_status,
+              availableCreditsCents:
+                devCreditStatus?.availableCreditsCents ??
+                billingOverview.available_credits_cents,
+            }
+          : null,
+      )
+    : null;
 
   // Even for newly created threads, load the persisted thread record so the UI
   // reflects the actual saved model instead of the Sonnet default.
@@ -870,7 +891,7 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
   const [activeChatGroup, moveChatGroups] = await activeChatGroupPromise;
   const resolvedThreadModel =
     thread?.model ??
-    pickerState?.defaultModel ??
+    pausedPickerState?.defaultModel ??
     fallbackThreadModel;
   recordChatThreadRouteLoaderStage(
     env,
@@ -892,25 +913,30 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
     threadTitle: thread?.title ?? null,
     threadModel: resolvedThreadModel,
     llmProvider:
-      pickerState?.llmProvider ??
+      pausedPickerState?.llmProvider ??
       ((effectiveLlmProviderConfig?.provider ?? null) as
         | import("@/types").LlmProvider
         | null),
-    customApi: pickerState?.customApi ?? customApi,
-    customModelId: pickerState?.customModelId ?? customModelId,
-    awsRegion: pickerState?.awsRegion ?? awsRegion,
+    customApi: pausedPickerState?.customApi ?? customApi,
+    customModelId: pausedPickerState?.customModelId ?? customModelId,
+    awsRegion: pausedPickerState?.awsRegion ?? awsRegion,
     modelOptions:
-      pickerState?.modelOptions ??
+      pausedPickerState?.modelOptions ??
       modelCatalogEntriesForIds(fallbackAllowedThreadModels),
     allowedThreadModels:
-      pickerState?.allowedThreadModels ?? fallbackAllowedThreadModels,
+      pausedPickerState?.allowedThreadModels ?? fallbackAllowedThreadModels,
     effectivePickerDefaultModel:
-      pickerState?.effectivePickerDefaultModel ?? null,
+      pausedPickerState?.effectivePickerDefaultModel ?? null,
     hasEffectivePickerDefault:
-      pickerState?.hasEffectivePickerDefault ?? false,
-    billingAccessMode: pickerState?.billingAccessMode ?? null,
+      pausedPickerState?.hasEffectivePickerDefault ?? false,
+    billingAccessMode: pausedPickerState?.billingAccessMode ?? null,
+    canUnlockPremiumModels:
+      pausedPickerState?.canUnlockPremiumModels ?? false,
+    hostedCreditsPaused: pausedPickerState?.hostedCreditsPaused ?? null,
+    allowOpenAiSubscription:
+      pausedPickerState?.allowOpenAiSubscription ?? false,
     experimentalSettings:
-      pickerState?.experimentalSettings ?? experimentalSettings,
+      pausedPickerState?.experimentalSettings ?? experimentalSettings,
     billingCreditStatus: applyDevBillingCreditStatusOverride(
       buildBillingCreditStatus(
         billingOverview,
@@ -949,6 +975,9 @@ export default function ChatPage() {
     effectivePickerDefaultModel,
     hasEffectivePickerDefault,
     billingAccessMode,
+    canUnlockPremiumModels,
+    hostedCreditsPaused,
+    allowOpenAiSubscription,
     experimentalSettings,
     billingCreditStatus,
     initialChatError,
@@ -1305,6 +1334,9 @@ export default function ChatPage() {
             effectivePickerDefaultModel={effectivePickerDefaultModel}
             hasEffectivePickerDefault={hasEffectivePickerDefault}
             billingAccessMode={billingAccessMode}
+            canUnlockPremiumModels={canUnlockPremiumModels}
+            hostedCreditsPaused={hostedCreditsPaused}
+            allowOpenAiSubscription={allowOpenAiSubscription}
             experimentalSettings={experimentalSettings}
             billingCreditStatus={billingCreditStatus}
             initialError={initialChatError ?? displayChatData.messagesError}

--- a/src/routes/_app.chat._index.tsx
+++ b/src/routes/_app.chat._index.tsx
@@ -20,6 +20,7 @@ import { loadUserProfileSummaries } from "@/lib/user-profiles.server";
 import {
   applyDevBillingCreditStatusOverride,
   buildBillingCreditStatus,
+  getDevBillingCreditStatus,
   getDevChatInitialError,
 } from "@/lib/chat-credit-status";
 import { waitUntil } from "@/lib/wait-until";
@@ -507,28 +508,53 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         },
       )
     : Promise.resolve(null);
+  const billingOverviewPromise =
+    !isSelfhostRuntime(env) && authContext.currentOrg
+      ? getOrgBillingOverview(env, authContext.currentOrg).catch((error) => {
+          console.warn("Failed to load billing overview for chat:", error);
+          return null;
+        })
+      : Promise.resolve(null);
   // Interactive bundle: model picker, billing, chat-group, and sales-prompt
   // data all depend on Durable Object RPC. Bundling them into one deferred
   // promise lets the loader return immediately after auth so the welcome
   // skeleton streams right away; the real composer renders once this resolves.
   const interactive = (async () => {
-    const [activeChatGroup, moveChatGroups, pickerState] = await Promise.all([
-      activeChatGroupPromise,
-      moveChatGroupsPromise,
-      pickerStatePromise,
-    ]);
+    const [activeChatGroup, moveChatGroups, pickerState, billingOverview] =
+      await Promise.all([
+        activeChatGroupPromise,
+        moveChatGroupsPromise,
+        pickerStatePromise,
+        billingOverviewPromise,
+      ]);
+    const devCreditStatus = getDevBillingCreditStatus(url.searchParams);
+    const pausedPickerState = pickerState
+      ? chatDO.applyHostedCreditPause(
+          pickerState,
+          billingOverview
+            ? {
+                billingStatus: billingOverview.billing_status,
+                availableCreditsCents:
+                  devCreditStatus?.availableCreditsCents ??
+                  billingOverview.available_credits_cents,
+              }
+            : null,
+        )
+      : null;
     const experimentalSettings =
-      pickerState?.experimentalSettings ??
+      pausedPickerState?.experimentalSettings ??
       authContext.currentOrgExperimentalSettings;
     const effectiveLlmProviderConfig = getEffectiveLlmProviderConfig(
       env,
       authContext.currentOrgLlmProviderConfig,
     );
     const llmProvider =
-      pickerState?.llmProvider ??
+      pausedPickerState?.llmProvider ??
       ((effectiveLlmProviderConfig?.provider ?? null) as
         | import("@/types").LlmProvider
         | null);
+    const allowOpenAiSubscription =
+      pausedPickerState?.allowOpenAiSubscription ?? false;
     const customApi = getStoredCustomLlmProviderApi(effectiveLlmProviderConfig);
     const customModelId = getStoredCustomLlmProviderModelId(
       effectiveLlmProviderConfig,
@@ -549,37 +575,33 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         customApi,
         customModelId,
         awsRegion,
+        allowOpenAiSubscription,
       },
     ).map((option) => option.value);
     const hasModelFallback = Boolean(workspaceId);
-    const billingOverview =
-      !isSelfhostRuntime(env) && authContext.currentOrg
-        ? await getOrgBillingOverview(env, authContext.currentOrg).catch(
-            (error) => {
-              console.warn("Failed to load billing overview for chat:", error);
-              return null;
-            },
-          )
-        : null;
-
     const threadModel =
-      pickerState?.defaultModel ??
+      pausedPickerState?.defaultModel ??
       (hasModelFallback ? fallbackThreadModel : null);
 
     return {
       threadModel,
       modelOptions:
-        pickerState?.modelOptions ??
+        pausedPickerState?.modelOptions ??
         modelCatalogEntriesForIds(
           hasModelFallback ? fallbackAllowedThreadModels : [],
         ),
       allowedThreadModels:
-        pickerState?.allowedThreadModels ??
+        pausedPickerState?.allowedThreadModels ??
         (hasModelFallback ? fallbackAllowedThreadModels : []),
       effectivePickerDefaultModel:
-        pickerState?.effectivePickerDefaultModel ?? null,
-      hasEffectivePickerDefault: pickerState?.hasEffectivePickerDefault ?? false,
-      billingAccessMode: pickerState?.billingAccessMode ?? null,
+        pausedPickerState?.effectivePickerDefaultModel ?? null,
+      hasEffectivePickerDefault:
+        pausedPickerState?.hasEffectivePickerDefault ?? false,
+      billingAccessMode: pausedPickerState?.billingAccessMode ?? null,
+      canUnlockPremiumModels:
+        pausedPickerState?.canUnlockPremiumModels ?? false,
+      hostedCreditsPaused: pausedPickerState?.hostedCreditsPaused ?? null,
+      allowOpenAiSubscription,
       billingCreditStatus: applyDevBillingCreditStatusOverride(
         buildBillingCreditStatus(billingOverview, llmProvider, threadModel),
         url.searchParams,
@@ -1063,6 +1085,9 @@ function ChatWelcomeContent({
     effectivePickerDefaultModel,
     hasEffectivePickerDefault,
     billingAccessMode,
+    canUnlockPremiumModels,
+    hostedCreditsPaused,
+    allowOpenAiSubscription,
     billingCreditStatus,
     salesPrompt,
     activeChatGroup,
@@ -1256,6 +1281,9 @@ function ChatWelcomeContent({
           effectivePickerDefaultModel={effectivePickerDefaultModel}
           hasEffectivePickerDefault={hasEffectivePickerDefault}
           billingAccessMode={billingAccessMode}
+          canUnlockPremiumModels={canUnlockPremiumModels}
+          hostedCreditsPaused={hostedCreditsPaused}
+          allowOpenAiSubscription={allowOpenAiSubscription}
           isOrgAdmin={isOrgAdmin}
           recentModelScope={recentModelScope}
           billingCreditStatus={billingCreditStatus}

--- a/src/routes/_app.chat._index.tsx
+++ b/src/routes/_app.chat._index.tsx
@@ -600,6 +600,9 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       canUnlockPremiumModels:
         pausedPickerState?.canUnlockPremiumModels ?? false,
       hostedCreditsPaused: pausedPickerState?.hostedCreditsPaused ?? null,
+      modelPickerSettingsHref:
+        pausedPickerState?.modelPickerSettingsHref ??
+        "/settings/organization/models",
       allowOpenAiSubscription,
       billingCreditStatus: applyDevBillingCreditStatusOverride(
         buildBillingCreditStatus(billingOverview, llmProvider, threadModel),
@@ -1086,6 +1089,7 @@ function ChatWelcomeContent({
     billingAccessMode,
     canUnlockPremiumModels,
     hostedCreditsPaused,
+    modelPickerSettingsHref,
     allowOpenAiSubscription,
     billingCreditStatus,
     salesPrompt,
@@ -1282,6 +1286,7 @@ function ChatWelcomeContent({
           billingAccessMode={billingAccessMode}
           canUnlockPremiumModels={canUnlockPremiumModels}
           hostedCreditsPaused={hostedCreditsPaused}
+          modelPickerSettingsHref={modelPickerSettingsHref}
           allowOpenAiSubscription={allowOpenAiSubscription}
           isOrgAdmin={isOrgAdmin}
           recentModelScope={recentModelScope}

--- a/src/routes/_app.chat._index.tsx
+++ b/src/routes/_app.chat._index.tsx
@@ -508,12 +508,11 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         },
       )
     : Promise.resolve(null);
+  // Do not convert a failed hosted billing read to null: null bypasses the
+  // credit pause and would expose models the Worker may reject.
   const billingOverviewPromise =
     !isSelfhostRuntime(env) && authContext.currentOrg
-      ? getOrgBillingOverview(env, authContext.currentOrg).catch((error) => {
-          console.warn("Failed to load billing overview for chat:", error);
-          return null;
-        })
+      ? getOrgBillingOverview(env, authContext.currentOrg)
       : Promise.resolve(null);
   // Interactive bundle: model picker, billing, chat-group, and sales-prompt
   // data all depend on Durable Object RPC. Bundling them into one deferred

--- a/src/routes/_app.settings.organization.billing.tsx
+++ b/src/routes/_app.settings.organization.billing.tsx
@@ -36,6 +36,7 @@ import { getByokProviderLabel } from "@/lib/byok-providers";
 import { getEffectiveLlmProviderConfig } from "@/lib/selfhost-ai-provider";
 import { isSelfhostRuntime } from "@/lib/selfhost-runtime";
 import type { BillingPlan, Organization } from "@/types";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { SettingsHeader } from "@/components/settings/settings-header";
@@ -53,6 +54,11 @@ import {
   formatInteger,
   useHydratedTimeZone,
 } from "@/lib/hydration-safe-datetime";
+import {
+  billingStatusBadgeVariant,
+  billingStatusLabel,
+  getBillingStatusDescription,
+} from "@/lib/billing";
 
 const EXISTING_STRIPE_SUBSCRIPTION_STATUSES = new Set([
   "active",
@@ -569,6 +575,7 @@ export default function BillingPage() {
   const timeZone = useHydratedTimeZone();
 
   const isEnterprise = overview.billing_status === "enterprise";
+  const isPastDue = overview.billing_status === "past_due";
   const plan: BillingPlan = normalizeBillingPlan(
     overview.billing_plan,
     overview.billing_status,
@@ -602,8 +609,12 @@ export default function BillingPage() {
         isCanceling && cancellationLabel
           ? `Cancels ${cancellationLabel}`
           : null,
+        isPastDue ? getBillingStatusDescription(overview) : null,
         planSubtitle(plan),
-        !isCanceling && hasActiveSubscription && renewalLabel
+        !isPastDue &&
+        !isCanceling &&
+        hasActiveSubscription &&
+        renewalLabel
           ? `Renews ${renewalLabel}.`
           : null,
       ].filter((line): line is string => Boolean(line));
@@ -667,7 +678,18 @@ export default function BillingPage() {
       <section className="space-y-3">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
-            <h2 className="text-lg font-semibold">{planHeading}</h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-lg font-semibold">{planHeading}</h2>
+              {isPastDue ? (
+                <Badge
+                  variant={billingStatusBadgeVariant(
+                    overview.billing_status,
+                  )}
+                >
+                  {billingStatusLabel(overview.billing_status)}
+                </Badge>
+              ) : null}
+            </div>
             <div className="space-y-0.5 text-sm text-muted-foreground">
               {planSummaryLines.map((line) => (
                 <p key={line}>{line}</p>
@@ -676,7 +698,11 @@ export default function BillingPage() {
           </div>
           {isEnterprise ? null : (
             <Button variant="outline" onClick={() => setView("manage")}>
-              {plan === "free" ? "Choose a plan" : "Manage plan"}
+              {isPastDue
+                ? "Fix payment"
+                : plan === "free"
+                  ? "Choose a plan"
+                  : "Manage plan"}
             </Button>
           )}
         </div>

--- a/src/routes/_app.settings.organization.models.tsx
+++ b/src/routes/_app.settings.organization.models.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from "react";
 import {
   redirect,
+  Link,
   useFetcher,
   useLoaderData,
   useLocation,
   useNavigate,
 } from "react-router";
-import { Star } from "lucide-react";
+import { Lock, Star } from "lucide-react";
 import { toast } from "sonner";
 import type { Route } from "./+types/_app.settings.organization.models";
 import { ModelLogo } from "@/components/model-logo";
@@ -19,6 +20,11 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from "@/components/ui/toggle-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { getContrastTextColor } from "@/lib/avatar";
 import {
   getAuthEnv,
@@ -30,12 +36,15 @@ import { getEnv } from "@/lib/cloudflare.server";
 import {
   ALL_LLM_MODELS,
   MODEL_CATALOG,
+  compareModelCatalogEntries,
   resolveModelPickerCatalog,
   sortAdditionalModelCatalogEntries,
   type ModelCatalogEntry,
 } from "@/lib/model-catalog";
 import { resolveEffectivePickerConfig } from "@/lib/model-picker-config";
 import {
+  CAMEL_CODE_LLM_MODEL,
+  CUSTOM_LLM_MODEL,
   getStoredCustomLlmProviderApi,
   getStoredCustomLlmProviderModelId,
   getStoredBedrockAwsRegion,
@@ -43,6 +52,11 @@ import {
   isLlmModel,
   type CustomLlmProviderApi,
 } from "@/lib/llm-provider-config";
+import {
+  isOrgBillingAccessReady,
+  resolveOrgBillingAccess,
+} from "@/lib/billing.server";
+import { isBillingLockedModel } from "@/lib/chat-do.server";
 import { getEffectiveLlmProviderConfig } from "@/lib/selfhost-ai-provider";
 import { cn } from "@/lib/utils";
 import type {
@@ -139,6 +153,7 @@ function buildPickerRows(
     customApi?: CustomLlmProviderApi | null;
     customModelId?: string | null;
     awsRegion?: string | null;
+    allowOpenAiSubscription?: boolean;
   },
 ): PickerModelRow[] {
   return resolveModelPickerCatalog({
@@ -148,6 +163,7 @@ function buildPickerRows(
     customApi: options.customApi,
     customModelId: options.customModelId,
     awsRegion: options.awsRegion,
+    allowOpenAiSubscription: options.allowOpenAiSubscription,
   })
     .filter((entry) => visibleModelIds.has(entry.id))
     .map((entry) => ({
@@ -213,10 +229,12 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   const selectedWorkspaceId = url.searchParams.get("workspaceId");
 
   const orgStub = authEnv.ORG.get(authEnv.ORG.idFromName(orgId));
-  const [orgConfig, workspaces] = await Promise.all([
+  const [orgConfig, workspaces, openAiSubscription] = await Promise.all([
     orgStub.getModelPickerConfig(),
     listOrgWorkspaces(authEnv, orgId),
+    orgStub.getOpenAiSubscription(),
   ]);
+  const allowOpenAiSubscription = openAiSubscription !== null;
   const effectiveLlmProviderConfig = getEffectiveLlmProviderConfig(
     env,
     authContext.currentOrgLlmProviderConfig,
@@ -233,7 +251,38 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     customApi,
     customModelId,
     awsRegion,
+    allowOpenAiSubscription,
   );
+  const billingAccess = resolveOrgBillingAccess({
+    env,
+    org: authContext.currentOrg,
+    llmProviderConfig: effectiveLlmProviderConfig,
+  });
+  const billingAccessMode = isOrgBillingAccessReady(billingAccess)
+    ? billingAccess.mode
+    : null;
+  const showLockedModels =
+    billingAccessMode !== "enterprise" && billingAccessMode !== "selfhost";
+  const billingLockedModelIds =
+    showLockedModels && billingAccessMode === "camel_free"
+      ? [...visibleModelIds].filter((id) =>
+          isBillingLockedModel(id, {
+            isFreeMode: true,
+            allowOpenAiSubscription,
+          }),
+        )
+      : [];
+  const hiddenLockedModels =
+    showLockedModels && billingAccessMode === "byok"
+      ? (Object.values(MODEL_CATALOG) as ModelCatalogEntry[])
+          .filter(
+            (entry) =>
+              !visibleModelIds.has(entry.id) &&
+              entry.id !== CUSTOM_LLM_MODEL &&
+              entry.id !== CAMEL_CODE_LLM_MODEL,
+          )
+          .sort(compareModelCatalogEntries)
+      : [];
   const workspaceConfigs = await loadWorkspaceConfigs(authEnv, workspaces);
   const selectedWorkspace =
     scope === "ws"
@@ -256,6 +305,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     customApi,
     customModelId,
     awsRegion,
+    allowOpenAiSubscription,
   });
   const useOrgDefaults =
     scope === "ws" ? (workspaceConfig?.use_org_defaults ?? true) : false;
@@ -272,6 +322,11 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         workspaceConfigs.get(workspace.id)?.use_org_defaults === false,
     })),
     useOrgDefaults,
+    allowOpenAiSubscription,
+    billingAccessMode,
+    showLockedModels,
+    billingLockedModelIds,
+    hiddenLockedModels,
     config: {
       usePlatformDefaults: displayConfig.use_platform_defaults !== false,
       inPicker: pickerRows,
@@ -301,12 +356,15 @@ async function loadActionTarget(args: {
     authContext.currentOrgLlmProviderConfig,
   );
   const experimentalSettings = authContext.currentOrgExperimentalSettings;
+  const allowOpenAiSubscription =
+    (await orgStub.getOpenAiSubscription()) !== null;
   const visibleModelIds = getVisibleModelIdsForSettings(
     effectiveLlmProviderConfig?.provider,
     experimentalSettings,
     getStoredCustomLlmProviderApi(effectiveLlmProviderConfig),
     getStoredCustomLlmProviderModelId(effectiveLlmProviderConfig),
     getStoredBedrockAwsRegion(effectiveLlmProviderConfig),
+    allowOpenAiSubscription,
   );
 
   if (scope === "org") {
@@ -405,6 +463,7 @@ function getVisibleModelIdsForSettings(
   customApi?: CustomLlmProviderApi | null,
   customModelId?: string | null,
   awsRegion?: string | null,
+  allowOpenAiSubscription?: boolean,
 ): Set<LlmModel> {
   return new Set(
     getVisibleLlmModelOptions(experimentalSettings, null, {
@@ -412,6 +471,7 @@ function getVisibleModelIdsForSettings(
       customApi,
       customModelId,
       awsRegion,
+      allowOpenAiSubscription,
     }).map((option) => option.value),
   );
 }
@@ -668,6 +728,7 @@ function ModelSettingsRow({
   editable,
   actionDisabled,
   defaultDisabled,
+  billingLocked = false,
 }: {
   row: PickerModelRow | { entry: ModelCatalogEntry };
   actionLabel: "add" | "remove";
@@ -676,6 +737,7 @@ function ModelSettingsRow({
   editable: boolean;
   actionDisabled?: boolean;
   defaultDisabled?: boolean;
+  billingLocked?: boolean;
 }) {
   const entry = row.entry;
   const isDefault = "isDefault" in row ? row.isDefault : false;
@@ -691,6 +753,19 @@ function ModelSettingsRow({
         <span className="text-sm font-medium text-muted-foreground">
           {entry.label}
         </span>
+        {billingLocked ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Lock
+                className="size-3.5 shrink-0 text-muted-foreground"
+                aria-label="Locked"
+              />
+            </TooltipTrigger>
+            <TooltipContent>
+              Needs a plan, credits, or an API key.
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
         {isDefault && (
           <span className="ml-auto text-xs text-muted-foreground">
             default
@@ -704,6 +779,19 @@ function ModelSettingsRow({
     <div className="flex min-h-10 items-center gap-2 py-2.5">
       <ModelLogo model={entry.id} size={16} className="size-4 shrink-0" />
       <span className="text-sm font-medium">{entry.label}</span>
+      {billingLocked ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Lock
+              className="size-3.5 shrink-0 text-muted-foreground"
+              aria-label="Locked"
+            />
+          </TooltipTrigger>
+          <TooltipContent>
+            Needs a plan, credits, or an API key.
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
       <div className="ml-auto flex items-center gap-1.5">
         {onDefault && (
           <Button
@@ -786,6 +874,28 @@ export default function OrganizationModelsPage() {
   const workspaceSelectorVisible = data.workspaces.length > 1;
   const workspaceControlsVisible =
     workspaceSelectorVisible || data.scope === "ws";
+  const billingLockedModelIds = new Set(
+    data.showLockedModels ? (data.billingLockedModelIds ?? []) : [],
+  );
+  const lockedBannerEntries = (() => {
+    const entries = data.billingLockedModelIds
+      .map((id) => MODEL_CATALOG[id])
+      .filter((entry): entry is ModelCatalogEntry => Boolean(entry))
+      .sort(compareModelCatalogEntries);
+    const picks: ModelCatalogEntry[] = [];
+    const seenLogos = new Set<string>();
+    for (const entry of entries) {
+      if (seenLogos.has(entry.providerLogo)) continue;
+      seenLogos.add(entry.providerLogo);
+      picks.push(entry);
+      if (picks.length === 3) break;
+    }
+    for (const entry of entries) {
+      if (picks.length === 3) break;
+      if (!picks.includes(entry)) picks.push(entry);
+    }
+    return picks;
+  })();
 
   useEffect(() => {
     if (fetcher.state !== "idle" || !fetcher.data) return;
@@ -839,6 +949,38 @@ export default function OrganizationModelsPage() {
         title="Models"
         description="Choose which models appear in your team's picker."
       />
+
+      {data.showLockedModels && data.billingLockedModelIds.length > 0 ? (
+        <div className="space-y-2 rounded-lg border p-4">
+          <div className="flex items-center gap-2">
+            <div className="flex shrink-0 -space-x-1.5">
+              {lockedBannerEntries.map((entry) => (
+                <span
+                  key={entry.id}
+                  className="flex rounded-md bg-background ring-2 ring-background"
+                >
+                  <span className="flex size-6 items-center justify-center rounded-md bg-muted/50">
+                    <ModelLogo model={entry.id} size={14} className="size-3.5" />
+                  </span>
+                </span>
+              ))}
+            </div>
+            <p className="text-sm font-medium">Premium models are locked</p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Your org is on the free camelCode model. Unlock premium models with a
+            plan, credits, or an API key.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" asChild>
+              <Link to="/settings/organization/billing">View plans</Link>
+            </Button>
+            <Button size="sm" variant="outline" asChild>
+              <Link to="/settings/organization/ai-provider">Add API key</Link>
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       {workspaceControlsVisible && (
         <div className="space-y-4">
@@ -936,6 +1078,7 @@ export default function OrganizationModelsPage() {
                 onAction={(model) => submit("removeModel", model)}
                 onDefault={(model) => submit("setDefault", model)}
                 editable={editable}
+                billingLocked={billingLockedModelIds.has(row.entry.id)}
                 actionDisabled={isSubmitting}
                 defaultDisabled={isSubmitting || !editingCustomList}
               />
@@ -973,6 +1116,7 @@ export default function OrganizationModelsPage() {
                     actionLabel="add"
                     onAction={(model) => submit("addModel", model)}
                     editable
+                    billingLocked={billingLockedModelIds.has(entry.id)}
                     actionDisabled={isSubmitting}
                   />
                 ))}
@@ -981,6 +1125,46 @@ export default function OrganizationModelsPage() {
           </section>
         </>
       )}
+
+      {data.showLockedModels && data.hiddenLockedModels.length > 0 ? (
+        <>
+          <Separator />
+
+          <section className="space-y-2">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-sm font-medium">Locked models</h2>
+              <Button size="sm" variant="outline" asChild>
+                <Link to="/settings/organization/billing">View plans</Link>
+              </Button>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Not available with your current setup. Unlock with a camelAI
+              plan, credits, or a different API key.
+            </p>
+            <div className="divide-y divide-border/60">
+              {data.hiddenLockedModels.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="flex min-h-10 items-center gap-2 py-2.5"
+                >
+                  <ModelLogo
+                    model={entry.id}
+                    size={16}
+                    className="size-4 shrink-0 opacity-60"
+                  />
+                  <span className="text-sm font-medium text-muted-foreground">
+                    {entry.label}
+                  </span>
+                  <Lock
+                    className="ml-auto size-3.5 text-muted-foreground"
+                    aria-label="Locked"
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/src/routes/_app.settings.organization.models.tsx
+++ b/src/routes/_app.settings.organization.models.tsx
@@ -324,6 +324,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     useOrgDefaults,
     allowOpenAiSubscription,
     billingAccessMode,
+    billingStatus: authContext.currentOrg.billing_status,
     showLockedModels,
     billingLockedModelIds,
     hiddenLockedModels,
@@ -877,6 +878,7 @@ export default function OrganizationModelsPage() {
   const billingLockedModelIds = new Set(
     data.showLockedModels ? (data.billingLockedModelIds ?? []) : [],
   );
+  const isPastDue = data.billingStatus === "past_due";
   const lockedBannerEntries = (() => {
     const entries = data.billingLockedModelIds
       .map((id) => MODEL_CATALOG[id])
@@ -965,15 +967,20 @@ export default function OrganizationModelsPage() {
                 </span>
               ))}
             </div>
-            <p className="text-sm font-medium">Premium models are locked</p>
+            <p className="text-sm font-medium">
+              {isPastDue ? "Payment is past due" : "Premium models are locked"}
+            </p>
           </div>
           <p className="text-sm text-muted-foreground">
-            Your org is on the free camelCode model. Unlock premium models with a
-            plan, credits, or an API key.
+            {isPastDue
+              ? "Fix payment in Billing to restore premium models."
+              : "Your org is on the free camelCode model. Unlock premium models with a plan, credits, or an API key."}
           </p>
           <div className="flex flex-wrap gap-2">
             <Button size="sm" asChild>
-              <Link to="/settings/organization/billing">View plans</Link>
+              <Link to="/settings/organization/billing">
+                {isPastDue ? "Fix payment" : "View plans"}
+              </Link>
             </Button>
             <Button size="sm" variant="outline" asChild>
               <Link to="/settings/organization/ai-provider">Add API key</Link>

--- a/tests/billing-chat-credit-status-route.test.ts
+++ b/tests/billing-chat-credit-status-route.test.ts
@@ -99,7 +99,60 @@ describe("billing chat credit status route", () => {
     expect(getLlmProviderConfig).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       ok: true,
-      billingCreditStatus: null,
+      billingCreditStatus: {
+        availableCreditsCents: 0,
+        isExhausted: true,
+        hasByokProvider: true,
+      },
+    });
+  });
+
+  it("preserves exhausted hosted-credit state after a BYOK-covered turn", async () => {
+    getEnvMock.mockReturnValue({});
+    requireAuthContextMock.mockResolvedValue({
+      currentOrg: {
+        id: "org_123",
+        name: "Org",
+        billing_status: "active",
+        billing_plan: "starter",
+      },
+      currentOrgLlmProviderConfig: {
+        provider: "anthropic",
+        credentials_encrypted: "encrypted",
+        config: "{}",
+        created_by: "user_123",
+        created_at: 1,
+        updated_at: 1,
+      },
+    });
+    getOrgBillingOverviewMock.mockResolvedValue(makeOverview());
+
+    const hostedTurn = await loader({
+      request: new Request(
+        "https://camelai.test/api/billing/chat-credit-status?model=gpt-5.6-sol",
+      ),
+      context: {},
+      params: {},
+    } as never);
+    const byokTurn = await loader({
+      request: new Request(
+        "https://camelai.test/api/billing/chat-credit-status?model=sonnet",
+      ),
+      context: {},
+      params: {},
+    } as never);
+
+    expect(hostedTurn).toMatchObject({
+      ok: true,
+      billingCreditStatus: { isExhausted: true },
+    });
+    expect(byokTurn).toMatchObject({
+      ok: true,
+      requestedModel: "sonnet",
+      billingCreditStatus: {
+        isExhausted: true,
+        hasByokProvider: true,
+      },
     });
   });
 

--- a/tests/billing-dialog-state.test.ts
+++ b/tests/billing-dialog-state.test.ts
@@ -3,6 +3,7 @@ import {
   getBillingDialogIdentityKey,
   getWelcomeAutoOpenState,
   hasActiveBillingDialog,
+  shouldNavigateToBillingForPausedModel,
   transitionBillingDialogState,
   type BillingDialogState,
 } from "@/lib/billing-dialog-state";
@@ -38,6 +39,27 @@ describe("billing dialog state", () => {
   it("includes billing dialogs owned outside Chat in the active-dialog guard", () => {
     expect(hasActiveBillingDialog({ kind: "none" }, true)).toBe(true);
     expect(hasActiveBillingDialog({ kind: "none" }, false)).toBe(false);
+  });
+
+  it("navigates payment-paused models to billing only for org admins", () => {
+    expect(
+      shouldNavigateToBillingForPausedModel(
+        "subscription_unavailable",
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      shouldNavigateToBillingForPausedModel(
+        "subscription_unavailable",
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      shouldNavigateToBillingForPausedModel(
+        "included_credits_exhausted",
+        true,
+      ),
+    ).toBe(false);
   });
 
   it("auto-opens once per user and org when dismissal persistence fails", () => {

--- a/tests/billing-settings-overview-ui.test.tsx
+++ b/tests/billing-settings-overview-ui.test.tsx
@@ -175,6 +175,51 @@ describe("BillingPage overview", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a past-due warning and payment recovery action", () => {
+    testState.loaderData.current = {
+      ...makeLoaderData(),
+      org: {
+        ...makeLoaderData().org,
+        billing_status: "past_due",
+        billing_plan: "pro",
+        billing_seat_count: 1,
+        billing_subscription_status: "past_due",
+      },
+      overview: {
+        ...makeLoaderData().overview,
+        billing_status: "past_due",
+        billing_plan: "pro",
+        billing_seat_count: 1,
+        billing_subscription_status: "past_due",
+      },
+      subscription: {
+        id: "sub_team",
+        status: "past_due",
+        current_period_end_ms: Date.UTC(2026, 5, 8, 12),
+        cancel_at_ms: null,
+        cancellation_date_ms: null,
+        cancel_at_period_end: false,
+        is_canceling: false,
+        trial_end_ms: null,
+      },
+    };
+
+    render(<BillingPage />);
+
+    expect(screen.getByText("Past due")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Your payment is past due. Fix it to restore premium models.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Renews Jun 8, 2026.")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fix payment" }));
+    expect(
+      screen.getByRole("button", { name: "Manage in Stripe" }),
+    ).toBeEnabled();
+  });
+
   it("does not render local payment-method details", () => {
     testState.loaderData.current = makeLoaderData();
 

--- a/tests/billing.test.ts
+++ b/tests/billing.test.ts
@@ -7,6 +7,7 @@ import {
   formatCreditBalance,
   formatCreditsFromUsd,
   formatUsdFromCents,
+  getBillingStatusDescription,
 } from "@/lib/billing";
 import {
   BILLING_PLAN_LIMITS,
@@ -196,6 +197,11 @@ describe("billing helpers", () => {
     expect(billingStatusBadgeVariant("active")).toBe("default");
     expect(billingStatusBadgeVariant("enterprise")).toBe("default");
     expect(billingStatusBadgeVariant("past_due")).toBe("destructive");
+    expect(
+      getBillingStatusDescription({
+        billing_status: "past_due",
+      } as Organization),
+    ).toBe("Your payment is past due. Fix it to restore premium models.");
   });
 
   it("formats credits and usd values from cents", () => {

--- a/tests/camel-code-picker-alert.test.tsx
+++ b/tests/camel-code-picker-alert.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+import { CamelCodePickerAlert } from "@/components/camel-code-picker-alert";
+
+function renderAlert(isOrgAdmin: boolean) {
+  return render(
+    <MemoryRouter>
+      <CamelCodePickerAlert
+        isOrgAdmin={isOrgAdmin}
+        settingsHref="/settings/organization/models?scope=ws&workspaceId=ws_123"
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("CamelCodePickerAlert", () => {
+  it("uses the existing alert and slotted button styles for admins", () => {
+    renderAlert(true);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Premium models are paused")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add camelCode to this picker to continue for free."),
+    ).toBeInTheDocument();
+
+    const settingsLink = screen.getByRole("link", {
+      name: "Open model settings",
+    });
+    expect(settingsLink).toHaveAttribute(
+      "href",
+      "/settings/organization/models?scope=ws&workspaceId=ws_123",
+    );
+    expect(settingsLink).toHaveAttribute("data-slot", "button");
+    expect(settingsLink.closest("button")).toBeNull();
+  });
+
+  it("directs members to an admin without showing an inaccessible link", () => {
+    renderAlert(false);
+
+    expect(
+      screen.getByText(
+        "Ask an organization admin to add camelCode to this picker.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Open model settings" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/chat-admin-readonly-loader.test.ts
+++ b/tests/chat-admin-readonly-loader.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/lib/auth-do.server', () => ({
 }));
 
 vi.mock('@/lib/chat-do.server', () => ({
+  applyHostedCreditPause: (state: unknown) => state,
   getThread: getThreadMock,
   getThreadPreviewState: getThreadPreviewStateMock,
   getTodoState: getTodoStateMock,

--- a/tests/chat-admin-readonly-loader.test.ts
+++ b/tests/chat-admin-readonly-loader.test.ts
@@ -11,6 +11,7 @@ const getThreadPreviewStateMock = vi.fn();
 const getTodoStateMock = vi.fn();
 const getUiMessagesMock = vi.fn();
 const getWorkspaceModelPickerStateMock = vi.fn();
+const getOrgBillingOverviewMock = vi.fn();
 const getOrgMock = vi.fn();
 const getWorkerScriptMock = vi.fn();
 const listWorkspaceIntegrationRecordsMock = vi.fn();
@@ -29,6 +30,10 @@ vi.mock('@/lib/auth.server', () => ({
 
 vi.mock('@/lib/cloudflare.server', () => ({
   getEnv: getEnvMock,
+}));
+
+vi.mock('@/lib/billing.server', () => ({
+  getOrgBillingOverview: getOrgBillingOverviewMock,
 }));
 
 vi.mock('@/lib/auth-do.server', () => ({
@@ -102,6 +107,7 @@ describe('chat loader admin readonly mode', () => {
       hasEffectivePickerDefault: true,
       defaultModel: 'sonnet',
     });
+    getOrgBillingOverviewMock.mockResolvedValue(null);
     getWorkerScriptMock.mockResolvedValue(null);
     listWorkspaceIntegrationRecordsMock.mockResolvedValue([]);
     readThreadMessagesMock.mockResolvedValue([]);
@@ -218,6 +224,7 @@ describe('chat loader workspace mismatch handling', () => {
       hasEffectivePickerDefault: true,
       defaultModel: 'sonnet',
     });
+    getOrgBillingOverviewMock.mockResolvedValue(null);
     requireSessionWorkspaceAccessMock.mockResolvedValue({
       orgId: 'org_active',
       workspaceId: 'ws_active',
@@ -280,6 +287,29 @@ describe('chat loader workspace mismatch handling', () => {
       previewTabs: [],
       activeTabId: null,
     });
+  });
+
+  it('preserves billing overview failures instead of exposing unpaused models', async () => {
+    const billingError = new Error('billing overview unavailable');
+    requireAuthContextMock.mockResolvedValue({
+      currentWorkspace: { id: 'ws_active' },
+      currentOrg: { id: 'org_active', slug: 'acme' },
+      orgs: [{ org_id: 'org_active', role: 'admin' }],
+    });
+    getThreadMock.mockResolvedValue({
+      id: 'thread_123',
+      workspace_id: 'ws_active',
+      title: 'Workspace Thread',
+    });
+    getOrgBillingOverviewMock.mockRejectedValueOnce(billingError);
+
+    await expect(
+      loader({
+        request: new Request('https://camelai.com/chat/thread_123'),
+        context: {},
+        params: { id: 'thread_123' },
+      } as never),
+    ).rejects.toBe(billingError);
   });
 
   it('seeds the normal transcript path from the thread record while durable history resolves', async () => {

--- a/tests/chat-billing-credit-notice.test.tsx
+++ b/tests/chat-billing-credit-notice.test.tsx
@@ -75,6 +75,18 @@ describe("BillingCreditNotice", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("omits the top-up action for payment issues", () => {
+    renderNotice("subscription_unavailable");
+
+    expect(screen.getByText("Payment issue")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Top up" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "View usage" }),
+    ).toBeInTheDocument();
+  });
+
   it("removes the monthly claim from generic exhausted-credit copy", () => {
     const { container } = renderNotice(null);
 

--- a/tests/chat-billing-credit-notice.test.tsx
+++ b/tests/chat-billing-credit-notice.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BillingCreditNotice } from "@/components/chat-billing-credit-notice";
+import type { BillingCreditStatus } from "@/lib/chat-credit-status";
+import type { ModelPausedReason } from "@/lib/model-picker-access";
+
+const exhaustedStatus: BillingCreditStatus = {
+  availableCreditsCents: 0,
+  totalCreditLimitCents: 1_000,
+  isExhausted: true,
+  hasByokProvider: false,
+};
+
+function renderNotice(
+  pauseReason: ModelPausedReason | null,
+  canTopUp = true,
+) {
+  return render(
+    <BillingCreditNotice
+      status={exhaustedStatus}
+      onOpenUsage={vi.fn()}
+      onTopUp={vi.fn()}
+      canTopUp={canTopUp}
+      pauseReason={pauseReason}
+    />,
+  );
+}
+
+describe("BillingCreditNotice", () => {
+  afterEach(cleanup);
+
+  it.each([
+    [
+      "payg_credits_exhausted",
+      "Out of hosted credits",
+      "camelCode is still available. Add credits to restore premium models.",
+    ],
+    [
+      "included_credits_exhausted",
+      "Plan credits used",
+      "camelCode is still available. Premium models return at renewal or after adding credits.",
+    ],
+    [
+      "trial_credits_exhausted",
+      "Trial credits used",
+      "camelCode is still available. Upgrade or add credits to restore premium models.",
+    ],
+    [
+      "subscription_unavailable",
+      "Payment issue",
+      "camelCode is still available. Fix payment to restore premium models.",
+    ],
+  ] satisfies Array<[ModelPausedReason, string, string]>)(
+    "shows direct %s pause guidance",
+    (pauseReason, title, description) => {
+      const { container } = renderNotice(pauseReason);
+
+      expect(screen.getByText(title)).toBeInTheDocument();
+      expect(screen.getByText(description)).toBeInTheDocument();
+      expect(container).not.toHaveTextContent(/this month|keep going/i);
+      expect(container.textContent).not.toContain("\u2014");
+    },
+  );
+
+  it("directs members to an admin without implying camelCode is blocked", () => {
+    renderNotice("trial_credits_exhausted", false);
+
+    expect(
+      screen.getByText(
+        "camelCode is still available. Ask an admin to upgrade or add credits.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Top up" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes the monthly claim from generic exhausted-credit copy", () => {
+    const { container } = renderNotice(null);
+
+    expect(screen.getByText("You're out of hosted credits")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("this month");
+  });
+});

--- a/tests/chat-credit-status.test.ts
+++ b/tests/chat-credit-status.test.ts
@@ -7,7 +7,7 @@ import {
   resolveDisplayedBillingCreditStatus,
   resolveRefreshedThreadModel,
   shouldShowLowCreditAlert,
-  shouldSwitchExhaustedThreadToCamelCode,
+  shouldSwitchExhaustedThreadModel,
 } from '@/lib/chat-credit-status';
 import type { OrgBillingOverview } from '@/lib/billing.server';
 
@@ -57,9 +57,9 @@ describe('chat credit status', () => {
     ).toBeNull();
   });
 
-  it('reconciles an exhausted premium thread to camelCode', () => {
+  it('reconciles an exhausted premium thread to a selectable fallback', () => {
     expect(
-      shouldSwitchExhaustedThreadToCamelCode(
+      shouldSwitchExhaustedThreadModel(
         {
           availableCreditsCents: 0,
           totalCreditLimitCents: 500,
@@ -70,7 +70,7 @@ describe('chat credit status', () => {
       ),
     ).toBe(true);
     expect(
-      shouldSwitchExhaustedThreadToCamelCode(
+      shouldSwitchExhaustedThreadModel(
         {
           availableCreditsCents: 0,
           totalCreditLimitCents: 0,
@@ -82,7 +82,7 @@ describe('chat credit status', () => {
     ).toBe(false);
   });
 
-  it('does not reconcile exhausted credential-covered threads to camelCode', () => {
+  it('does not reconcile exhausted credential-covered threads', () => {
     const status = {
       availableCreditsCents: 0,
       totalCreditLimitCents: 500,
@@ -91,14 +91,14 @@ describe('chat credit status', () => {
     };
 
     expect(
-      shouldSwitchExhaustedThreadToCamelCode(
+      shouldSwitchExhaustedThreadModel(
         status,
         'sonnet',
         'anthropic',
       ),
     ).toBe(false);
     expect(
-      shouldSwitchExhaustedThreadToCamelCode(
+      shouldSwitchExhaustedThreadModel(
         status,
         'gpt-5.6-sol',
         'anthropic',

--- a/tests/chat-credit-status.test.ts
+++ b/tests/chat-credit-status.test.ts
@@ -4,6 +4,7 @@ import {
   applyDevBillingCreditStatusOverride,
   buildBillingCreditStatus,
   getDevChatInitialError,
+  resolveDisplayedBillingCreditStatus,
   resolveRefreshedThreadModel,
   shouldShowLowCreditAlert,
   shouldSwitchExhaustedThreadToCamelCode,
@@ -81,6 +82,31 @@ describe('chat credit status', () => {
     ).toBe(false);
   });
 
+  it('does not reconcile exhausted credential-covered threads to camelCode', () => {
+    const status = {
+      availableCreditsCents: 0,
+      totalCreditLimitCents: 500,
+      isExhausted: true,
+      hasByokProvider: true,
+    };
+
+    expect(
+      shouldSwitchExhaustedThreadToCamelCode(
+        status,
+        'sonnet',
+        'anthropic',
+      ),
+    ).toBe(false);
+    expect(
+      shouldSwitchExhaustedThreadToCamelCode(
+        status,
+        'gpt-5.6-sol',
+        'anthropic',
+        true,
+      ),
+    ).toBe(false);
+  });
+
   it('maps available credit balances to low-credit tiers', () => {
     expect(activeLowCreditTier(600)).toBeNull();
     expect(activeLowCreditTier(500)).toBeNull();
@@ -119,6 +145,7 @@ describe('chat credit status', () => {
       totalCreditLimitCents: 1000,
       isExhausted: false,
       hasByokProvider: false,
+      billingStatus: 'active',
     });
   });
 
@@ -157,7 +184,7 @@ describe('chat credit status', () => {
     });
   });
 
-  it('hides hosted credit status for threads covered by BYOK', () => {
+  it('keeps org-wide credit status for threads covered by BYOK', () => {
     expect(
       buildBillingCreditStatus(
         makeOverview({
@@ -167,7 +194,11 @@ describe('chat credit status', () => {
         'anthropic',
         'sonnet',
       ),
-    ).toBeNull();
+    ).toMatchObject({
+      availableCreditsCents: 0,
+      isExhausted: true,
+      hasByokProvider: true,
+    });
 
     expect(
       buildBillingCreditStatus(
@@ -178,10 +209,14 @@ describe('chat credit status', () => {
         'openai',
         'gpt-5.6-luna',
       ),
-    ).toBeNull();
+    ).toMatchObject({
+      availableCreditsCents: 0,
+      isExhausted: true,
+      hasByokProvider: true,
+    });
   });
 
-  it('hides hosted credit status while a thread uses camelCode', () => {
+  it('keeps exhausted status available while a thread uses camelCode', () => {
     expect(
       buildBillingCreditStatus(
         makeOverview({
@@ -190,6 +225,80 @@ describe('chat credit status', () => {
         }),
         false,
         'deepseek-v4-auto',
+      ),
+    ).toMatchObject({
+      availableCreditsCents: 0,
+      isExhausted: true,
+    });
+  });
+
+  it('shows camelCode credit status only while hosted models are paused', () => {
+    const status = buildBillingCreditStatus(
+      makeOverview({
+        available_credits_cents: 0,
+        total_credit_limit_cents: 0,
+      }),
+      false,
+      'deepseek-v4-auto',
+    );
+
+    expect(
+      resolveDisplayedBillingCreditStatus(
+        status,
+        'deepseek-v4-auto',
+        false,
+      ),
+    ).toBeNull();
+    expect(
+      resolveDisplayedBillingCreditStatus(
+        status,
+        'deepseek-v4-auto',
+        true,
+      ),
+    ).toBe(status);
+  });
+
+  it('suppresses the displayed notice for BYOK-covered model turns', () => {
+    const status = buildBillingCreditStatus(
+      makeOverview({
+        available_credits_cents: 0,
+        total_credit_limit_cents: 0,
+      }),
+      'anthropic',
+      'sonnet',
+    );
+
+    expect(
+      resolveDisplayedBillingCreditStatus(
+        status,
+        'sonnet',
+        true,
+        'anthropic',
+      ),
+    ).toBeNull();
+    expect(status).toMatchObject({
+      isExhausted: true,
+      hasByokProvider: true,
+    });
+  });
+
+  it('suppresses the displayed notice for OpenAI-login-covered model turns', () => {
+    const status = buildBillingCreditStatus(
+      makeOverview({
+        available_credits_cents: 0,
+        total_credit_limit_cents: 0,
+      }),
+      'anthropic',
+      'gpt-5.6-sol',
+    );
+
+    expect(
+      resolveDisplayedBillingCreditStatus(
+        status,
+        'gpt-5.6-sol',
+        true,
+        'anthropic',
+        true,
       ),
     ).toBeNull();
   });

--- a/tests/chat-do-model-picker-state.test.ts
+++ b/tests/chat-do-model-picker-state.test.ts
@@ -456,8 +456,7 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     ['active', 'subscription', 'included_credits_exhausted'],
     ['trialing', 'subscription', 'trial_credits_exhausted'],
     ['inactive', 'credits', 'payg_credits_exhausted'],
-    ['past_due', 'credits', 'subscription_unavailable'],
-    ['canceled', 'credits', 'subscription_unavailable'],
+    ['past_due', 'camel_free', 'subscription_unavailable'],
   ] as const)(
     'maps %s billing to %s hosted-model pauses',
     (billingStatus, billingAccessMode, reason) => {
@@ -480,6 +479,17 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
       expect(result.defaultModel).toBe(CAMEL_CODE_LLM_MODEL);
     },
   );
+
+  it('does not label a canceled subscription as a payment issue', () => {
+    const state = pickerState({ billingAccessMode: 'camel_free' });
+    const result = applyHostedCreditPause(state, {
+      billingStatus: 'canceled',
+      availableCreditsCents: 0,
+    });
+
+    expect(result.modelOptions).toEqual(state.modelOptions);
+    expect(result.hostedCreditsPaused).toBeNull();
+  });
 
   it('leaves BYOK- and OpenAI-covered models available during a hosted credit pause', () => {
     const result = applyHostedCreditPause(

--- a/tests/chat-do-model-picker-state.test.ts
+++ b/tests/chat-do-model-picker-state.test.ts
@@ -129,6 +129,53 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     expect(workspaceStub.getModelPickerConfig).toHaveBeenCalledTimes(2);
   });
 
+  it('links workspace pickers to their scoped model settings', async () => {
+    const workspaceStub = {
+      getInfo: vi.fn().mockResolvedValue({ org_id: 'org_123' }),
+      getModelPickerConfig: vi.fn().mockResolvedValue({
+        use_org_defaults: false,
+        use_platform_defaults: false,
+        models: [{ id: 'sonnet', added_at: 1 }],
+        default_model: 'sonnet',
+      }),
+    };
+    const orgStub = {
+      getInfo: vi.fn().mockResolvedValue({
+        billing_status: 'inactive',
+        billing_credit_purchase_total_cents: 0,
+        billing_credit_grant_total_cents: 0,
+      }),
+      getLlmProviderConfig: vi.fn().mockResolvedValue(null),
+      getExperimentalSettings: vi
+        .fn()
+        .mockResolvedValue({ claude_proxy_models: false }),
+      getModelPickerConfig: vi.fn().mockResolvedValue({
+        use_platform_defaults: true,
+        models: [],
+        default_model: null,
+      }),
+    };
+
+    getEnvMock.mockReturnValue({
+      WORKSPACE: {
+        idFromName: (id: string) => id,
+        get: () => workspaceStub,
+      },
+      ORG: {
+        idFromName: (id: string) => id,
+        get: () => orgStub,
+      },
+    });
+
+    const state = await getWorkspaceModelPickerState({}, 'ws_123');
+
+    expect(state?.modelPickerSettingsHref).toBe(
+      '/settings/organization/models?scope=ws&workspaceId=ws_123',
+    );
+    expect(state?.modelOptions.map((option) => option.id)).toEqual(['sonnet']);
+    expect(state?.allowedThreadModels).toEqual([]);
+  });
+
   it('defaults an inactive zero-credit hosted organization to camelCode', async () => {
     const workspaceStub = {
       getInfo: vi.fn().mockResolvedValue({ org_id: 'org_123' }),
@@ -303,11 +350,14 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     const freeState = await loadState({ billingStatus: 'inactive' });
     expect(freeState).toMatchObject({
       billingAccessMode: 'camel_free',
-      defaultModel: 'deepseek-v4-auto',
-      effectivePickerDefaultModel: 'deepseek-v4-auto',
+      defaultModel: null,
+      effectivePickerDefaultModel: 'sonnet',
       canUnlockPremiumModels: true,
     });
-    expect(freeState?.allowedThreadModels).toEqual(['deepseek-v4-auto']);
+    expect(freeState?.allowedThreadModels).toEqual([]);
+    expect(freeState?.modelOptions.map((option) => option.id)).not.toContain(
+      'deepseek-v4-auto',
+    );
     expect(
       freeState?.modelOptions.find((option) => option.id === 'sonnet'),
     ).toMatchObject({ locked: true, unlockHint: 'generic' });
@@ -327,6 +377,8 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     });
     expect(openAiState?.billingAccessMode).toBe('camel_free');
     expect(openAiState?.canUnlockPremiumModels).toBe(true);
+    expect(openAiState?.defaultModel).toBe('gpt-5.6-sol');
+    expect(openAiState?.effectivePickerDefaultModel).toBe('gpt-5.6-sol');
     expect(openAiState?.allowedThreadModels).toContain('gpt-5.6-sol');
     expect(
       openAiState?.modelOptions.find(
@@ -339,6 +391,9 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     );
     expect(openAiState?.modelOptions.map((option) => option.id)).not.toContain(
       'grok-4.5',
+    );
+    expect(openAiState?.modelOptions.map((option) => option.id)).not.toContain(
+      'deepseek-v4-auto',
     );
 
     const platformFreeState = await loadState({
@@ -392,6 +447,7 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
       defaultModel: 'sonnet',
       canUnlockPremiumModels: false,
       hostedCreditsPaused: null,
+      modelPickerSettingsHref: '/settings/organization/models',
       ...overrides,
     };
   }
@@ -448,7 +504,7 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     });
   });
 
-  it('adds camelCode when a hosted pause locks every custom picker model', () => {
+  it('keeps an all-paused custom picker unchanged and preserves its configured default', () => {
     const result = applyHostedCreditPause(
       pickerState({
         modelOptions: [MODEL_CATALOG.sonnet],
@@ -458,14 +514,42 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     );
 
     expect(result.modelOptions.map((option) => option.id)).toEqual([
-      CAMEL_CODE_LLM_MODEL,
       'sonnet',
     ]);
-    expect(result.allowedThreadModels).toEqual([CAMEL_CODE_LLM_MODEL]);
-    expect(result.defaultModel).toBe(CAMEL_CODE_LLM_MODEL);
-    expect(result.effectivePickerDefaultModel).toBe(
-      CAMEL_CODE_LLM_MODEL,
+    expect(result.allowedThreadModels).toEqual([]);
+    expect(result.defaultModel).toBe('sonnet');
+    expect(result.effectivePickerDefaultModel).toBe('sonnet');
+  });
+
+  it('uses the cheapest credential-covered model when the configured default pauses', () => {
+    const result = applyHostedCreditPause(
+      pickerState({
+        allowOpenAiSubscription: true,
+        modelOptions: [
+          MODEL_CATALOG.sonnet,
+          MODEL_CATALOG['gpt-5.6-sol'],
+          MODEL_CATALOG['gpt-5.6-luna'],
+        ],
+        allowedThreadModels: [
+          'sonnet',
+          'gpt-5.6-sol',
+          'gpt-5.6-luna',
+        ],
+      }),
+      { billingStatus: 'active', availableCreditsCents: 0 },
     );
+
+    expect(result.modelOptions.map((option) => option.id)).toEqual([
+      'sonnet',
+      'gpt-5.6-sol',
+      'gpt-5.6-luna',
+    ]);
+    expect(result.allowedThreadModels).toEqual([
+      'gpt-5.6-sol',
+      'gpt-5.6-luna',
+    ]);
+    expect(result.defaultModel).toBe('gpt-5.6-luna');
+    expect(result.effectivePickerDefaultModel).toBe('gpt-5.6-luna');
   });
 
   it.each(['enterprise', 'byok', 'camel_free'] as const)(

--- a/tests/chat-do-model-picker-state.test.ts
+++ b/tests/chat-do-model-picker-state.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/lib/thread-title-generation.server', () => ({
 }));
 
 const {
+  applyHostedCreditPause,
   createThread,
   createThreadWithValidatedAccess,
   deleteThread,
@@ -21,6 +22,10 @@ const {
   updateThread,
   updateThreadModel,
 } = await import('@/lib/chat-do.server');
+const { MODEL_CATALOG } = await import('@/lib/model-catalog');
+const { CAMEL_CODE_LLM_MODEL } = await import('@/lib/llm-provider-config');
+type WorkspaceModelPickerState =
+  import('@/lib/chat-do.server').WorkspaceModelPickerState;
 const { generateThreadTitleWithOpenAI } = await import('@/lib/thread-title-generation.server');
 
 describe('getWorkspaceModelPickerState rollout compatibility', () => {
@@ -300,6 +305,7 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
       billingAccessMode: 'camel_free',
       defaultModel: 'deepseek-v4-auto',
       effectivePickerDefaultModel: 'deepseek-v4-auto',
+      canUnlockPremiumModels: true,
     });
     expect(freeState?.allowedThreadModels).toEqual(['deepseek-v4-auto']);
     expect(
@@ -320,18 +326,20 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
       openAiSubscription: { account_id: 'acct_123' },
     });
     expect(openAiState?.billingAccessMode).toBe('camel_free');
+    expect(openAiState?.canUnlockPremiumModels).toBe(true);
     expect(openAiState?.allowedThreadModels).toContain('gpt-5.6-sol');
     expect(
       openAiState?.modelOptions.find(
         (option) => option.id === 'gpt-5.6-sol',
       )?.locked,
     ).not.toBe(true);
-    expect(
-      openAiState?.modelOptions.find((option) => option.id === 'sonnet'),
-    ).toMatchObject({ locked: true, unlockHint: 'generic' });
-    expect(
-      openAiState?.modelOptions.find((option) => option.id === 'grok-4.5'),
-    ).toMatchObject({ locked: true, unlockHint: 'generic' });
+    expect(openAiState?.modelOptions.some((option) => option.locked)).toBe(false);
+    expect(openAiState?.modelOptions.map((option) => option.id)).not.toContain(
+      'sonnet',
+    );
+    expect(openAiState?.modelOptions.map((option) => option.id)).not.toContain(
+      'grok-4.5',
+    );
 
     const platformFreeState = await loadState({
       billingStatus: 'inactive',
@@ -351,7 +359,225 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     expect(
       paidState?.modelOptions.find((option) => option.id === 'fable-5'),
     ).toMatchObject({ id: 'fable-5' });
+    expect(paidState?.canUnlockPremiumModels).toBe(false);
     expect(paidState?.modelOptions.some((option) => option.locked)).toBe(false);
+  });
+
+  function pickerState(
+    overrides: Partial<WorkspaceModelPickerState> = {},
+  ): WorkspaceModelPickerState {
+    return {
+      orgId: 'org_123',
+      llmProvider: null,
+      customApi: null,
+      customModelId: null,
+      awsRegion: null,
+      allowOpenAiSubscription: false,
+      billingAccessMode: 'subscription',
+      experimentalSettings: { claude_proxy_models: false },
+      modelOptions: [
+        MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
+        MODEL_CATALOG.sonnet,
+        MODEL_CATALOG['gpt-5.6-sol'],
+        MODEL_CATALOG['grok-4.5'],
+      ],
+      allowedThreadModels: [
+        CAMEL_CODE_LLM_MODEL,
+        'sonnet',
+        'gpt-5.6-sol',
+        'grok-4.5',
+      ],
+      effectivePickerDefaultModel: 'sonnet',
+      hasEffectivePickerDefault: true,
+      defaultModel: 'sonnet',
+      canUnlockPremiumModels: false,
+      hostedCreditsPaused: null,
+      ...overrides,
+    };
+  }
+
+  it.each([
+    ['active', 'subscription', 'included_credits_exhausted'],
+    ['trialing', 'subscription', 'trial_credits_exhausted'],
+    ['inactive', 'credits', 'payg_credits_exhausted'],
+    ['past_due', 'credits', 'subscription_unavailable'],
+    ['canceled', 'credits', 'subscription_unavailable'],
+  ] as const)(
+    'maps %s billing to %s hosted-model pauses',
+    (billingStatus, billingAccessMode, reason) => {
+      const result = applyHostedCreditPause(
+        pickerState({ billingAccessMode }),
+        { billingStatus, availableCreditsCents: 0 },
+      );
+
+      expect(result.hostedCreditsPaused).toEqual({ reason });
+      expect(
+        result.modelOptions.find(
+          (option) => option.id === CAMEL_CODE_LLM_MODEL,
+        )?.pausedReason,
+      ).toBeUndefined();
+      expect(
+        result.modelOptions.find((option) => option.id === 'sonnet'),
+      ).toMatchObject({ locked: true, pausedReason: reason });
+      expect(result.allowedThreadModels).toEqual([CAMEL_CODE_LLM_MODEL]);
+      expect(result.effectivePickerDefaultModel).toBe(CAMEL_CODE_LLM_MODEL);
+      expect(result.defaultModel).toBe(CAMEL_CODE_LLM_MODEL);
+    },
+  );
+
+  it('leaves BYOK- and OpenAI-covered models available during a hosted credit pause', () => {
+    const result = applyHostedCreditPause(
+      pickerState({
+        llmProvider: 'anthropic',
+        allowOpenAiSubscription: true,
+      }),
+      { billingStatus: 'active', availableCreditsCents: 0 },
+    );
+
+    expect(
+      result.modelOptions.find((option) => option.id === 'sonnet')?.locked,
+    ).not.toBe(true);
+    expect(
+      result.modelOptions.find((option) => option.id === 'gpt-5.6-sol')?.locked,
+    ).not.toBe(true);
+    expect(
+      result.modelOptions.find((option) => option.id === 'grok-4.5'),
+    ).toMatchObject({
+      locked: true,
+      pausedReason: 'included_credits_exhausted',
+    });
+  });
+
+  it('adds camelCode when a hosted pause locks every custom picker model', () => {
+    const result = applyHostedCreditPause(
+      pickerState({
+        modelOptions: [MODEL_CATALOG.sonnet],
+        allowedThreadModels: ['sonnet'],
+      }),
+      { billingStatus: 'active', availableCreditsCents: 0 },
+    );
+
+    expect(result.modelOptions.map((option) => option.id)).toEqual([
+      CAMEL_CODE_LLM_MODEL,
+      'sonnet',
+    ]);
+    expect(result.allowedThreadModels).toEqual([CAMEL_CODE_LLM_MODEL]);
+    expect(result.defaultModel).toBe(CAMEL_CODE_LLM_MODEL);
+    expect(result.effectivePickerDefaultModel).toBe(
+      CAMEL_CODE_LLM_MODEL,
+    );
+  });
+
+  it.each(['enterprise', 'byok', 'camel_free'] as const)(
+    'does not pause hosted models in %s mode',
+    (billingAccessMode) => {
+      const state = pickerState({ billingAccessMode });
+      const result = applyHostedCreditPause(state, {
+        billingStatus: 'active',
+        availableCreditsCents: 0,
+      });
+
+      expect(result.modelOptions).toEqual(state.modelOptions);
+      expect(result.hostedCreditsPaused).toBeNull();
+    },
+  );
+
+  it('does not pause hosted models while credits remain', () => {
+    const state = pickerState();
+    const result = applyHostedCreditPause(state, {
+      billingStatus: 'active',
+      availableCreditsCents: 1,
+    });
+
+    expect(result.modelOptions).toEqual(state.modelOptions);
+    expect(result.hostedCreditsPaused).toBeNull();
+  });
+
+  it('only offers More models when the org setup leaves unlockable catalog gaps', async () => {
+    async function loadState(args: {
+      provider?: 'anthropic' | 'openrouter' | 'custom';
+      billingStatus?: 'inactive' | 'active' | 'enterprise';
+      purchasedCredits?: number;
+    }) {
+      const workspaceStub = {
+        getModelPickerConfig: vi.fn().mockResolvedValue({
+          use_org_defaults: true,
+          models: [],
+          default_model: null,
+        }),
+      };
+      const orgStub = {
+        getOpenAiSubscription: vi.fn().mockResolvedValue(null),
+        getModelPickerConfig: vi.fn().mockResolvedValue({
+          use_platform_defaults: true,
+          models: [],
+          default_model: null,
+        }),
+      };
+      getEnvMock.mockReturnValue({
+        WORKSPACE: {
+          idFromName: (id: string) => id,
+          get: () => workspaceStub,
+        },
+        ORG: {
+          idFromName: (id: string) => id,
+          get: () => orgStub,
+        },
+      });
+      const llmProviderConfig = args.provider
+        ? {
+            provider: args.provider,
+            credentials_encrypted: 'encrypted',
+            config:
+              args.provider === 'custom'
+                ? JSON.stringify({ custom_model_id: 'custom-model' })
+                : '{}',
+            created_by: 'user_123',
+            created_at: 1,
+            updated_at: 1,
+          }
+        : null;
+
+      return getWorkspaceModelPickerState({}, 'ws_123', {
+        orgId: 'org_123',
+        llmProviderConfig,
+        experimentalSettings: { claude_proxy_models: false },
+        orgBillingState: {
+          billing_status: args.billingStatus ?? 'inactive',
+          billing_credit_purchase_total_cents: args.purchasedCredits ?? 0,
+          billing_credit_grant_total_cents: 0,
+        },
+      });
+    }
+
+    await expect(loadState({ provider: 'anthropic' })).resolves.toMatchObject({
+      billingAccessMode: 'byok',
+      canUnlockPremiumModels: true,
+    });
+    await expect(loadState({ provider: 'openrouter' })).resolves.toMatchObject({
+      billingAccessMode: 'byok',
+      canUnlockPremiumModels: false,
+    });
+    await expect(loadState({ provider: 'custom' })).resolves.toMatchObject({
+      billingAccessMode: 'byok',
+      canUnlockPremiumModels: false,
+    });
+    await expect(loadState({ billingStatus: 'active' })).resolves.toMatchObject({
+      billingAccessMode: 'subscription',
+      canUnlockPremiumModels: false,
+    });
+    await expect(
+      loadState({ purchasedCredits: 100 }),
+    ).resolves.toMatchObject({
+      billingAccessMode: 'credits',
+      canUnlockPremiumModels: false,
+    });
+    await expect(
+      loadState({ billingStatus: 'enterprise' }),
+    ).resolves.toMatchObject({
+      billingAccessMode: 'enterprise',
+      canUnlockPremiumModels: false,
+    });
   });
 
   it('rethrows picker config errors other than missing RPC rollout errors', async () => {

--- a/tests/model-picker-access.test.ts
+++ b/tests/model-picker-access.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { CAMEL_CODE_LLM_MODEL } from "@/lib/llm-provider-config";
+import { MODEL_CATALOG } from "@/lib/model-catalog";
+import {
+  deriveHostedCreditPause,
+  type ModelPickerOption,
+} from "@/lib/model-picker-access";
+
+const BASE_OPTIONS: ModelPickerOption[] = [
+  MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
+  MODEL_CATALOG.sonnet,
+  MODEL_CATALOG["gpt-5.6-sol"],
+  MODEL_CATALOG["grok-4.5"],
+];
+
+describe("deriveHostedCreditPause", () => {
+  it("locks hosted premium rows as soon as a refreshed balance is exhausted", () => {
+    const result = deriveHostedCreditPause({
+      modelOptions: BASE_OPTIONS,
+      billingAccessMode: "subscription",
+      llmProvider: null,
+      allowOpenAiSubscription: false,
+      billing: {
+        billingStatus: "active",
+        availableCreditsCents: 0,
+      },
+    });
+
+    expect(result.hostedCreditsPaused).toEqual({
+      reason: "included_credits_exhausted",
+    });
+    expect(
+      result.modelOptions.find(
+        (option) => option.id === CAMEL_CODE_LLM_MODEL,
+      )?.locked,
+    ).not.toBe(true);
+    expect(
+      result.modelOptions.find((option) => option.id === "sonnet"),
+    ).toMatchObject({
+      locked: true,
+      pausedReason: "included_credits_exhausted",
+    });
+  });
+
+  it("keeps models covered by mixed BYOK and OpenAI credentials usable", () => {
+    const result = deriveHostedCreditPause({
+      modelOptions: BASE_OPTIONS,
+      billingAccessMode: "subscription",
+      llmProvider: "anthropic",
+      allowOpenAiSubscription: true,
+      billing: {
+        billingStatus: "active",
+        availableCreditsCents: 0,
+      },
+    });
+
+    expect(
+      result.modelOptions.find((option) => option.id === "sonnet")?.locked,
+    ).not.toBe(true);
+    expect(
+      result.modelOptions.find((option) => option.id === "gpt-5.6-sol")
+        ?.locked,
+    ).not.toBe(true);
+    expect(
+      result.modelOptions.find((option) => option.id === "grok-4.5"),
+    ).toMatchObject({
+      locked: true,
+      pausedReason: "included_credits_exhausted",
+    });
+  });
+
+  it("injects camelCode when a pause locks every custom picker model", () => {
+    const result = deriveHostedCreditPause({
+      modelOptions: [
+        MODEL_CATALOG.sonnet,
+        MODEL_CATALOG["gpt-5.6-sol"],
+      ],
+      billingAccessMode: "subscription",
+      llmProvider: null,
+      allowOpenAiSubscription: false,
+      billing: {
+        billingStatus: "active",
+        availableCreditsCents: 0,
+      },
+    });
+
+    expect(result.modelOptions.map((entry) => entry.id)).toEqual([
+      CAMEL_CODE_LLM_MODEL,
+      "sonnet",
+      "gpt-5.6-sol",
+    ]);
+    expect(
+      result.modelOptions
+        .filter((entry) => !entry.locked)
+        .map((entry) => entry.id),
+    ).toEqual([CAMEL_CODE_LLM_MODEL]);
+  });
+
+  it("does not report a pause for a camelCode-only custom picker", () => {
+    const result = deriveHostedCreditPause({
+      modelOptions: [MODEL_CATALOG[CAMEL_CODE_LLM_MODEL]],
+      billingAccessMode: "subscription",
+      llmProvider: null,
+      allowOpenAiSubscription: false,
+      billing: {
+        billingStatus: "active",
+        availableCreditsCents: 0,
+      },
+    });
+
+    expect(result.hostedCreditsPaused).toBeNull();
+    expect(result.modelOptions).toEqual([
+      MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
+    ]);
+  });
+
+  it("does not report a pause when every model is credential-covered", () => {
+    const result = deriveHostedCreditPause({
+      modelOptions: [
+        MODEL_CATALOG.sonnet,
+        MODEL_CATALOG["gpt-5.6-sol"],
+      ],
+      billingAccessMode: "subscription",
+      llmProvider: "anthropic",
+      allowOpenAiSubscription: true,
+      billing: {
+        billingStatus: "active",
+        availableCreditsCents: 0,
+      },
+    });
+
+    expect(result.hostedCreditsPaused).toBeNull();
+    expect(result.modelOptions.every((entry) => !entry.locked)).toBe(true);
+    expect(
+      result.modelOptions.every((entry) => !entry.pausedReason),
+    ).toBe(true);
+  });
+
+  it("clears loader-time pause locks after a live balance recovery", () => {
+    const paused = BASE_OPTIONS.map((entry) =>
+      entry.id === "sonnet"
+        ? {
+            ...entry,
+            locked: true,
+            pausedReason: "included_credits_exhausted" as const,
+          }
+        : entry,
+    );
+    const result = deriveHostedCreditPause({
+      modelOptions: paused,
+      billingAccessMode: "subscription",
+      llmProvider: null,
+      allowOpenAiSubscription: false,
+      billing: {
+        billingStatus: "active",
+        availableCreditsCents: 100,
+      },
+    });
+
+    expect(result.hostedCreditsPaused).toBeNull();
+    expect(
+      result.modelOptions.find((option) => option.id === "sonnet"),
+    ).not.toMatchObject({
+      locked: true,
+    });
+  });
+});

--- a/tests/model-picker-access.test.ts
+++ b/tests/model-picker-access.test.ts
@@ -3,6 +3,8 @@ import { CAMEL_CODE_LLM_MODEL } from "@/lib/llm-provider-config";
 import { MODEL_CATALOG } from "@/lib/model-catalog";
 import {
   deriveHostedCreditPause,
+  findCheapestSelectableModel,
+  shouldPromptToAddCamelCode,
   type ModelPickerOption,
 } from "@/lib/model-picker-access";
 
@@ -69,7 +71,7 @@ describe("deriveHostedCreditPause", () => {
     });
   });
 
-  it("injects camelCode when a pause locks every custom picker model", () => {
+  it("preserves a custom picker when every configured model pauses", () => {
     const result = deriveHostedCreditPause({
       modelOptions: [
         MODEL_CATALOG.sonnet,
@@ -85,7 +87,6 @@ describe("deriveHostedCreditPause", () => {
     });
 
     expect(result.modelOptions.map((entry) => entry.id)).toEqual([
-      CAMEL_CODE_LLM_MODEL,
       "sonnet",
       "gpt-5.6-sol",
     ]);
@@ -93,7 +94,45 @@ describe("deriveHostedCreditPause", () => {
       result.modelOptions
         .filter((entry) => !entry.locked)
         .map((entry) => entry.id),
-    ).toEqual([CAMEL_CODE_LLM_MODEL]);
+    ).toEqual([]);
+    expect(
+      shouldPromptToAddCamelCode(
+        result.modelOptions,
+        result.hostedCreditsPaused,
+      ),
+    ).toBe(true);
+  });
+
+  it("chooses the cheapest selectable model and preserves picker order for ties", () => {
+    expect(
+      findCheapestSelectableModel([
+        MODEL_CATALOG["gpt-5.6-sol"],
+        MODEL_CATALOG["gpt-5.6-terra"],
+        MODEL_CATALOG["gpt-5.6-luna"],
+      ])?.id,
+    ).toBe("gpt-5.6-luna");
+    expect(
+      findCheapestSelectableModel([
+        MODEL_CATALOG["gpt-5.6-luna"],
+        MODEL_CATALOG.haiku,
+      ])?.id,
+    ).toBe("gpt-5.6-luna");
+  });
+
+  it("prompts for camelCode when free-mode billing locks every custom model", () => {
+    expect(
+      shouldPromptToAddCamelCode(
+        [
+          {
+            ...MODEL_CATALOG.sonnet,
+            locked: true,
+            unlockHint: "generic",
+          },
+        ],
+        null,
+      ),
+    ).toBe(true);
+    expect(shouldPromptToAddCamelCode([], null)).toBe(false);
   });
 
   it("does not report a pause for a camelCode-only custom picker", () => {

--- a/tests/model-picker-access.test.ts
+++ b/tests/model-picker-access.test.ts
@@ -16,6 +16,50 @@ const BASE_OPTIONS: ModelPickerOption[] = [
 ];
 
 describe("deriveHostedCreditPause", () => {
+  it("surfaces a past-due subscription even when access resolves to free mode", () => {
+    const result = deriveHostedCreditPause({
+      modelOptions: BASE_OPTIONS,
+      billingAccessMode: "camel_free",
+      llmProvider: null,
+      allowOpenAiSubscription: false,
+      billing: {
+        billingStatus: "past_due",
+        availableCreditsCents: 0,
+      },
+    });
+
+    expect(result.hostedCreditsPaused).toEqual({
+      reason: "subscription_unavailable",
+    });
+    expect(
+      result.modelOptions.find((option) => option.id === "sonnet"),
+    ).toMatchObject({
+      locked: true,
+      pausedReason: "subscription_unavailable",
+    });
+    expect(
+      result.modelOptions.find(
+        (option) => option.id === CAMEL_CODE_LLM_MODEL,
+      )?.locked,
+    ).not.toBe(true);
+  });
+
+  it("treats a canceled subscription as free-tier access", () => {
+    const result = deriveHostedCreditPause({
+      modelOptions: BASE_OPTIONS,
+      billingAccessMode: "camel_free",
+      llmProvider: null,
+      allowOpenAiSubscription: false,
+      billing: {
+        billingStatus: "canceled",
+        availableCreditsCents: 0,
+      },
+    });
+
+    expect(result.hostedCreditsPaused).toBeNull();
+    expect(result.modelOptions).toEqual(BASE_OPTIONS);
+  });
+
   it("locks hosted premium rows as soon as a refreshed balance is exhausted", () => {
     const result = deriveHostedCreditPause({
       modelOptions: BASE_OPTIONS,

--- a/tests/model-picker.test.tsx
+++ b/tests/model-picker.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { HTMLAttributes, ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ModelPicker } from '@/components/model-picker';
 import { MODEL_CATALOG } from '@/lib/model-catalog';
@@ -266,5 +267,172 @@ describe('ModelPicker metadata card state', () => {
     expect(screen.getByRole('tooltip')).not.toHaveTextContent(
       'your OpenAI account',
     );
+  });
+
+  it.each([
+    [
+      'payg_credits_exhausted',
+      'Out of credits',
+      'Add credits to keep using these models.',
+      'Locked',
+    ],
+    [
+      'included_credits_exhausted',
+      'Monthly credits used',
+      'Resets when your plan renews. Add credits to keep going now.',
+      'Out of credits',
+    ],
+    [
+      'trial_credits_exhausted',
+      'Trial credits used',
+      'Upgrade or add credits to keep using these models.',
+      'Locked',
+    ],
+    [
+      'subscription_unavailable',
+      'Payment issue',
+      'Fix payment to restore these models.',
+      'Locked',
+    ],
+  ] as const)(
+    'renders the %s paused section',
+    (reason, header, description, iconLabel) => {
+      render(
+        <ModelPicker
+          value={CAMEL_CODE_LLM_MODEL}
+          onValueChange={vi.fn()}
+          options={[
+            MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
+            {
+              ...MODEL_CATALOG.sonnet,
+              locked: true,
+              pausedReason: reason,
+            },
+          ]}
+          isOrgAdmin={false}
+          pausedSection={{ reason }}
+        />,
+      );
+
+      expect(screen.getByText(header)).toBeInTheDocument();
+      expect(screen.getByText(description)).toBeInTheDocument();
+      expect(screen.getByLabelText(iconLabel)).toBeInTheDocument();
+    },
+  );
+
+  it('treats paused rows as locked actions without changing the model', () => {
+    const onValueChange = vi.fn();
+    const onLockedModelSelect = vi.fn();
+    render(
+      <ModelPicker
+        value={CAMEL_CODE_LLM_MODEL}
+        onValueChange={onValueChange}
+        options={[
+          MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
+          {
+            ...MODEL_CATALOG.sonnet,
+            locked: true,
+            pausedReason: 'payg_credits_exhausted',
+          },
+        ]}
+        isOrgAdmin={false}
+        onLockedModelSelect={onLockedModelSelect}
+      />,
+    );
+
+    fireEvent.click(getModelItem('Sonnet 5'));
+    expect(onLockedModelSelect).toHaveBeenCalledWith('sonnet');
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('explains the paused reason in model metadata', () => {
+    render(
+      <ModelPicker
+        value={CAMEL_CODE_LLM_MODEL}
+        onValueChange={vi.fn()}
+        options={[
+          MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
+          {
+            ...MODEL_CATALOG.sonnet,
+            locked: true,
+            pausedReason: 'included_credits_exhausted',
+          },
+        ]}
+        isOrgAdmin={false}
+      />,
+    );
+
+    fireEvent.focus(getModelItem('Sonnet 5'));
+    expect(screen.getByRole('tooltip')).toHaveTextContent(
+      'Available again when your plan renews, or add credits now.',
+    );
+  });
+
+  it('renders More models when additional catalog access can be unlocked', () => {
+    const onUnlockRequest = vi.fn();
+    render(
+      <ModelPicker
+        value={CAMEL_CODE_LLM_MODEL}
+        onValueChange={vi.fn()}
+        options={[MODEL_CATALOG[CAMEL_CODE_LLM_MODEL]]}
+        isOrgAdmin={false}
+        showMoreModelsCta
+        onUnlockRequest={onUnlockRequest}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('More models'));
+    expect(onUnlockRequest).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText('Unlock premium models'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows at most one model-related footer row', () => {
+    const lockedRender = render(
+      <MemoryRouter>
+        <ModelPicker
+          value={CAMEL_CODE_LLM_MODEL}
+          onValueChange={vi.fn()}
+          options={[
+            MODEL_CATALOG[CAMEL_CODE_LLM_MODEL],
+            { ...MODEL_CATALOG.sonnet, locked: true },
+          ]}
+          isOrgAdmin
+          showMoreModelsCta
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Unlock premium models')).toBeInTheDocument();
+    expect(screen.queryByText('More models')).not.toBeInTheDocument();
+    expect(screen.queryByText('Manage models')).not.toBeInTheDocument();
+    lockedRender.unmount();
+
+    const moreRender = render(
+      <MemoryRouter>
+        <ModelPicker
+          value={CAMEL_CODE_LLM_MODEL}
+          onValueChange={vi.fn()}
+          options={[MODEL_CATALOG[CAMEL_CODE_LLM_MODEL]]}
+          isOrgAdmin
+          showMoreModelsCta
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('More models')).toBeInTheDocument();
+    expect(screen.queryByText('Manage models')).not.toBeInTheDocument();
+    moreRender.unmount();
+
+    render(
+      <MemoryRouter>
+        <ModelPicker
+          value={CAMEL_CODE_LLM_MODEL}
+          onValueChange={vi.fn()}
+          options={[MODEL_CATALOG[CAMEL_CODE_LLM_MODEL]]}
+          isOrgAdmin
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Manage models')).toBeInTheDocument();
   });
 });

--- a/tests/model-settings-action.test.ts
+++ b/tests/model-settings-action.test.ts
@@ -9,6 +9,7 @@ const orgGetModelPickerConfigMock = vi.fn();
 const orgSetModelPickerConfigMock = vi.fn();
 const orgGetLlmProviderConfigMock = vi.fn();
 const orgGetExperimentalSettingsMock = vi.fn();
+const orgGetOpenAiSubscriptionMock = vi.fn();
 const workspaceGetModelPickerConfigMock = vi.fn();
 const workspaceSetModelPickerConfigMock = vi.fn();
 
@@ -88,6 +89,7 @@ describe('organization model settings actions', () => {
           setModelPickerConfig: orgSetModelPickerConfigMock,
           getLlmProviderConfig: orgGetLlmProviderConfigMock,
           getExperimentalSettings: orgGetExperimentalSettingsMock,
+          getOpenAiSubscription: orgGetOpenAiSubscriptionMock,
         }),
       },
       WORKSPACE: {
@@ -117,6 +119,7 @@ describe('organization model settings actions', () => {
     orgGetExperimentalSettingsMock.mockRejectedValue(
       new Error('unexpected experimental settings read'),
     );
+    orgGetOpenAiSubscriptionMock.mockResolvedValue(null);
     workspaceGetModelPickerConfigMock.mockResolvedValue({
       use_org_defaults: true,
       use_platform_defaults: true,
@@ -500,6 +503,51 @@ describe('organization model settings actions', () => {
     expect(workspaceSetModelPickerConfigMock).not.toHaveBeenCalled();
   });
 
+  it('allows OpenAI-login models alongside Anthropic BYOK credentials', async () => {
+    mockAuthContext({
+      currentOrgLlmProviderConfig: providerRecord('anthropic'),
+    });
+    orgGetOpenAiSubscriptionMock.mockResolvedValue({
+      account_id: 'acct_123',
+    });
+    orgGetModelPickerConfigMock.mockResolvedValue({
+      use_platform_defaults: false,
+      models: [{ id: 'sonnet', added_at: 10 }],
+      default_model: 'sonnet',
+    });
+
+    const response = await action({
+      request: formRequest({
+        intent: 'addModel',
+        model: 'gpt-5.6-sol',
+      }, ''),
+      context: {},
+      params: {},
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+    });
+    expect(orgSetModelPickerConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        use_platform_defaults: false,
+        models: [
+          { id: 'gpt-5.6-sol', added_at: expect.any(Number) },
+          { id: 'sonnet', added_at: 10 },
+        ],
+        default_model: 'sonnet',
+      }),
+      expect.objectContaining({
+        actorId: 'user_123',
+        details: {
+          intent: 'addModel',
+          model: 'gpt-5.6-sol',
+        },
+      }),
+    );
+  });
+
   it('rejects adding retired Gemini 3.1 Pro Preview as a new picker model', async () => {
     workspaceGetModelPickerConfigMock.mockResolvedValue({
       use_org_defaults: false,
@@ -688,6 +736,7 @@ describe('organization model settings loader', () => {
           getModelPickerConfig: orgGetModelPickerConfigMock,
           getLlmProviderConfig: orgGetLlmProviderConfigMock,
           getExperimentalSettings: orgGetExperimentalSettingsMock,
+          getOpenAiSubscription: orgGetOpenAiSubscriptionMock,
         }),
       },
       WORKSPACE: {
@@ -711,6 +760,7 @@ describe('organization model settings loader', () => {
     orgGetExperimentalSettingsMock.mockRejectedValue(
       new Error('unexpected experimental settings read'),
     );
+    orgGetOpenAiSubscriptionMock.mockResolvedValue(null);
     workspaceGetModelPickerConfigMock.mockResolvedValue({
       use_org_defaults: true,
       models: [],
@@ -744,6 +794,12 @@ describe('organization model settings loader', () => {
     ]);
     expect(result.config.additional).toEqual([]);
     expect(result.config.capacity.used).toBe(4);
+    expect(result.billingAccessMode).toBe('byok');
+    expect(result.showLockedModels).toBe(true);
+    expect(result.billingLockedModelIds).toEqual([]);
+    expect(result.hiddenLockedModels.map((entry) => entry.id)).toContain(
+      'sonnet',
+    );
   });
 
   it('does not mark retained defaults as active in platform-default settings', async () => {
@@ -850,5 +906,90 @@ describe('organization model settings loader', () => {
     ]);
     expect(result.config.additional).toEqual([]);
     expect(result.config.capacity.used).toBe(5);
+  });
+
+  it('shows OpenAI-login models as usable with Anthropic BYOK credentials', async () => {
+    mockAuthContext({
+      currentOrgLlmProviderConfig: providerRecord('anthropic'),
+    });
+    orgGetOpenAiSubscriptionMock.mockResolvedValue({
+      account_id: 'acct_123',
+    });
+    orgGetModelPickerConfigMock.mockResolvedValue({
+      use_platform_defaults: true,
+      models: [],
+      default_model: null,
+    });
+
+    const result = await loader({
+      request: loaderRequest(),
+      context: {},
+      params: {},
+    } as never);
+
+    expect(result.config.inPicker.map((row) => row.entry.id)).toContain(
+      'gpt-5.6-sol',
+    );
+    expect(result.config.additional.map((entry) => entry.id)).not.toContain(
+      'gpt-5.6-sol',
+    );
+    expect(result.hiddenLockedModels.map((entry) => entry.id)).not.toContain(
+      'gpt-5.6-sol',
+    );
+  });
+
+  it('returns billing lock metadata for free orgs with OpenAI login', async () => {
+    mockAuthContext({
+      currentOrg: {
+        id: 'org_123',
+        billing_status: 'inactive',
+        billing_credit_purchase_total_cents: 0,
+        billing_credit_grant_total_cents: 0,
+      },
+      currentOrgLlmProviderConfig: null,
+    });
+    orgGetOpenAiSubscriptionMock.mockResolvedValue({
+      account_id: 'acct_123',
+    });
+    orgGetModelPickerConfigMock.mockResolvedValue({
+      use_platform_defaults: true,
+      models: [],
+      default_model: null,
+    });
+
+    const result = await loader({
+      request: loaderRequest(),
+      context: {},
+      params: {},
+    } as never);
+
+    expect(result.billingAccessMode).toBe('camel_free');
+    expect(result.allowOpenAiSubscription).toBe(true);
+    expect(result.showLockedModels).toBe(true);
+    expect(result.billingLockedModelIds).toContain('sonnet');
+    expect(result.billingLockedModelIds).not.toContain('gpt-5.6-sol');
+    expect(result.hiddenLockedModels).toEqual([]);
+  });
+
+  it('suppresses locked catalog metadata for enterprise orgs', async () => {
+    mockAuthContext({
+      currentOrg: {
+        id: 'org_123',
+        billing_status: 'enterprise',
+        billing_credit_purchase_total_cents: 0,
+        billing_credit_grant_total_cents: 0,
+      },
+    });
+
+    const result = await loader({
+      request: loaderRequest(),
+      context: {},
+      params: {},
+    } as never);
+
+    expect(result.billingAccessMode).toBe('enterprise');
+    expect(result.showLockedModels).toBe(false);
+    expect(result.billingLockedModelIds).toEqual([]);
+    expect(result.hiddenLockedModels).toEqual([]);
   });
 });

--- a/tests/model-settings-ui.test.tsx
+++ b/tests/model-settings-ui.test.tsx
@@ -76,6 +76,7 @@ function loaderData(overrides: Record<string, unknown> = {}) {
     useOrgDefaults: false,
     allowOpenAiSubscription: false,
     billingAccessMode: 'subscription',
+    billingStatus: 'active',
     showLockedModels: true,
     billingLockedModelIds: [],
     hiddenLockedModels: [],
@@ -377,6 +378,7 @@ describe('organization model settings UI', () => {
   it('advertises and marks billing-locked models for free orgs', () => {
     loaderDataMock.mockReturnValue(loaderData({
       billingAccessMode: 'camel_free',
+      billingStatus: 'inactive',
       billingLockedModelIds: [
         'sonnet',
         'gpt-5.6-sol',
@@ -408,6 +410,43 @@ describe('organization model settings UI', () => {
       );
     }
     expect(screen.getByLabelText('Locked')).toBeInTheDocument();
+  });
+
+  it('routes past-due orgs to fix payment', () => {
+    loaderDataMock.mockReturnValue(loaderData({
+      billingAccessMode: 'camel_free',
+      billingStatus: 'past_due',
+      billingLockedModelIds: ['sonnet'],
+    }));
+
+    render(<OrganizationModelsPage />);
+
+    expect(screen.getByText('Payment is past due')).toBeInTheDocument();
+    expect(
+      screen.getByText('Fix payment in Billing to restore premium models.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Fix payment' }),
+    ).toHaveAttribute('href', '/settings/organization/billing');
+    expect(
+      screen.queryByText(/Your org is on the free camelCode model/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows canceled orgs as free-tier orgs', () => {
+    loaderDataMock.mockReturnValue(loaderData({
+      billingAccessMode: 'camel_free',
+      billingStatus: 'canceled',
+      billingLockedModelIds: ['sonnet'],
+    }));
+
+    render(<OrganizationModelsPage />);
+
+    expect(screen.getByText('Premium models are locked')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your org is on the free camelCode model/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Payment is past due')).not.toBeInTheDocument();
   });
 
   it('shows provider-hidden models as a read-only BYOK catalog section', () => {

--- a/tests/model-settings-ui.test.tsx
+++ b/tests/model-settings-ui.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MODEL_CATALOG } from '@/lib/model-catalog';
 import OrganizationModelsPage from '@/routes/_app.settings.organization.models';
@@ -27,6 +28,9 @@ vi.mock('react-router', () => ({
     search: '?scope=ws&workspaceId=ws_123',
   }),
   useNavigate: () => navigateMock,
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
 }));
 
 vi.mock('@/lib/auth.server', () => ({
@@ -70,6 +74,11 @@ function loaderData(overrides: Record<string, unknown> = {}) {
       },
     ],
     useOrgDefaults: false,
+    allowOpenAiSubscription: false,
+    billingAccessMode: 'subscription',
+    showLockedModels: true,
+    billingLockedModelIds: [],
+    hiddenLockedModels: [],
     config: {
       usePlatformDefaults: true,
       inPicker: [
@@ -363,5 +372,78 @@ describe('organization model settings UI', () => {
     expect(
       screen.queryByText('Switch to a custom list to edit which models appear.'),
     ).not.toBeInTheDocument();
+  });
+
+  it('advertises and marks billing-locked models for free orgs', () => {
+    loaderDataMock.mockReturnValue(loaderData({
+      billingAccessMode: 'camel_free',
+      billingLockedModelIds: [
+        'sonnet',
+        'gpt-5.6-sol',
+        'gemini-3.5-flash',
+      ],
+    }));
+
+    const { container } = render(<OrganizationModelsPage />);
+
+    expect(screen.getByText('Premium models are locked')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your org is on the free camelCode model/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'View plans' }),
+    ).toHaveAttribute('href', '/settings/organization/billing');
+    expect(
+      screen.getByRole('link', { name: 'Add API key' }),
+    ).toHaveAttribute('href', '/settings/organization/ai-provider');
+    const stackedChips = container.querySelectorAll(
+      'span.rounded-md.bg-background.ring-2.ring-background',
+    );
+    expect(stackedChips).toHaveLength(3);
+    for (const chip of stackedChips) {
+      expect(chip.firstElementChild).toHaveClass(
+        'size-6',
+        'rounded-md',
+        'bg-muted/50',
+      );
+    }
+    expect(screen.getByLabelText('Locked')).toBeInTheDocument();
+  });
+
+  it('shows provider-hidden models as a read-only BYOK catalog section', () => {
+    loaderDataMock.mockReturnValue(loaderData({
+      billingAccessMode: 'byok',
+      hiddenLockedModels: [
+        MODEL_CATALOG['gpt-5.6-sol'],
+        MODEL_CATALOG['gemini-3.5-flash'],
+      ],
+    }));
+
+    render(<OrganizationModelsPage />);
+
+    expect(screen.getByText('Locked models')).toBeInTheDocument();
+    expect(screen.getByText('GPT-5.6 Sol')).toBeInTheDocument();
+    expect(screen.getByText('Gemini 3.5 Flash')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'add' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'remove' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('suppresses every locked-model treatment for enterprise orgs', () => {
+    loaderDataMock.mockReturnValue(loaderData({
+      billingAccessMode: 'enterprise',
+      showLockedModels: false,
+      billingLockedModelIds: ['sonnet'],
+      hiddenLockedModels: [MODEL_CATALOG['gpt-5.6-sol']],
+    }));
+
+    render(<OrganizationModelsPage />);
+
+    expect(
+      screen.queryByText('Premium models are locked'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Locked models')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Locked')).not.toBeInTheDocument();
   });
 });

--- a/tests/new-chat-sales-prompt-loader.test.ts
+++ b/tests/new-chat-sales-prompt-loader.test.ts
@@ -218,6 +218,18 @@ describe('new chat loader sales prompt handling', () => {
     consoleError.mockRestore();
   });
 
+  it('preserves billing overview failures instead of exposing unpaused models', async () => {
+    const billingError = new Error('billing overview unavailable');
+    getOrgBillingOverviewMock.mockRejectedValueOnce(billingError);
+
+    const result = await loader({
+      request: new Request('https://camelai.dev/chat'),
+      context: {},
+    } as never);
+
+    await expect(result.interactive).rejects.toBe(billingError);
+  });
+
   it('falls back to provider-visible models when picker state loading fails', async () => {
     getWorkspaceModelPickerStateMock.mockRejectedValue(new Error('picker down'));
     requireAuthContextMock.mockResolvedValue({

--- a/tests/new-chat-sales-prompt-loader.test.ts
+++ b/tests/new-chat-sales-prompt-loader.test.ts
@@ -42,6 +42,7 @@ vi.mock('@/lib/mention-sources.server', () => ({
 }));
 
 vi.mock('@/lib/chat-do.server', () => ({
+  applyHostedCreditPause: (state: unknown) => state,
   getRecentThreads: getRecentThreadsMock,
   getWorkspaceModelPickerState: getWorkspaceModelPickerStateMock,
 }));

--- a/tests/unlock-premium-modal.test.tsx
+++ b/tests/unlock-premium-modal.test.tsx
@@ -1,14 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { UnlockPremiumModal } from "@/components/billing/unlock-premium-modal";
+import type { UnlockPremiumModalVariant } from "@/components/billing/unlock-premium-modal";
 import type { LlmModel } from "@/types";
 
 function renderModal({
   triggerModel = "sonnet",
   isOrgAdmin = true,
+  variant = "unlock",
 }: {
   triggerModel?: LlmModel;
   isOrgAdmin?: boolean;
+  variant?: UnlockPremiumModalVariant;
 } = {}) {
   render(
     <UnlockPremiumModal
@@ -21,6 +24,7 @@ function renderModal({
       onTopUp={vi.fn()}
       onAddKey={vi.fn()}
       onOpenAiSignIn={vi.fn()}
+      variant={variant}
     />,
   );
 }
@@ -104,5 +108,63 @@ describe("UnlockPremiumModal", () => {
     expect(
       screen.queryByRole("button", { name: "Add key" }),
     ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "payg_credits_exhausted",
+      "Out of credits",
+      "used all your camelAI credits",
+      "unlock-method-credits",
+      "Buy credits",
+    ],
+    [
+      "included_credits_exhausted",
+      "Monthly credits used",
+      "used this month's included credits",
+      "unlock-method-credits",
+      "Buy credits",
+    ],
+    [
+      "trial_credits_exhausted",
+      "Trial credits used",
+      "used your trial credits",
+      "unlock-method-subscribe",
+      "Subscribe",
+    ],
+  ] satisfies Array<
+    [
+      UnlockPremiumModalVariant,
+      string,
+      string,
+      string,
+      string,
+    ]
+  >)(
+    "renders the %s recovery variant",
+    (variant, title, description, recommendedTestId, recommendedTitle) => {
+      renderModal({ variant });
+
+      expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(description))).toBeInTheDocument();
+      const recommended = screen.getByTestId(recommendedTestId);
+      expect(recommended).toHaveClass("ring-2", "ring-primary");
+      expect(recommended).toHaveTextContent(recommendedTitle);
+      expect(screen.getAllByText("Recommended")).toHaveLength(1);
+    },
+  );
+
+  it("offers an upgrade-plan row after included credits are used", () => {
+    renderModal({ variant: "included_credits_exhausted" });
+
+    expect(screen.getByText("Upgrade plan")).toBeInTheDocument();
+    expect(
+      screen.getByText("Higher plans include more monthly credits."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Extra credits on top of your plan. Available immediately.",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/tests/use-billing-credit-status.test.tsx
+++ b/tests/use-billing-credit-status.test.tsx
@@ -56,4 +56,62 @@ describe("useBillingCreditStatus", () => {
     });
     expect(result.current.currentBillingCreditStatus?.isExhausted).toBe(true);
   });
+
+  it("preserves exhausted org status across a subsequent BYOK-covered turn", () => {
+    const fetcher = {
+      data: undefined as BillingCreditStatusResourceData | undefined,
+      load: vi.fn(),
+    };
+    const selectedThreadModelRef = {
+      current: "gpt-5.6-sol" as LlmModel,
+    };
+    const locationSearchRef = { current: "" };
+    const { result, rerender } = renderHook(() =>
+      useBillingCreditStatus({
+        billingStatusFetcher: fetcher as never,
+        initialStatus: null,
+        threadId: "thread_123",
+        selectedThreadModelRef,
+        locationSearchRef,
+      }),
+    );
+
+    fetcher.data = {
+      ok: true,
+      billingCreditStatus: {
+        availableCreditsCents: 0,
+        totalCreditLimitCents: 500,
+        isExhausted: true,
+        hasByokProvider: true,
+        billingStatus: "active",
+      },
+      requestedModel: "gpt-5.6-sol",
+      threadModel: "deepseek-v4-auto",
+      threadModelUpdatedAt: 1234,
+    };
+    rerender();
+    expect(result.current.currentBillingCreditStatus?.isExhausted).toBe(true);
+
+    selectedThreadModelRef.current = "sonnet";
+    fetcher.data = {
+      ok: true,
+      billingCreditStatus: {
+        availableCreditsCents: 0,
+        totalCreditLimitCents: 500,
+        isExhausted: true,
+        hasByokProvider: true,
+        billingStatus: "active",
+      },
+      requestedModel: "sonnet",
+      threadModel: "sonnet",
+      threadModelUpdatedAt: 2345,
+    };
+    rerender();
+
+    expect(result.current.currentBillingCreditStatus).toMatchObject({
+      availableCreditsCents: 0,
+      isExhausted: true,
+      hasByokProvider: true,
+    });
+  });
 });

--- a/workers/main/tests/billing-org.test.ts
+++ b/workers/main/tests/billing-org.test.ts
@@ -86,6 +86,44 @@ describe("OrgDO billing grant idempotency", () => {
     };
   }
 
+  it("normalizes a completed cancellation to the free tier", async () => {
+    const { userId: ownerId } = await createUser(
+      testEnv,
+      testEmail(),
+      "password",
+      "Owner",
+    );
+    const { org } = await createOrg(
+      testEnv,
+      "Canceled Subscription Org",
+      ownerId,
+      { billingPlan: "pro" },
+    );
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+
+    await expect(
+      orgStub.updateBillingState({
+        billing_status: "canceled",
+        billing_plan: "pro",
+        billing_seat_count: 1,
+        billing_subscription_id: "sub_canceled",
+        billing_subscription_status: "canceled",
+      }),
+    ).resolves.toMatchObject({
+      billing_status: "inactive",
+      billing_plan: "payg",
+      billing_seat_count: 1,
+      billing_subscription_id: null,
+      billing_subscription_status: null,
+    });
+    await expect(orgStub.getInfo()).resolves.toMatchObject({
+      billing_status: "inactive",
+      billing_plan: "payg",
+      billing_subscription_id: null,
+      billing_subscription_status: null,
+    });
+  });
+
   it("uses paid Team capacity locally without mutating billing", async () => {
     const { userId: ownerId } = await createUser(
       testEnv,


### PR DESCRIPTION
## Summary

Centralizes model access derivation so provider coverage, OpenAI sign-in, billing mode, and exhausted hosted credits produce consistent picker states.
Updates chat and organization settings to show locked or paused models with reason-specific recovery actions while preserving camelCode and subscription-covered options.
Adds tailored exhausted-credit dialogs and routes organization admins to billing when appropriate.
Validated with `bun run typecheck` and 12 focused Vitest files covering 137 passing tests.
