### PR TITLE
Add transcript + tool-call export to R2 Data Catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Important DOs and runtime classes live primarily in `workers/main/src/`:
 - `mcp-handler.ts` - Internal MCP agent/tools.
 - `*-mcp.ts` / `connections-runtime.ts` - Per-provider connection MCP wrappers and shared connection runtime (candidate for an `integrations/` folder).
 - `observability.ts` - Shared Cloudflare Analytics Engine event/error writer. New structured instrumentation should go through this helper instead of calling `writeDataPoint` directly.
+- `lake-streams.ts` + `chat-thread/transcript-lake.ts` - Transcript / tool-call export to Iceberg tables in R2 Data Catalog via Cloudflare Pipelines. Both bindings are optional and every helper no-ops without them, so dev/tests/self-host never export. Tool durations are measured live (Pi records no tool start timestamp) and stamped as `uiMetadata.toolDurationMs`. Design, setup commands, and the privacy posture: `docs/transcript-lake.md`. Verify with `bun run test:workers -- transcript-lake`.
 
 Durable Objects use SQLite-backed storage. Prefer:
 
@@ -228,7 +229,7 @@ waitUntil(
 
 - Cloudflare Workers Observability and source-map uploads are enabled in deployed Wrangler configs.
 - Structured operational events go to `OBSERVABILITY_EVENTS`; structured errors are mirrored through `ERROR_ANALYTICS`. Use `recordObservabilityEvent` / `recordErrorEvent` from `workers/main/src/observability.ts` for new instrumentation.
-- Keep observability payloads diagnostic but not transcript-like: include ids, counts, status, durations, routes, and error metadata; do not store chat message contents, secrets, request bodies, or auth headers.
+- Keep observability payloads diagnostic but not transcript-like: include ids, counts, status, durations, routes, and error metadata; do not store chat message contents, secrets, request bodies, or auth headers. The one deliberate exception is the transcript data lake (`docs/transcript-lake.md`), which exports transcript text on purpose and is governed by its own access/retention rules — it is not a licence to widen Analytics Engine payloads.
 - The main app workers attach Tail Consumers to `workers/user-logs-tail/`, which forwards raw Worker trace/log/exception events into `WorkerLogsDO`.
 - Production datasets are `chiridion_observability_prod` and `chiridion_errors_prod`; staging uses the corresponding `_staging` datasets. Verify bindings in the environment-specific `wrangler*.jsonc` files before changing collection paths.
 - Query Analytics Engine through Cloudflare's SQL API with an account token that has Account Analytics Read. The account id is `CF_ACCOUNT_ID` in Wrangler vars. Example:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ Important DOs and runtime classes live primarily in `workers/main/src/`:
 - `mcp-handler.ts` - Internal MCP agent/tools.
 - `*-mcp.ts` / `connections-runtime.ts` - Per-provider connection MCP wrappers and shared connection runtime (candidate for an `integrations/` folder).
 - `observability.ts` - Shared Cloudflare Analytics Engine event/error writer. New structured instrumentation should go through this helper instead of calling `writeDataPoint` directly.
-- `lake-streams.ts` + `chat-thread/transcript-lake.ts` - Transcript / tool-call export to Iceberg tables in R2 Data Catalog via Cloudflare Pipelines. Both bindings are optional and every helper no-ops without them, so dev/tests/self-host never export. Tool durations are measured live (Pi records no tool start timestamp) and stamped as `uiMetadata.toolDurationMs`. Design, setup commands, and the privacy posture: `docs/transcript-lake.md`. Verify with `bun run test:workers -- transcript-lake`.
+- `lake-streams.ts` + `chat-thread/transcript-lake.ts` - Transcript / tool-call export to Iceberg tables in R2 Data Catalog via Cloudflare Pipelines. Both bindings are optional and every helper no-ops without them, so dev/tests/self-host never export. Tool durations are measured live (Pi records no tool start timestamp) and stamped as `uiMetadata.toolDurationMs`. Design, setup commands, and the privacy posture: `config/pipelines/README.md`. Verify with `bun run test:workers -- transcript-lake`.
 
 Durable Objects use SQLite-backed storage. Prefer:
 
@@ -229,7 +229,7 @@ waitUntil(
 
 - Cloudflare Workers Observability and source-map uploads are enabled in deployed Wrangler configs.
 - Structured operational events go to `OBSERVABILITY_EVENTS`; structured errors are mirrored through `ERROR_ANALYTICS`. Use `recordObservabilityEvent` / `recordErrorEvent` from `workers/main/src/observability.ts` for new instrumentation.
-- Keep observability payloads diagnostic but not transcript-like: include ids, counts, status, durations, routes, and error metadata; do not store chat message contents, secrets, request bodies, or auth headers. The one deliberate exception is the transcript data lake (`docs/transcript-lake.md`), which exports transcript text on purpose and is governed by its own access/retention rules — it is not a licence to widen Analytics Engine payloads.
+- Keep observability payloads diagnostic but not transcript-like: include ids, counts, status, durations, routes, and error metadata; do not store chat message contents, secrets, request bodies, or auth headers. The one deliberate exception is the transcript data lake (`config/pipelines/README.md`), which exports transcript text on purpose and is governed by its own access/retention rules — it is not a licence to widen Analytics Engine payloads.
 - The main app workers attach Tail Consumers to `workers/user-logs-tail/`, which forwards raw Worker trace/log/exception events into `WorkerLogsDO`.
 - Production datasets are `chiridion_observability_prod` and `chiridion_errors_prod`; staging uses the corresponding `_staging` datasets. Verify bindings in the environment-specific `wrangler*.jsonc` files before changing collection paths.
 - Query Analytics Engine through Cloudflare's SQL API with an account token that has Account Analytics Read. The account id is `CF_ACCOUNT_ID` in Wrangler vars. Example:

--- a/config/pipelines/README.md
+++ b/config/pipelines/README.md
@@ -42,7 +42,7 @@ They are deliberately separate. Transcripts are customer content subject to
 deletion requests; operational timings you want to keep for years. One table
 would weld those two policies together.
 
-Schemas live in [`config/pipelines/`](../config/pipelines/). Columns are **flat
+Schemas live in the JSON files alongside this README. Columns are **flat
 scalars**, which is load-bearing rather than stylistic: Parquet is columnar and
 R2 SQL bills on bytes scanned, so a duration query prunes the fat `text` column
 and reads almost nothing. A single JSON payload column would force every query

--- a/config/pipelines/pi_messages.schema.json
+++ b/config/pipelines/pi_messages.schema.json
@@ -1,0 +1,24 @@
+{
+  "fields": [
+    { "name": "ingested_at_ms", "type": "int64", "required": true },
+    { "name": "ts_ms", "type": "int64", "required": true },
+    { "name": "thread_id", "type": "string", "required": true },
+    { "name": "org_id", "type": "string", "required": true },
+    { "name": "workspace_id", "type": "string", "required": true },
+    { "name": "user_id", "type": "string", "required": false },
+    { "name": "idx", "type": "int64", "required": true },
+    { "name": "role", "type": "string", "required": true },
+    { "name": "render_message_id", "type": "string", "required": false },
+    { "name": "tool_name", "type": "string", "required": false },
+    { "name": "tool_call_id", "type": "string", "required": false },
+    { "name": "tool_is_error", "type": "bool", "required": false },
+    { "name": "tool_duration_ms", "type": "int64", "required": false },
+    { "name": "model", "type": "string", "required": false },
+    { "name": "provider", "type": "string", "required": false },
+    { "name": "stop_reason", "type": "string", "required": false },
+    { "name": "text", "type": "string", "required": false },
+    { "name": "text_chars", "type": "int64", "required": false },
+    { "name": "text_truncated", "type": "bool", "required": false },
+    { "name": "image_count", "type": "int64", "required": false }
+  ]
+}

--- a/config/pipelines/tool_calls.schema.json
+++ b/config/pipelines/tool_calls.schema.json
@@ -1,0 +1,22 @@
+{
+  "fields": [
+    { "name": "ingested_at_ms", "type": "int64", "required": true },
+    { "name": "ts_ms", "type": "int64", "required": true },
+    { "name": "thread_id", "type": "string", "required": true },
+    { "name": "org_id", "type": "string", "required": true },
+    { "name": "workspace_id", "type": "string", "required": true },
+    { "name": "user_id", "type": "string", "required": false },
+    { "name": "turn_id", "type": "string", "required": false },
+    { "name": "tool_call_id", "type": "string", "required": true },
+    { "name": "parent_tool_call_id", "type": "string", "required": false },
+    { "name": "tool_name", "type": "string", "required": true },
+    { "name": "surface", "type": "string", "required": true },
+    { "name": "model", "type": "string", "required": false },
+    { "name": "provider", "type": "string", "required": false },
+    { "name": "duration_ms", "type": "int64", "required": true },
+    { "name": "ok", "type": "bool", "required": true },
+    { "name": "error_message", "type": "string", "required": false },
+    { "name": "blocks_on_human", "type": "bool", "required": false },
+    { "name": "result_chars", "type": "int64", "required": false }
+  ]
+}

--- a/docs/transcript-lake.md
+++ b/docs/transcript-lake.md
@@ -1,0 +1,163 @@
+# Transcript data lake
+
+Streams chat transcripts and tool-call timings into Apache Iceberg tables in R2
+Data Catalog, so fleet-wide questions ("what are the slowest tool calls?", "how
+often does the agent retry after a failed edit?") are one SQL query instead of
+one Durable Object wakeup per thread.
+
+Reading **one** transcript stays faster through the admin API
+(`get_thread_jsonl` / `manage_thread_message_rows`) — that path is a point
+lookup against the authoritative store and is always current. The lake exists
+for **bulk** and **predicate-selected** reads, where the win is structural:
+today, selecting threads requires downloading all of them first.
+
+## Why the timing instrumentation is not optional
+
+Pi records no tool start timestamp. An assistant message's `timestamp` is
+stamped when the model *request opens* (`pi-ai/api/*`, before any streaming), so
+a duration derived after the fact as `toolResult.timestamp − previous message
+timestamp` silently includes model latency. Measured against production, only
+~12% of tool calls sit second-or-later in a batch where that subtraction is
+clean.
+
+So the duration is measured live, between `tool_execution_start` and
+`tool_execution_end`, and stamped onto the persisted row as
+`uiMetadata.toolDurationMs`. Exporting raw transcripts *without* this would
+reproduce the same unusable numbers, only faster to query.
+
+Inner `js_exec` calls get the same treatment in `CodeModeToolsBinding
+.callToolEnvelope`. They never produce a `pi_core` row at all — to the
+transcript the whole script is one opaque `js_exec`, which in production is ~35%
+of all tool calls and hides every build, deploy, notebook, and DB timing inside
+it.
+
+## Tables
+
+| Table | Row | Retention posture |
+| --- | --- | --- |
+| `pi_messages` | one per persisted `pi_core` row | user content — deletion-bound |
+| `tool_calls` | one per tool execution, incl. inner code-mode calls | no content — long retention |
+
+They are deliberately separate. Transcripts are customer content subject to
+deletion requests; operational timings you want to keep for years. One table
+would weld those two policies together.
+
+Schemas live in [`config/pipelines/`](../config/pipelines/). Columns are **flat
+scalars**, which is load-bearing rather than stylistic: Parquet is columnar and
+R2 SQL bills on bytes scanned, so a duration query prunes the fat `text` column
+and reads almost nothing. A single JSON payload column would force every query
+to scan the entire transcript corpus.
+
+`pi_messages.text` is a bounded text projection (100k chars, `text_truncated`
+flags the cut, `text_chars` keeps the true length queryable). It never contains
+image bytes — images are reduced to `image_count`.
+
+## Setup
+
+Nothing exports until the bindings exist; the code no-ops on a missing binding
+exactly like `recordObservabilityEvent` does for a missing Analytics Engine
+dataset. That makes this safe to deploy before the infrastructure is created,
+and safe to leave off in dev, tests, and self-host.
+
+1. Create an R2 API token with **Admin Read & Write**. Pipelines authenticates
+   to the catalog with it, and it also carries R2 SQL Read for querying. It is
+   held by the sink, never by the Worker.
+
+2. Create a stream + sink + pipeline per table, per environment:
+
+   ```bash
+   npx wrangler pipelines setup --name camelai_pi_messages_prod
+   # Stream:   schema from config/pipelines/pi_messages.schema.json
+   #           HTTP endpoint: no (every producer is a Worker binding)
+   # Sink:     Data Catalog (Iceberg), table pi_messages
+   # Pipeline: Simple ingestion (SELECT * FROM stream)
+
+   npx wrangler pipelines setup --name camelai_tool_calls_prod
+   # ... same, schema config/pipelines/tool_calls.schema.json, table tool_calls
+   ```
+
+   Consider `--roll-interval 60` (the minimum) if you want fresher data; the
+   default is 300s. Below 60s Iceberg compaction starts fighting the writes.
+
+3. Add the bindings to the environment's Wrangler config:
+
+   ```jsonc
+   "pipelines": [
+     { "binding": "TRANSCRIPT_LAKE", "stream": "<PI_MESSAGES_STREAM_ID>" },
+     { "binding": "TOOL_CALLS_LAKE", "stream": "<TOOL_CALLS_STREAM_ID>" }
+   ]
+   ```
+
+   Use separate streams per environment, matching the existing
+   `chiridion_observability_prod` / `_staging` dataset convention.
+
+## Delivery semantics
+
+`TranscriptLakeMirror` keeps a high-water mark in DO storage and advances it
+only after the stream accepts the rows, mirroring the `pi_core` → render-history
+backfill in `chat-thread/ui-mirror.ts`. The sync runs after every commit (via
+`waitUntil`, so a slow stream never extends a turn) and again on WebSocket
+connect, which doubles as the repair path for rows lost to an eviction.
+
+That makes the guarantee **at-least-once**, so duplicates are expected. Dedupe
+at read time:
+
+```sql
+SELECT * FROM default.pi_messages
+QUALIFY row_number() OVER (
+  PARTITION BY thread_id, idx ORDER BY ingested_at_ms DESC
+) = 1
+```
+
+`replacePiCoreMessages` (compaction, fork seeding, admin repair) rewrites the
+whole table with a fresh `created_at`; the mirror detects that its anchor row
+changed and re-exports the thread. The lake keeps both versions — the newest
+`ingested_at_ms` wins under the dedupe above, and the older rows remain as an
+audit trail of what the rewrite replaced.
+
+A cold DO holding a long thread backfills its history on first sync, capped at
+500 rows per call and resumed on the next one. Threads that never wake up are
+not exported: a fleet-wide backfill of dormant history should read each thread
+once and write Parquet directly to R2, not stream it (streams cap at 5MB/s).
+
+## Querying
+
+R2 SQL supports `GROUP BY`, `HAVING`, joins, CTEs, window functions, `QUALIFY`,
+and `approx_percentile_cont`. It does **not** support `OFFSET` or `UNNEST`, and
+is read-only.
+
+Slowest real tool calls, excluding tools that block on a human (those measure
+how long the user was away, not how slow we are):
+
+```sql
+SELECT tool_name, surface,
+       approx_percentile_cont(duration_ms, 0.5) AS p50,
+       approx_percentile_cont(duration_ms, 0.99) AS p99,
+       max(duration_ms) AS max_ms,
+       count(*) AS calls
+FROM default.tool_calls
+WHERE ts_ms > <epoch_ms> AND NOT blocks_on_human
+GROUP BY tool_name, surface
+ORDER BY p99 DESC
+LIMIT 25
+```
+
+For bulk transcript reads, do **not** page through R2 SQL — it has no `OFFSET`
+and open-beta query timeouts. R2 Data Catalog is a standard Iceberg REST
+catalog, so point DuckDB or PyIceberg at it and read the Parquet directly.
+
+## Privacy note
+
+`AGENTS.md` requires that observability payloads stay diagnostic and never carry
+chat message contents. **The lake is the deliberate exception**: `pi_messages`
+stores transcript text on purpose, because behavioral analysis is the point.
+That makes access control, retention, and deletion policy decisions rather than
+implementation details:
+
+- The catalog is reachable only with an account R2 token. Treat it as customer
+  data, not telemetry.
+- Iceberg through Pipelines is append-only — there is no row delete. Deletion
+  requests need either a partition rewrite job or a design change that keeps
+  bodies in R2 objects keyed by thread, with the lake holding pointers.
+- `tool_calls` carries no content and is unaffected by any of this, which is the
+  main reason it is a separate table.

--- a/src/lib/runtime-artifacts.ts
+++ b/src/lib/runtime-artifacts.ts
@@ -37,6 +37,15 @@ export interface PiUiMetadata {
    * UI-only — stripPiUiMetadata removes it from model-facing loads.
    */
   renderMessageId?: string;
+  /**
+   * Wall-clock milliseconds the tool took to execute, stamped on toolResult rows
+   * at commit time from the live tool_execution_start/end pair. Pi records no
+   * start timestamp of its own, so without this the duration is unrecoverable
+   * after the fact: an assistant row's `timestamp` is stamped when the model
+   * request opens, making result-minus-previous include model latency.
+   * UI-only — stripPiUiMetadata removes it from model-facing loads.
+   */
+  toolDurationMs?: number;
 }
 
 export function isRuntimeCallArtifact(value: unknown): value is RuntimeCallArtifact {
@@ -69,10 +78,19 @@ export function normalizePiUiMetadata(value: unknown): PiUiMetadata | undefined 
     typeof record.renderMessageId === "string" && record.renderMessageId.trim()
       ? record.renderMessageId.trim()
       : undefined;
-  if (codeModeArtifacts.length === 0 && !renderMessageId) return undefined;
+  const toolDurationMs =
+    typeof record.toolDurationMs === "number" &&
+    Number.isFinite(record.toolDurationMs) &&
+    record.toolDurationMs >= 0
+      ? Math.round(record.toolDurationMs)
+      : undefined;
+  if (codeModeArtifacts.length === 0 && !renderMessageId && toolDurationMs === undefined) {
+    return undefined;
+  }
   return {
     ...(codeModeArtifacts.length > 0 ? { codeModeArtifacts } : {}),
     ...(renderMessageId ? { renderMessageId } : {}),
+    ...(toolDurationMs === undefined ? {} : { toolDurationMs }),
   };
 }
 

--- a/workers/main/src/chat-thread-do.ts
+++ b/workers/main/src/chat-thread-do.ts
@@ -94,6 +94,12 @@ import { planPiTurnResume } from "./pi-turn-journal";
 
 import { recordErrorEvent, recordObservabilityEvent } from "./observability";
 import {
+  boundLakeErrorMessage,
+  sendToolCallRecords,
+  toolBlocksOnHuman,
+} from "./lake-streams";
+import { TranscriptLakeMirror } from "./chat-thread/transcript-lake";
+import {
   BrowserPromptCoordinator,
   type ConnectionSetupResponse,
 } from "./chat-thread-browser-prompts";
@@ -614,6 +620,25 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
   private previewStateInstance?: ChatThreadPreviewState;
   private streamingActivityInstance?: ChatThreadStreamingActivity;
   private threadMetadataInstance?: ChatThreadMetadata;
+  private transcriptLakeInstance?: TranscriptLakeMirror;
+  // Live tool timing. Pi emits tool_execution_start/end but records no start
+  // timestamp on the resulting toolResult message, so duration exists only
+  // between these two events: `piToolStartedAtMs` holds it in flight, and
+  // `piToolDurationMs` carries the settled value forward to the commit that
+  // stamps it onto the persisted row (uiMetadata.toolDurationMs).
+  //
+  // Lazily materialized through prototype getters rather than constructor field
+  // initializers, so the prototype-fake seam these handlers are unit-tested
+  // through (Object.create(ChatThreadDO.prototype)) does not have to enumerate
+  // them to exercise an unrelated event.
+  private piToolStartedAtMsMap?: Map<string, number>;
+  private piToolDurationMsMap?: Map<string, number>;
+  private get piToolStartedAtMs(): Map<string, number> {
+    return (this.piToolStartedAtMsMap ??= new Map<string, number>());
+  }
+  private get piToolDurationMs(): Map<string, number> {
+    return (this.piToolDurationMsMap ??= new Map<string, number>());
+  }
   private lastChatMemoryStoreSnapshotAt = 0;
   private lastChatMemoryPhaseAt = new Map<string, number>();
   private aiChatMemoryBoundariesInstrumented = false;
@@ -1369,6 +1394,10 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       await this.topUpUiMessagesFromPiCore();
       await this.healLegacyUiMessageTimes();
       await this.healLegacyUiMessageAuthors();
+      // Repair path for the lake export: catches rows whose post-commit sync was
+      // lost to an eviction or a stream failure, and backfills threads whose
+      // history predates the export entirely.
+      this.scheduleTranscriptLakeSync();
 
       if (!this.isThreadStreaming() && this.currentTodos.length > 0) {
         // This syncs a completed-todo override; do not overwrite it afterward.
@@ -2596,6 +2625,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       sql: () => this.ctx.storage.sql,
       r2: () => this.env.R2_BUCKET,
       chatContext: () => this.chatContext,
+      takeToolDurationMs: (toolCallId) => this.takePiToolDurationMs(toolCallId),
     }));
   }
 
@@ -3005,13 +3035,46 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     return this.uiMirror.rebuildUiMessagesFromPiCore();
   }
 
-  /** Compatibility seam used by direct pi_core persistence tests. */
-  appendPiCoreMessages(messages: AgentMessage[]): Promise<void> {
-    return this.piCoreStore.appendPiCoreMessages(messages);
+  // Transcript data lake export (pi_core -> Pipelines -> R2 Data Catalog).
+  // Watermark-based and idempotent, so it is safe to fire from every commit.
+  private get transcriptLake(): TranscriptLakeMirror {
+    return (this.transcriptLakeInstance ??= new TranscriptLakeMirror({
+      sql: () => this.ctx.storage.sql,
+      kv: () => this.ctx.storage.kv,
+      chatContext: () => this.chatContext,
+      env: () => this.env,
+      withMemoryPhase: (operation, fn) => this.withChatMemoryPhase(operation, fn),
+      recordChatThreadObservabilityEvent: (event, details) =>
+        this.recordChatThreadObservabilityEvent(event, details),
+    }));
   }
 
-  private appendPiCoreMessagesIfMissing(messages: AgentMessage[]): Promise<void> {
-    return this.piCoreStore.appendPiCoreMessagesIfMissing(messages);
+  /**
+   * Export newly committed pi_core rows. Deliberately fired through waitUntil:
+   * the lake is derived data, so a slow or failing stream must never extend a
+   * turn — the high-water mark simply re-sends the range on the next call.
+   */
+  private scheduleTranscriptLakeSync(): void {
+    // Defensive on both bindings: export is opt-in per environment, and this
+    // runs from connect/commit paths that must never fail because telemetry
+    // plumbing is absent.
+    if (!this.env?.TRANSCRIPT_LAKE || !this.ctx?.waitUntil) return;
+    this.ctx.waitUntil(
+      this.transcriptLake.syncTranscriptLake().catch((error) => {
+        console.error("[ChatThreadDO] transcript lake sync failed", error);
+      }),
+    );
+  }
+
+  /** Compatibility seam used by direct pi_core persistence tests. */
+  async appendPiCoreMessages(messages: AgentMessage[]): Promise<void> {
+    await this.piCoreStore.appendPiCoreMessages(messages);
+    this.scheduleTranscriptLakeSync();
+  }
+
+  private async appendPiCoreMessagesIfMissing(messages: AgentMessage[]): Promise<void> {
+    await this.piCoreStore.appendPiCoreMessagesIfMissing(messages);
+    this.scheduleTranscriptLakeSync();
   }
 
   // --- Durable resume of an interrupted Pi turn (Flue-style journal + reconcile) ---
@@ -5838,6 +5901,56 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     return merged;
   }
 
+  /**
+   * Close out a tool's timing at tool_execution_end: emit the `tool_calls` lake
+   * row and retain the duration so the commit path can stamp it onto the
+   * persisted toolResult row. Returns null when no matching start was seen (a
+   * resumed turn whose start event predates this DO instance), so callers can
+   * omit the field rather than publish a fabricated zero.
+   */
+  private settlePiToolDuration(
+    toolCallId: string,
+    toolName: string,
+    isError: boolean,
+    result: unknown,
+  ): number | null {
+    const startedAtMs = this.piToolStartedAtMs.get(toolCallId);
+    this.piToolStartedAtMs.delete(toolCallId);
+    if (typeof startedAtMs !== "number") return null;
+    const durationMs = Math.max(0, Date.now() - startedAtMs);
+    this.piToolDurationMs.set(toolCallId, durationMs);
+    const context = this.chatContext;
+    sendToolCallRecords(this.env, [{
+      ingested_at_ms: Date.now(),
+      ts_ms: startedAtMs,
+      thread_id: context?.threadId ?? "",
+      org_id: context?.orgId ?? "",
+      workspace_id: context?.workspaceId ?? "",
+      user_id: context?.userId ?? "",
+      turn_id: this.activePiStreamTurnId ?? "",
+      tool_call_id: toolCallId,
+      parent_tool_call_id: "",
+      tool_name: toolName,
+      surface: "agent",
+      model: this.piSession?.state.model?.id ?? "",
+      provider: this.piCurrentUsageProvider ?? "",
+      duration_ms: durationMs,
+      ok: !isError,
+      error_message: isError ? boundLakeErrorMessage(piToolResultText(result)) : "",
+      blocks_on_human: toolBlocksOnHuman(toolName),
+      result_chars: piToolResultText(result).length,
+    }]);
+    return durationMs;
+  }
+
+  /** Duration measured for a settled tool call, consumed at commit time. */
+  private takePiToolDurationMs(toolCallId: string): number | undefined {
+    const durationMs = this.piToolDurationMs.get(toolCallId);
+    if (durationMs === undefined) return undefined;
+    this.piToolDurationMs.delete(toolCallId);
+    return durationMs;
+  }
+
   private async handlePiSessionEvent(event: AgentEvent): Promise<void> {
     this.touchPiTurnProgress();
     if (event.type === "agent_start") {
@@ -5846,6 +5959,11 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       this.piActiveItemId = null;
       this.piReasoningItemId = null;
       this.piToolArgs = new Map();
+      // In-flight timings must not outlive the run that opened them: a tool
+      // whose end event never arrived would otherwise attach its stale start to
+      // a later call that reuses the id.
+      this.piToolStartedAtMs.clear();
+      this.piToolDurationMs.clear();
       this.piToolFailures = new Map();
       this.piToolFailureRecordedCallIds = new Set();
       this.piAgentStartedAtMs = Date.now();
@@ -6057,6 +6175,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     if (event.type === "tool_execution_start") {
       const toolCallId = event.toolCallId || `pi_tool_${crypto.randomUUID()}`;
       const toolName = event.toolName || "tool";
+      this.piToolStartedAtMs.set(toolCallId, Date.now());
       const args = this.rememberPiToolArgs(toolCallId, piEventArgs(event.args));
       this.publishPiToolActivity(toolCallId, toolName, args, "running");
       this.pushPiRuntimeEvent("item/started", {
@@ -6091,6 +6210,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
         result: event.result,
         isError,
       });
+      const durationMs = this.settlePiToolDuration(toolCallId, toolName, isError, event.result);
       const status = isError ? "failed" : "completed";
       const item: Record<string, unknown> = {
         id: toolCallId,
@@ -6100,6 +6220,10 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
         status,
         isError,
         result: event.result,
+        // The UIMessage encoder already forwards this onto the tool part
+        // (pi-chunk-encoder's tool-output-available), so tool cards get a real
+        // duration as soon as it is measured here.
+        ...(durationMs === null ? {} : { durationMs }),
       };
       const contentItems = piRuntimeContentItems(event.result);
       if (contentItems.length > 0) {

--- a/workers/main/src/chat-thread/pi-core-store.ts
+++ b/workers/main/src/chat-thread/pi-core-store.ts
@@ -28,6 +28,7 @@ import type {
   PiSqlStorageSerialization,
 } from "../pi-message-storage";
 import { piTextBytes, piCoreMessageKey } from "./pi-message-helpers";
+import { normalizePiUiMetadata } from "../../../../src/lib/runtime-artifacts";
 import { createPiSummaryMessage } from "./pi-compaction";
 import { buildWorkspaceScopedR2Key } from "../../../../src/lib/workspace-r2-paths";
 import type { ChatContextState } from "./types";
@@ -58,6 +59,12 @@ export interface PiCoreMessageStoreDeps {
   chatContext(): ChatContextState | null;
   /** Privacy-safe allocation counters used by focused tests and diagnostics. */
   recordReadOperation?(operation: "payload_row_parsed" | "r2_image_hydrated"): void;
+  /**
+   * Wall-clock duration measured for a settled tool call, consumed once as its
+   * toolResult row is committed. Optional so tests and non-agent callers can
+   * construct the store without a timing source.
+   */
+  takeToolDurationMs?(toolCallId: string): number | undefined;
 }
 
 export class PiCoreMessageStore {
@@ -497,6 +504,32 @@ export class PiCoreMessageStore {
     ];
   }
 
+  /**
+   * Stamp a toolResult row with the wall-clock duration measured live between
+   * its tool_execution_start/end pair. Pi persists no start timestamp, and an
+   * assistant row's `timestamp` marks when the model request opened, so a
+   * duration derived after the fact from adjacent message timestamps would
+   * silently include model latency. Recording it at commit time is the only
+   * point where the real value is still known. UI-only metadata:
+   * sanitizePiModelMessage strips it before anything reaches the provider.
+   */
+  private stampPiToolDuration(message: AgentMessage): AgentMessage {
+    const take = this.deps.takeToolDurationMs;
+    if (!take) return message;
+    const record = message as unknown as Record<string, unknown>;
+    if (record.role !== "toolResult") return message;
+    const toolCallId =
+      typeof record.toolCallId === "string" ? record.toolCallId.trim() : "";
+    if (!toolCallId) return message;
+    const durationMs = take.call(this.deps, toolCallId);
+    if (typeof durationMs !== "number") return message;
+    const existing = normalizePiUiMetadata(record.uiMetadata);
+    return {
+      ...record,
+      uiMetadata: { ...existing, toolDurationMs: durationMs },
+    } as unknown as AgentMessage;
+  }
+
   async appendPiCoreMessages(messages: AgentMessage[]): Promise<void> {
     if (messages.length === 0) return;
     this.ensurePiCoreTables();
@@ -509,7 +542,7 @@ export class PiCoreMessageStore {
     const startIndex = Math.max(0, Math.floor(Number(rows[0]?.next_idx) || 0));
     const now = Date.now();
     for (let offset = 0; offset < messages.length; offset += 1) {
-      const message = messages[offset];
+      const message = this.stampPiToolDuration(messages[offset]);
       const serialized = await this.serializePiMessageForSqlStorageDetailed(message);
       this.deps.sql().exec(
         "INSERT INTO pi_core_messages (idx, payload, created_at) VALUES (?, ?, ?)",

--- a/workers/main/src/chat-thread/transcript-lake.ts
+++ b/workers/main/src/chat-thread/transcript-lake.ts
@@ -1,0 +1,242 @@
+// pi_core → transcript data lake mirror.
+//
+// Streams every persisted pi_core row to the `pi_messages` Iceberg table so
+// fleet-wide transcript questions become one SQL query instead of one Durable
+// Object wakeup per thread. (Reading ONE transcript stays faster through the
+// admin API — this exists for bulk and predicate-selected reads.)
+//
+// Durability model mirrors the pi_core → ai-chat render-history backfill in
+// ./ui-mirror: a high-water mark in DO storage, advanced only after the stream
+// accepts the rows. A failed or dropped send simply leaves the mark behind, and
+// the next sync (post-append, or on the next WebSocket connect) re-sends the
+// same range. That makes at-least-once the guarantee and duplicates expected;
+// readers dedupe on (thread_id, idx) keeping the newest ingested_at_ms.
+import {
+  boundLakeErrorMessage,
+  sendPiMessageRecords,
+  truncateForLake,
+  type LakeStreamEnv,
+  type PiMessageLakeRecord,
+} from "../lake-streams";
+import { normalizePiUiMetadata } from "../../../../src/lib/runtime-artifacts";
+import type { ChatContextState } from "./types";
+
+/** Next pi_core idx to export. */
+const TRANSCRIPT_LAKE_MARK_KEY = "transcriptLakeSyncedIdx";
+/**
+ * `created_at` of the last exported row. replacePiCoreMessages (compaction,
+ * fork seeding, admin repair) rewrites the whole table with a fresh timestamp,
+ * so a mismatch here is the rewrite signal that forces a full re-export.
+ */
+const TRANSCRIPT_LAKE_MARK_STAMP_KEY = "transcriptLakeSyncedCreatedAtMs";
+
+/**
+ * Rows exported per sync call. A cold DO holding a long thread backfills its
+ * whole history on first sync; capping the batch keeps that off a turn's
+ * critical path, and the watermark makes the remainder resumable on the next
+ * call rather than lost.
+ */
+const TRANSCRIPT_LAKE_MAX_ROWS_PER_SYNC = 500;
+
+export interface TranscriptLakeDeps {
+  sql(): SqlStorage;
+  kv(): {
+    get<T>(key: string): T | undefined;
+    put(key: string, value: unknown): void;
+  };
+  chatContext(): ChatContextState | null;
+  env(): LakeStreamEnv;
+  withMemoryPhase<T>(operation: string, fn: () => Promise<T>): Promise<T>;
+  recordChatThreadObservabilityEvent(
+    event: string,
+    details?: Record<string, unknown>,
+  ): void;
+}
+
+interface PiCoreRow extends Record<string, SqlStorageValue> {
+  idx: number;
+  payload: string;
+  created_at: number;
+}
+
+/** Text projection of a pi message. Never carries image bytes. */
+export function projectPiContentForLake(content: unknown): {
+  text: string;
+  imageCount: number;
+} {
+  if (typeof content === "string") return { text: content, imageCount: 0 };
+  if (!Array.isArray(content)) return { text: "", imageCount: 0 };
+  const parts: string[] = [];
+  let imageCount = 0;
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const item = block as Record<string, unknown>;
+    if (item.type === "text" && typeof item.text === "string") {
+      parts.push(item.text);
+    } else if (item.type === "thinking" && typeof item.thinking === "string") {
+      parts.push(item.thinking);
+    } else if (item.type === "image") {
+      // Deliberately drops `data`: image bytes would dominate the table and are
+      // useless to SQL. The count keeps their presence queryable.
+      imageCount += 1;
+    } else if (item.type === "toolCall") {
+      const name = typeof item.name === "string" ? item.name : "tool";
+      parts.push(`[toolCall:${name}]`);
+    }
+  }
+  return { text: parts.join("\n"), imageCount };
+}
+
+export function piCoreRowToLakeRecord(
+  row: PiCoreRow,
+  context: {
+    threadId: string;
+    orgId: string;
+    workspaceId: string;
+    userId: string;
+  },
+  ingestedAtMs: number,
+): PiMessageLakeRecord | null {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(row.payload) as Record<string, unknown>;
+  } catch {
+    // A corrupt row must not wedge the mark behind it forever; skipping matches
+    // how loadPiCoreMessages tolerates unparseable history.
+    return null;
+  }
+  const role = typeof parsed.role === "string" ? parsed.role : "";
+  if (!role) return null;
+  const projected = projectPiContentForLake(parsed.content);
+  const bounded = truncateForLake(projected.text);
+  const uiMetadata = normalizePiUiMetadata(parsed.uiMetadata);
+  const timestamp =
+    typeof parsed.timestamp === "number" && Number.isFinite(parsed.timestamp)
+      ? Math.floor(parsed.timestamp)
+      : row.created_at;
+  return {
+    ingested_at_ms: ingestedAtMs,
+    ts_ms: timestamp,
+    thread_id: context.threadId,
+    org_id: context.orgId,
+    workspace_id: context.workspaceId,
+    user_id: context.userId,
+    idx: row.idx,
+    role,
+    render_message_id: uiMetadata?.renderMessageId ?? "",
+    tool_name: typeof parsed.toolName === "string" ? parsed.toolName : "",
+    tool_call_id: typeof parsed.toolCallId === "string" ? parsed.toolCallId : "",
+    tool_is_error: parsed.isError === true,
+    tool_duration_ms: uiMetadata?.toolDurationMs ?? -1,
+    model: typeof parsed.model === "string" ? parsed.model : "",
+    provider: typeof parsed.provider === "string" ? parsed.provider : "",
+    stop_reason: typeof parsed.stopReason === "string" ? parsed.stopReason : "",
+    text: bounded.text,
+    text_chars: bounded.chars,
+    text_truncated: bounded.truncated,
+    image_count: projected.imageCount,
+  };
+}
+
+export class TranscriptLakeMirror {
+  constructor(private readonly deps: TranscriptLakeDeps) {}
+
+  /**
+   * Export pi_core rows at or beyond the high-water mark. Safe to call on every
+   * append and on connect: with no new rows (or no configured binding) it costs
+   * one scalar read and returns.
+   */
+  async syncTranscriptLake(options: { force?: boolean } = {}): Promise<void> {
+    if (!this.deps.env().TRANSCRIPT_LAKE) return;
+    const context = this.deps.chatContext();
+    const threadId = context?.threadId ?? "";
+    if (!threadId) return;
+
+    const startedAt = Date.now();
+    const rows = await this.deps.withMemoryPhase("transcript_lake_read", async () =>
+      this.readPendingRows(options.force === true),
+    );
+    if (rows.length === 0) return;
+
+    const ingestedAtMs = Date.now();
+    const records: PiMessageLakeRecord[] = [];
+    for (const row of rows) {
+      const record = piCoreRowToLakeRecord(
+        row,
+        {
+          threadId,
+          orgId: context?.orgId ?? "",
+          workspaceId: context?.workspaceId ?? "",
+          userId: context?.userId ?? "",
+        },
+        ingestedAtMs,
+      );
+      if (record) records.push(record);
+    }
+
+    const lastRow = rows[rows.length - 1];
+    const sent = records.length === 0
+      ? true // every row in the range was unparseable; advance past them
+      : await sendPiMessageRecords(this.deps.env(), records);
+    if (!sent) {
+      // Mark stays put: the same range re-sends on the next sync.
+      this.deps.recordChatThreadObservabilityEvent("transcript_lake_sync", {
+        operation: "transcript_lake_sync",
+        status: "send_failed",
+        severity: "warn",
+        count: records.length,
+        durationMs: Date.now() - startedAt,
+      });
+      return;
+    }
+
+    this.deps.kv().put(TRANSCRIPT_LAKE_MARK_KEY, lastRow.idx + 1);
+    this.deps.kv().put(TRANSCRIPT_LAKE_MARK_STAMP_KEY, lastRow.created_at);
+    this.deps.recordChatThreadObservabilityEvent("transcript_lake_sync", {
+      operation: "transcript_lake_sync",
+      status: "ok",
+      count: records.length,
+      durationMs: Date.now() - startedAt,
+    });
+  }
+
+  private readPendingRows(force: boolean): Promise<PiCoreRow[]> {
+    const mark = force ? 0 : this.readValidatedMark();
+    const rows = this.deps.sql()
+      .exec<PiCoreRow>(
+        `SELECT idx, payload, created_at FROM pi_core_messages
+         WHERE idx >= ? ORDER BY idx ASC LIMIT ?`,
+        mark,
+        TRANSCRIPT_LAKE_MAX_ROWS_PER_SYNC,
+      )
+      .toArray();
+    return Promise.resolve(rows);
+  }
+
+  /**
+   * The stored mark, or 0 when the row it was taken against no longer matches —
+   * i.e. replacePiCoreMessages rewrote history underneath us and the whole
+   * thread needs re-exporting.
+   */
+  private readValidatedMark(): number {
+    const mark = this.deps.kv().get<number>(TRANSCRIPT_LAKE_MARK_KEY) ?? 0;
+    if (mark <= 0) return 0;
+    const stamp = this.deps.kv().get<number>(TRANSCRIPT_LAKE_MARK_STAMP_KEY);
+    if (typeof stamp !== "number") return 0;
+    const row = this.deps.sql()
+      .exec<{ created_at: number }>(
+        "SELECT created_at FROM pi_core_messages WHERE idx = ?",
+        mark - 1,
+      )
+      .toArray()[0];
+    if (!row || row.created_at !== stamp) return 0;
+    return mark;
+  }
+}
+
+export const __testing = {
+  TRANSCRIPT_LAKE_MARK_KEY,
+  TRANSCRIPT_LAKE_MARK_STAMP_KEY,
+  TRANSCRIPT_LAKE_MAX_ROWS_PER_SYNC,
+  boundLakeErrorMessage,
+};

--- a/workers/main/src/chat-thread/types.ts
+++ b/workers/main/src/chat-thread/types.ts
@@ -10,6 +10,11 @@
 // exists to keep the DO file smaller.
 
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type {
+  LakeStream,
+  PiMessageLakeRecord,
+  ToolCallLakeRecord,
+} from "../lake-streams";
 import type { OrgDO, UserDO } from "../auth";
 import type { WorkspaceDO } from "../workspace";
 import type { WorkspaceCronDO } from "../workspace-cron";
@@ -140,6 +145,10 @@ export interface ChatEnv extends WorkspaceFilesystemEnv {
   CODE_MODE_LOADER?: WorkerLoader;
   OBSERVABILITY_EVENTS?: AnalyticsEngineDataset;
   ERROR_ANALYTICS?: AnalyticsEngineDataset;
+  // Transcript data lake streams (Cloudflare Pipelines -> R2 Data Catalog).
+  // Optional everywhere: absent bindings disable export, they never fail a turn.
+  TRANSCRIPT_LAKE?: LakeStream<PiMessageLakeRecord>;
+  TOOL_CALLS_LAKE?: LakeStream<ToolCallLakeRecord>;
   CF_ZONE_ID?: string;
   CF_API_TOKEN?: string;
   CF_CUSTOM_HOSTNAME_FALLBACK?: string;

--- a/workers/main/src/code-mode-tools.ts
+++ b/workers/main/src/code-mode-tools.ts
@@ -24,6 +24,11 @@ import { PiContainerTools, PI_CONTAINER_TOOL_DEFINITIONS } from "./pi-container-
 import { parseFilePreviewPath } from "./preview-paths";
 import type { ConnectionSetupResponse } from "./chat-thread-browser-prompts";
 import { CodeModeWebSearch } from "./code-mode-web-search";
+import {
+  boundLakeErrorMessage,
+  sendToolCallRecords,
+  toolBlocksOnHuman,
+} from "./lake-streams";
 import type { HostedCapability } from "../../../src/lib/capability-allowances";
 import { buildWorkspaceScopedR2Key } from "../../../src/lib/workspace-r2-paths";
 import { retryR2Read } from "../../../src/lib/r2-read-retry";
@@ -78,6 +83,21 @@ export interface AIVirtualBindingProps {
   orgId: string;
   workspaceId: string;
   userId?: string;
+}
+
+/**
+ * Size of a tool result for telemetry only. Never throws and never retains the
+ * serialized copy: an unserializable or oversized result reports 0 rather than
+ * failing the tool call it is measuring.
+ */
+function measureResultChars(value: unknown): number {
+  if (value === undefined || value === null) return 0;
+  if (typeof value === "string") return value.length;
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return 0;
+  }
 }
 
 function simplifyAgentWebToolResult(name: string, value: unknown): unknown {
@@ -2706,11 +2726,19 @@ export class CodeModeToolsBinding extends WorkerEntrypoint<ChatEnv, CodeModeTool
     | { ok: true; data: unknown }
     | { ok: false; error: { tool: string; message: string; origin: "tool" } }
   > {
+    // Inner code-mode calls never produce a pi_core row: to the transcript the
+    // whole script is one opaque `js_exec`, which in production is ~35% of all
+    // tool calls and hides every build, deploy, notebook and DB timing inside
+    // it. Timing them here is the only place those durations are observable.
+    const startedAtMs = Date.now();
     try {
       const result = await this.callTool(name, rawArgs);
-      return { ok: true, data: simplifyAgentWebToolResult(name, result) };
+      const data = simplifyAgentWebToolResult(name, result);
+      this.recordCodeModeToolCall(name, startedAtMs, true, "", data);
+      return { ok: true, data };
     } catch (error) {
       const message = error instanceof Error && error.message ? error.message : String(error);
+      this.recordCodeModeToolCall(name, startedAtMs, false, message, undefined);
       const props = this.ctx?.props;
       if (name === "build_project" || name === "deploy_project") {
         console.error("[code-mode] project tool call failed", {
@@ -2734,6 +2762,37 @@ export class CodeModeToolsBinding extends WorkerEntrypoint<ChatEnv, CodeModeTool
       }
       return { ok: false, error: { tool: name, message, origin: "tool" } };
     }
+  }
+
+  /** Emit one `tool_calls` lake row for a call made from inside js_exec. */
+  private recordCodeModeToolCall(
+    toolName: string,
+    startedAtMs: number,
+    ok: boolean,
+    errorMessage: string,
+    result: unknown,
+  ): void {
+    const props = this.ctx?.props;
+    sendToolCallRecords(this.env, [{
+      ingested_at_ms: Date.now(),
+      ts_ms: startedAtMs,
+      thread_id: props?.threadId ?? "",
+      org_id: props?.orgId ?? "",
+      workspace_id: props?.workspaceId ?? "",
+      user_id: props?.userId ?? "",
+      turn_id: "",
+      tool_call_id: crypto.randomUUID(),
+      parent_tool_call_id: props?.parentToolUseId ?? "",
+      tool_name: toolName,
+      surface: "code_mode",
+      model: "",
+      provider: "",
+      duration_ms: Math.max(0, Date.now() - startedAtMs),
+      ok,
+      error_message: ok ? "" : boundLakeErrorMessage(errorMessage),
+      blocks_on_human: toolBlocksOnHuman(toolName),
+      result_chars: measureResultChars(result),
+    }]);
   }
 
   async callTool(name: string, rawArgs: unknown = {}): Promise<unknown> {

--- a/workers/main/src/lake-streams.ts
+++ b/workers/main/src/lake-streams.ts
@@ -1,7 +1,7 @@
 // Cloudflare Pipelines stream bindings for the transcript data lake.
 //
 // Two narrow, FLAT record shapes are sent here and land as Apache Iceberg
-// tables in R2 Data Catalog (see docs/transcript-lake.md):
+// tables in R2 Data Catalog (see config/pipelines/README.md):
 //
 //   pi_messages  - one row per persisted pi_core row (the transcript itself)
 //   tool_calls   - one row per tool execution, including the inner code-mode

--- a/workers/main/src/lake-streams.ts
+++ b/workers/main/src/lake-streams.ts
@@ -1,0 +1,174 @@
+// Cloudflare Pipelines stream bindings for the transcript data lake.
+//
+// Two narrow, FLAT record shapes are sent here and land as Apache Iceberg
+// tables in R2 Data Catalog (see docs/transcript-lake.md):
+//
+//   pi_messages  - one row per persisted pi_core row (the transcript itself)
+//   tool_calls   - one row per tool execution, including the inner code-mode
+//                  calls that js_exec makes and that never reach pi_core
+//
+// Flatness is load-bearing, not stylistic. Parquet is columnar, and R2 SQL
+// bills on bytes scanned: with real columns a duration/percentile query prunes
+// the fat `text` column and reads almost nothing, whereas a single JSON payload
+// column would force every query to scan the entire transcript corpus.
+//
+// Both bindings are OPTIONAL. Local dev, `vitest`, and any environment whose
+// Wrangler config omits the binding simply do not export — every helper here
+// no-ops on a missing binding exactly like recordObservabilityEvent does for a
+// missing Analytics Engine dataset.
+import { waitUntil } from "cloudflare:workers";
+
+/**
+ * Structural shape of a Pipelines stream binding. Declared locally rather than
+ * imported from `cloudflare:pipelines` so the worker still typechecks in
+ * environments that have not configured (and therefore not code-generated) the
+ * binding, and so tests can inject a plain fake.
+ */
+export interface LakeStream<TRecord> {
+  send(records: TRecord[]): Promise<void>;
+}
+
+export interface LakeStreamEnv {
+  TRANSCRIPT_LAKE?: LakeStream<PiMessageLakeRecord>;
+  TOOL_CALLS_LAKE?: LakeStream<ToolCallLakeRecord>;
+}
+
+/** One row per persisted pi_core message. */
+export interface PiMessageLakeRecord {
+  ingested_at_ms: number;
+  ts_ms: number;
+  thread_id: string;
+  org_id: string;
+  workspace_id: string;
+  user_id: string;
+  idx: number;
+  role: string;
+  render_message_id: string;
+  tool_name: string;
+  tool_call_id: string;
+  tool_is_error: boolean;
+  /** -1 when unknown (pi records no start time; see PiUiMetadata.toolDurationMs). */
+  tool_duration_ms: number;
+  model: string;
+  provider: string;
+  stop_reason: string;
+  /** Bounded text projection. Never contains image bytes. */
+  text: string;
+  /** Full character count before truncation, so truncation is visible in SQL. */
+  text_chars: number;
+  text_truncated: boolean;
+  image_count: number;
+}
+
+/** One row per tool execution. Carries no message content. */
+export interface ToolCallLakeRecord {
+  ingested_at_ms: number;
+  ts_ms: number;
+  thread_id: string;
+  org_id: string;
+  workspace_id: string;
+  user_id: string;
+  turn_id: string;
+  tool_call_id: string;
+  /** Set for calls js_exec makes through the code-mode binding; "" at top level. */
+  parent_tool_call_id: string;
+  tool_name: string;
+  /** "agent" for model-visible calls, "code_mode" for inner js_exec calls. */
+  surface: string;
+  model: string;
+  provider: string;
+  duration_ms: number;
+  ok: boolean;
+  error_message: string;
+  /**
+   * True for tools that block on a human answering. These dominate any naive
+   * "slowest tool" ranking while measuring nothing but how long the user was
+   * away, so ranking queries filter on this rather than hardcoding names.
+   */
+  blocks_on_human: boolean;
+  result_chars: number;
+}
+
+/**
+ * Tools whose duration is bounded by a human, not by our systems.
+ * Keep in sync with the blocking tool surface in pi-tools.ts.
+ */
+const HUMAN_BLOCKING_TOOLS = new Set([
+  "AskUserQuestion",
+  "ask_user_question",
+  "prompt_connection_setup",
+]);
+
+export function toolBlocksOnHuman(toolName: string): boolean {
+  return HUMAN_BLOCKING_TOOLS.has(toolName);
+}
+
+/** Bound on a single `text` projection; longer content is truncated and flagged. */
+export const LAKE_TEXT_MAX_CHARS = 100_000;
+
+/**
+ * Records per send(). Streams cap an ingestion request at 5MB; batching well
+ * under that keeps a single fat transcript row from rejecting a whole batch.
+ */
+const LAKE_SEND_BATCH_SIZE = 50;
+
+export function truncateForLake(text: string): {
+  text: string;
+  chars: number;
+  truncated: boolean;
+} {
+  const chars = text.length;
+  if (chars <= LAKE_TEXT_MAX_CHARS) return { text, chars, truncated: false };
+  return { text: text.slice(0, LAKE_TEXT_MAX_CHARS), chars, truncated: true };
+}
+
+export function boundLakeErrorMessage(message: string): string {
+  return message.length > 512 ? `${message.slice(0, 512)}…` : message;
+}
+
+async function sendInBatches<TRecord>(
+  stream: LakeStream<TRecord>,
+  records: TRecord[],
+): Promise<void> {
+  for (let offset = 0; offset < records.length; offset += LAKE_SEND_BATCH_SIZE) {
+    await stream.send(records.slice(offset, offset + LAKE_SEND_BATCH_SIZE));
+  }
+}
+
+/**
+ * Await-able send used by the transcript mirror, whose high-water mark may only
+ * advance once the rows are durably accepted. Resolves false on any failure so
+ * the caller leaves the mark where it is and retries the same range later.
+ */
+export async function sendPiMessageRecords(
+  env: LakeStreamEnv | undefined,
+  records: PiMessageLakeRecord[],
+): Promise<boolean> {
+  const stream = env?.TRANSCRIPT_LAKE;
+  if (!stream || records.length === 0) return false;
+  try {
+    await sendInBatches(stream, records);
+    return true;
+  } catch (error) {
+    console.error("[lake] transcript stream send failed", error);
+    return false;
+  }
+}
+
+/**
+ * Fire-and-forget send for tool-call telemetry. Unlike the transcript rows these
+ * are derived data with no watermark behind them: a dropped batch costs one
+ * turn's timing rows, never transcript history, so it must not delay a turn.
+ */
+export function sendToolCallRecords(
+  env: LakeStreamEnv | undefined,
+  records: ToolCallLakeRecord[],
+): void {
+  const stream = env?.TOOL_CALLS_LAKE;
+  if (!stream || records.length === 0) return;
+  waitUntil(
+    sendInBatches(stream, records).catch((error) => {
+      console.error("[lake] tool-call stream send failed", error);
+    }),
+  );
+}

--- a/workers/main/src/types.ts
+++ b/workers/main/src/types.ts
@@ -2,6 +2,11 @@
  * Shared types and constants for the main worker
  */
 
+import type {
+  LakeStream,
+  PiMessageLakeRecord,
+  ToolCallLakeRecord,
+} from "./lake-streams.js";
 import type { ChatEnv } from "./chat-thread-do.js";
 import type { DOEnv } from "./auth.js";
 import type { DataProxyEnv } from "./data-proxy.js";
@@ -69,6 +74,10 @@ export interface Env
   SESSIONS: KVNamespace;
   OBSERVABILITY_EVENTS?: AnalyticsEngineDataset;
   ERROR_ANALYTICS?: AnalyticsEngineDataset;
+  // Transcript data lake streams (Cloudflare Pipelines -> R2 Data Catalog).
+  // Optional everywhere: absent bindings disable export, they never fail a turn.
+  TRANSCRIPT_LAKE?: LakeStream<PiMessageLakeRecord>;
+  TOOL_CALLS_LAKE?: LakeStream<ToolCallLakeRecord>;
   APP_SCREENSHOT_QUEUE?: Queue<AppScreenshotJob>;
   SLACK_EVENTS_QUEUE?: Queue<SlackEventQueueMessage>;
   BROWSER?: Fetcher;

--- a/workers/main/tests/transcript-lake.test.ts
+++ b/workers/main/tests/transcript-lake.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  TranscriptLakeMirror,
+  piCoreRowToLakeRecord,
+  projectPiContentForLake,
+  __testing,
+} from '../src/chat-thread/transcript-lake';
+import { LAKE_TEXT_MAX_CHARS, type PiMessageLakeRecord } from '../src/lake-streams';
+import { PiCoreMessageStore } from '../src/chat-thread/pi-core-store';
+
+const CONTEXT = {
+  threadId: 'thread-1',
+  workspaceId: 'workspace-1',
+  orgId: 'org-1',
+  userId: 'user-1',
+  userName: null,
+  userEmail: null,
+};
+
+interface FakeRow {
+  idx: number;
+  payload: string;
+  created_at: number;
+}
+
+function createMirrorHarness(
+  rows: FakeRow[],
+  options: { send?: (records: PiMessageLakeRecord[]) => Promise<void>; withBinding?: boolean } = {},
+) {
+  const kvStore = new Map<string, unknown>();
+  const sent: PiMessageLakeRecord[][] = [];
+  const send = options.send
+    ?? (async (records: PiMessageLakeRecord[]) => {
+      sent.push(records);
+    });
+  const exec = vi.fn((sql: string, ...args: unknown[]) => {
+    if (sql.includes('WHERE idx >= ?')) {
+      const [mark, limit] = args as [number, number];
+      return { toArray: () => rows.filter((row) => row.idx >= mark).slice(0, limit) };
+    }
+    if (sql.includes('WHERE idx = ?')) {
+      const [idx] = args as [number];
+      const row = rows.find((candidate) => candidate.idx === idx);
+      return { toArray: () => (row ? [{ created_at: row.created_at }] : []) };
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  });
+  const mirror = new TranscriptLakeMirror({
+    sql: () => ({ exec }) as never,
+    kv: () => ({
+      get: <T>(key: string) => kvStore.get(key) as T | undefined,
+      put: (key: string, value: unknown) => {
+        kvStore.set(key, value);
+      },
+    }),
+    chatContext: () => CONTEXT,
+    env: () => (options.withBinding === false ? {} : { TRANSCRIPT_LAKE: { send } }),
+    withMemoryPhase: (_operation, fn) => fn(),
+    recordChatThreadObservabilityEvent: () => {},
+  });
+  return { mirror, sent, kvStore, exec };
+}
+
+function userRow(idx: number, text: string, createdAt = 1_000 + idx): FakeRow {
+  return {
+    idx,
+    payload: JSON.stringify({ role: 'user', content: text, timestamp: createdAt }),
+    created_at: createdAt,
+  };
+}
+
+describe('projectPiContentForLake', () => {
+  it('keeps text and thinking but never image bytes', () => {
+    const projected = projectPiContentForLake([
+      { type: 'text', text: 'hello' },
+      { type: 'thinking', thinking: 'pondering' },
+      { type: 'image', mimeType: 'image/png', data: 'AAAABBBBCCCC-image-bytes' },
+      { type: 'toolCall', name: 'deploy_project', id: 'call-1' },
+    ]);
+    expect(projected.text).toBe('hello\npondering\n[toolCall:deploy_project]');
+    expect(projected.text).not.toContain('image-bytes');
+    expect(projected.imageCount).toBe(1);
+  });
+
+  it('passes plain string content through', () => {
+    expect(projectPiContentForLake('just text')).toEqual({ text: 'just text', imageCount: 0 });
+  });
+});
+
+describe('piCoreRowToLakeRecord', () => {
+  it('surfaces the stamped tool duration and tool identity as flat columns', () => {
+    const row: FakeRow = {
+      idx: 7,
+      created_at: 5_000,
+      payload: JSON.stringify({
+        role: 'toolResult',
+        toolCallId: 'call-9',
+        toolName: 'deploy_project',
+        isError: true,
+        timestamp: 4_900,
+        content: [{ type: 'text', text: 'boom' }],
+        uiMetadata: { toolDurationMs: 1234, renderMessageId: 'turn-1' },
+      }),
+    };
+    const record = piCoreRowToLakeRecord(row, CONTEXT, 9_999);
+    expect(record).toMatchObject({
+      idx: 7,
+      role: 'toolResult',
+      tool_name: 'deploy_project',
+      tool_call_id: 'call-9',
+      tool_is_error: true,
+      tool_duration_ms: 1234,
+      render_message_id: 'turn-1',
+      ts_ms: 4_900,
+      ingested_at_ms: 9_999,
+      thread_id: 'thread-1',
+      org_id: 'org-1',
+      text: 'boom',
+    });
+  });
+
+  it('reports -1 rather than 0 when no duration was measured', () => {
+    const record = piCoreRowToLakeRecord(userRow(0, 'hi'), CONTEXT, 1);
+    expect(record?.tool_duration_ms).toBe(-1);
+  });
+
+  it('truncates oversized text but keeps the true length queryable', () => {
+    const long = 'x'.repeat(LAKE_TEXT_MAX_CHARS + 500);
+    const record = piCoreRowToLakeRecord(userRow(0, long), CONTEXT, 1);
+    expect(record?.text).toHaveLength(LAKE_TEXT_MAX_CHARS);
+    expect(record?.text_chars).toBe(LAKE_TEXT_MAX_CHARS + 500);
+    expect(record?.text_truncated).toBe(true);
+  });
+
+  it('skips corrupt rows instead of failing the batch', () => {
+    expect(piCoreRowToLakeRecord({ idx: 0, payload: 'not json', created_at: 1 }, CONTEXT, 1))
+      .toBeNull();
+  });
+});
+
+describe('TranscriptLakeMirror', () => {
+  it('does nothing when no stream binding is configured', async () => {
+    const harness = createMirrorHarness([userRow(0, 'hi')], { withBinding: false });
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.sent).toHaveLength(0);
+    expect(harness.exec).not.toHaveBeenCalled();
+  });
+
+  it('exports pending rows once and advances the high-water mark', async () => {
+    const harness = createMirrorHarness([userRow(0, 'one'), userRow(1, 'two')]);
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.sent.flat().map((record) => record.idx)).toEqual([0, 1]);
+    expect(harness.kvStore.get(__testing.TRANSCRIPT_LAKE_MARK_KEY)).toBe(2);
+
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.sent.flat()).toHaveLength(2);
+  });
+
+  it('leaves the mark behind on a failed send so the range re-sends', async () => {
+    let fail = true;
+    const harness = createMirrorHarness([userRow(0, 'one')], {
+      send: async () => {
+        if (fail) throw new Error('stream unavailable');
+      },
+    });
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.kvStore.get(__testing.TRANSCRIPT_LAKE_MARK_KEY)).toBeUndefined();
+
+    fail = false;
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.kvStore.get(__testing.TRANSCRIPT_LAKE_MARK_KEY)).toBe(1);
+  });
+
+  it('re-exports the whole thread when pi_core history was rewritten underneath it', async () => {
+    const rows = [userRow(0, 'one', 1_000), userRow(1, 'two', 1_001)];
+    const harness = createMirrorHarness(rows);
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.kvStore.get(__testing.TRANSCRIPT_LAKE_MARK_KEY)).toBe(2);
+
+    // replacePiCoreMessages (compaction / fork / admin repair) rewrites every
+    // row with a fresh created_at, invalidating the mark's anchor row.
+    rows.splice(0, rows.length, userRow(0, 'compacted', 7_000), userRow(1, 'two', 7_000));
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.sent[1].map((record) => record.idx)).toEqual([0, 1]);
+    expect(harness.sent[1][0].text).toBe('compacted');
+  });
+
+  it('caps a single sync so a long backfill stays resumable', async () => {
+    const rows = Array.from(
+      { length: __testing.TRANSCRIPT_LAKE_MAX_ROWS_PER_SYNC + 10 },
+      (_row, idx) => userRow(idx, `m${idx}`),
+    );
+    const harness = createMirrorHarness(rows);
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.sent.flat()).toHaveLength(__testing.TRANSCRIPT_LAKE_MAX_ROWS_PER_SYNC);
+    expect(harness.kvStore.get(__testing.TRANSCRIPT_LAKE_MARK_KEY))
+      .toBe(__testing.TRANSCRIPT_LAKE_MAX_ROWS_PER_SYNC);
+
+    await harness.mirror.syncTranscriptLake();
+    expect(harness.sent.flat()).toHaveLength(rows.length);
+  });
+});
+
+describe('PiCoreMessageStore tool duration stamping', () => {
+  function createAppendHarness(durations: Map<string, number>) {
+    const inserted: string[] = [];
+    const exec = vi.fn((sql: string, ...args: unknown[]) => {
+      if (sql.trimStart().startsWith('CREATE TABLE') || sql.includes('INSERT OR IGNORE')) {
+        return { toArray: () => [] };
+      }
+      if (sql.includes('FROM pi_core_state')) {
+        return { toArray: () => [{ generation: 1, row_count: inserted.length }] };
+      }
+      if (sql.includes('UPDATE pi_core_state')) return { toArray: () => [] };
+      if (sql.includes('next_idx')) return { toArray: () => [{ next_idx: inserted.length }] };
+      if (sql.includes('INSERT INTO pi_core_messages')) {
+        inserted.push(args[1] as string);
+        return { toArray: () => [] };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const store = new PiCoreMessageStore({
+      sql: () => ({ exec }) as never,
+      r2: () => ({}) as never,
+      chatContext: () => CONTEXT,
+      takeToolDurationMs: (toolCallId) => {
+        const value = durations.get(toolCallId);
+        durations.delete(toolCallId);
+        return value;
+      },
+    });
+    return { store, inserted };
+  }
+
+  it('stamps the measured duration onto the toolResult row it belongs to', async () => {
+    const harness = createAppendHarness(new Map([['call-1', 4321]]));
+    await harness.store.appendPiCoreMessages([
+      {
+        role: 'toolResult',
+        toolCallId: 'call-1',
+        toolName: 'read',
+        content: [{ type: 'text', text: 'ok' }],
+        isError: false,
+        timestamp: 1,
+      },
+    ] as never);
+    expect(JSON.parse(harness.inserted[0]).uiMetadata).toMatchObject({ toolDurationMs: 4321 });
+  });
+
+  it('leaves rows untouched when no duration was measured', async () => {
+    const harness = createAppendHarness(new Map());
+    await harness.store.appendPiCoreMessages([
+      { role: 'user', content: 'hi', timestamp: 1 },
+      {
+        role: 'toolResult',
+        toolCallId: 'unmeasured',
+        toolName: 'read',
+        content: [{ type: 'text', text: 'ok' }],
+        isError: false,
+        timestamp: 2,
+      },
+    ] as never);
+    expect(JSON.parse(harness.inserted[0]).uiMetadata).toBeUndefined();
+    expect(JSON.parse(harness.inserted[1]).uiMetadata).toBeUndefined();
+  });
+});

--- a/wrangler.prod.jsonc
+++ b/wrangler.prod.jsonc
@@ -112,7 +112,7 @@
     { "binding": "ERROR_ANALYTICS", "dataset": "chiridion_errors_prod" },
     { "binding": "OBSERVABILITY_EVENTS", "dataset": "chiridion_observability_prod" },
   ],
-  // Transcript data lake (docs/transcript-lake.md). Streams land in the
+  // Transcript data lake (config/pipelines/README.md). Streams land in the
   // chiridion-transcript-lake-prod R2 Data Catalog as Iceberg tables.
   "pipelines": [
     { "binding": "TRANSCRIPT_LAKE", "stream": "c3b4395560954073baf658cc22850e03" },

--- a/wrangler.prod.jsonc
+++ b/wrangler.prod.jsonc
@@ -112,6 +112,12 @@
     { "binding": "ERROR_ANALYTICS", "dataset": "chiridion_errors_prod" },
     { "binding": "OBSERVABILITY_EVENTS", "dataset": "chiridion_observability_prod" },
   ],
+  // Transcript data lake (docs/transcript-lake.md). Streams land in the
+  // chiridion-transcript-lake-prod R2 Data Catalog as Iceberg tables.
+  "pipelines": [
+    { "binding": "TRANSCRIPT_LAKE", "stream": "c3b4395560954073baf658cc22850e03" },
+    { "binding": "TOOL_CALLS_LAKE", "stream": "79c4a38bc6134964b1f981734972a622" },
+  ],
   "kv_namespaces": [
     { "binding": "EMAIL_TO_USER", "id": "45b452b3b19c42f6991408c140149a70" },
     { "binding": "APP_KV", "id": "0ee80299e67c4c7fa0c1ad618b7e7a9c" },

--- a/wrangler.staging.jsonc
+++ b/wrangler.staging.jsonc
@@ -104,6 +104,12 @@
     { "binding": "ERROR_ANALYTICS", "dataset": "chiridion_errors_staging" },
     { "binding": "OBSERVABILITY_EVENTS", "dataset": "chiridion_observability_staging" },
   ],
+  // Transcript data lake (docs/transcript-lake.md). Streams land in the
+  // chiridion-transcript-lake-staging R2 Data Catalog as Iceberg tables.
+  "pipelines": [
+    { "binding": "TRANSCRIPT_LAKE", "stream": "02a2d092797b4903bd1f259752d563d2" },
+    { "binding": "TOOL_CALLS_LAKE", "stream": "51df244b1d8f4098adf032cd1c35256f" },
+  ],
   "kv_namespaces": [
     { "binding": "EMAIL_TO_USER", "id": "ab267c4f44b847dda8bdca400a4e1884" },
     { "binding": "APP_KV", "id": "e894eb2caf1641ad8870da994b992fce" },

--- a/wrangler.staging.jsonc
+++ b/wrangler.staging.jsonc
@@ -104,7 +104,7 @@
     { "binding": "ERROR_ANALYTICS", "dataset": "chiridion_errors_staging" },
     { "binding": "OBSERVABILITY_EVENTS", "dataset": "chiridion_observability_staging" },
   ],
-  // Transcript data lake (docs/transcript-lake.md). Streams land in the
+  // Transcript data lake (config/pipelines/README.md). Streams land in the
   // chiridion-transcript-lake-staging R2 Data Catalog as Iceberg tables.
   "pipelines": [
     { "binding": "TRANSCRIPT_LAKE", "stream": "02a2d092797b4903bd1f259752d563d2" },


### PR DESCRIPTION
Streams chat transcripts and tool-call timings into Apache Iceberg tables in R2 Data Catalog via Cloudflare Pipelines, so fleet-wide transcript questions become one SQL query instead of one Durable Object wakeup per thread.

**Inert until you create the streams.** Both bindings are optional and every helper no-ops without them, so this is safe to merge and deploy before any infrastructure exists. Dev, tests, and self-host never export.

## Why the timing instrumentation is the load-bearing half

Pi records no tool start timestamp, and an assistant message's `timestamp` is stamped when the model *request opens*. Deriving duration after the fact as `toolResult.timestamp − previous message timestamp` therefore includes model latency — measured against production, only ~12% of tool calls sit second-or-later in a batch where that subtraction is clean. Exporting raw transcripts without measuring would reproduce the same unusable numbers, only faster to query.

Duration is now measured live between `tool_execution_start`/`end` and stamped onto the persisted row as `uiMetadata.toolDurationMs` (UI-only — `sanitizePiModelMessage` strips it before anything reaches a provider). It also reaches the tool card: `pi-chunk-encoder` already forwarded `item.durationMs` and nothing ever set it.

Inner `js_exec` calls are timed in `CodeModeToolsBinding.callToolEnvelope`. They produce no `pi_core` row at all, so the transcript sees one opaque `js_exec` — ~35% of production tool calls, hiding every build, deploy, notebook, and DB timing inside it.

## Design points

- **Two tables.** `pi_messages` carries transcript content and is deletion-bound; `tool_calls` carries none and can be retained indefinitely. One table would weld those retention policies together.
- **Flat scalar columns.** Parquet is columnar and R2 SQL bills on bytes scanned, so timing queries prune the fat `text` column. A JSON payload column would make every query scan the whole corpus.
- **No image bytes.** `text` is a bounded projection (100k chars, truncation flagged, true length kept); images become `image_count`.
- **At-least-once delivery.** A high-water mark in DO storage advanced only after the stream accepts rows, mirroring the existing `pi_core` → render-history backfill. Synced after each commit via `waitUntil` (never extends a turn) and again on connect as the repair path. Readers dedupe on `(thread_id, idx)` by newest `ingested_at_ms`; `docs/transcript-lake.md` has the `QUALIFY` snippet.
- **Rewrite-aware.** `replacePiCoreMessages` (compaction / fork / admin repair) invalidates the mark's anchor row and triggers a full re-export, leaving the prior version in the lake as an audit trail.

## Verification

- `bun run test:workers -- transcript-lake` — 13 new tests
- `bun run test:workers` — 143 files, 1677 passed
- `bun run test:run` — 2407 passed
- `bun run typecheck` — clean
- `bun run lint` — one pre-existing `no-new-array` warning in `pi-core-store.ts` that also fails on `main` (unrelated line, left alone)

## Follow-ups for you

1. Create the streams/sinks per `docs/transcript-lake.md` (needs an R2 Admin Read & Write token) and add the `pipelines` bindings to `wrangler.staging.jsonc` / `wrangler.prod.jsonc`. Staging first.
2. Decide the deletion story before this holds much data — Iceberg through Pipelines is append-only, so purge/GDPR needs a partition rewrite job or a design that keeps bodies in R2 objects with the lake holding pointers.
3. Dormant threads are only exported when they next wake; a fleet-wide backfill of old history should write Parquet directly to R2 rather than through the 5MB/s stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)