### PR TITLE
Add evals for recurring user frustration patterns

### DIFF
--- a/workers/main/tests/evals/login-flow-rescue-live.test.ts
+++ b/workers/main/tests/evals/login-flow-rescue-live.test.ts
@@ -1,0 +1,594 @@
+import { env } from "cloudflare:test";
+import { describe, it } from "vitest";
+
+import { isRealEvalDeployEnabled } from "../../src/eval-deploy-context";
+import type { ChatThreadDO } from "../../src/chat-thread-do";
+import type { WorkspaceFilesystemDO } from "../../src/workspace-filesystem-do";
+import { createOrg, createUser, type TestEnv } from "../test-helpers";
+import {
+  assertPassFailCriteria,
+  buildEvalCriteriaSummary,
+  buildNoAssistantErrorCriterion,
+  buildResultEventCriterion,
+  buildRuntimeEventsCriterion,
+  buildSessionCompletedCriterion,
+  passFailCriterion,
+  scoreCriterion,
+  scoreSignalEfficiency,
+} from "./eval-criteria";
+import {
+  assertDeployedApp,
+  type EvalDeployedApp,
+} from "./eval-deploy-assert";
+import { emitEvalTranscript } from "./eval-transcript";
+import {
+  evaluateAgentEvalSignal,
+  getEvalSignalThresholds,
+  type EvalSignalEnv,
+} from "./eval-signal";
+import {
+  diffProjectFileSnapshots,
+  fetchWithRetry,
+  legacyDeployPathEvidence,
+  seedDoProjectFiles,
+  snapshotProjectFiles,
+  type ProjectFileDiff,
+} from "./project-eval-helpers";
+import {
+  configureEvalModel,
+  getEvalTimeoutMs,
+  type EvalModelEnv,
+} from "./model-config";
+
+type LoginFlowRescueEvalEnv = TestEnv & EvalModelEnv & EvalSignalEnv & {
+  CHAT_THREAD: DurableObjectNamespace<ChatThreadDO>;
+  WORKSPACE_FS: DurableObjectNamespace<WorkspaceFilesystemDO>;
+  R2_BUCKET: R2Bucket;
+  RUN_AGENT_EVALS?: string;
+  EVAL_REAL_DEPLOY?: string;
+  CF_API_TOKEN?: string;
+};
+
+const PROJECT_NAME = "login-portal";
+const USERNAME = "operator";
+const CORRECT_PASSWORD = "Cedar-Bridge-42!";
+const WRONG_PASSWORD = "Cedar-Bridge-99!";
+const HOME_MARKER = "EXISTING_OPERATIONS_HOME";
+const LOGIN_MARKER = "LOGIN_PORTAL_FORM";
+const ADMIN_MARKER = "PROTECTED_ADMIN_CONSOLE";
+const GENERATED_BUILD_PATHS = new Set(["/bun.lock", "/.camelai/tmp/build.log"]);
+const testEnv = env as unknown as LoginFlowRescueEvalEnv;
+const maybeIt = isRealEvalDeployEnabled(testEnv) ? it : it.skip;
+const SESSION_TIMEOUT_MS = getEvalTimeoutMs(testEnv, 900_000);
+
+const RUBRIC = {
+  version: 1,
+  objective:
+    "Diagnose and minimally repair an existing deployed login flow, proving both negative and positive authentication behavior instead of declaring success from one API response.",
+  passThreshold: 75,
+  criticalMinimum: 3,
+  criteria: [
+    {
+      id: "authentication_correctness",
+      description:
+        "Wrong credentials are rejected, correct credentials create a session, and the protected route enforces that session.",
+      weight: 40,
+      critical: true,
+      evidenceHints: ["smoke", "runtimeAssertions"],
+    },
+    {
+      id: "user_flow_verification",
+      description:
+        "The deployed login page remains usable and the repair addresses the client-side loading/navigation failure, not just the POST endpoint.",
+      weight: 30,
+      critical: true,
+      evidenceHints: ["result", "sourceInspection", "smoke"],
+    },
+    {
+      id: "scoped_repair",
+      description:
+        "The agent fixes the existing project and preserves the operations home instead of replacing the application.",
+      weight: 20,
+      critical: false,
+      evidenceHints: ["projectDiff", "sourceInspection"],
+    },
+    {
+      id: "evidence_quality",
+      description:
+        "The handoff reports the live URL and distinguishes the invalid-login, valid-login, and protected-route checks performed.",
+      weight: 10,
+      critical: false,
+      evidenceHints: ["result", "trajectory"],
+    },
+  ],
+} as const;
+
+const SEEDED_FILES: Record<string, string> = {
+  "/app/routes.ts": `import { index, route, type RouteConfig } from "@react-router/dev/routes";
+
+export default [
+  index("routes/home.tsx"),
+  route("login", "routes/login.tsx"),
+  route("admin", "routes/admin.tsx"),
+] satisfies RouteConfig;
+`,
+  "/app/routes/home.tsx": `export default function Home() {
+  return (
+    <main>
+      <h1>Operations Portal</h1>
+      <p>${HOME_MARKER}</p>
+      <a href="/login">Team login</a>
+    </main>
+  );
+}
+`,
+  "/app/routes/login.tsx": `import { useState } from "react";
+import { useNavigate } from "react-router";
+
+export default function Login() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<{ success?: boolean; error?: string }>();
+  if (result?.success) navigate("/admin");
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    const form = new FormData(event.currentTarget);
+    const response = await fetch("/api/login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        username: form.get("username"),
+        password: form.get("password"),
+      }),
+    });
+    setResult(await response.json());
+  }
+
+  return (
+    <main>
+      <h1>Team login</h1>
+      <p>${LOGIN_MARKER}</p>
+      <form onSubmit={submit}>
+        <input name="username" aria-label="Username" />
+        <input name="password" type="password" aria-label="Password" />
+        <button type="submit" disabled={loading}>
+          {loading ? "Signing in..." : "Sign in"}
+        </button>
+      </form>
+      {result?.error ? <p role="alert">{result.error}</p> : null}
+    </main>
+  );
+}
+`,
+  "/app/routes/admin.tsx": `export default function Admin() {
+  return (
+    <main>
+      <h1>Admin console</h1>
+      <p>${ADMIN_MARKER}</p>
+    </main>
+  );
+}
+`,
+  "/workers/app.ts": `import { createRequestHandler } from "react-router";
+
+interface Env {
+  ASSETS?: { fetch(request: Request): Promise<Response> | Response };
+}
+
+const requestHandler = createRequestHandler(
+  () => import("virtual:react-router/server-build"),
+  import.meta.env.MODE,
+);
+
+function shouldServeAsset(request: Request): boolean {
+  const pathname = new URL(request.url).pathname;
+  return (request.method === "GET" || request.method === "HEAD") &&
+    (pathname.startsWith("/assets/") || pathname.includes("."));
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const url = new URL(request.url);
+    if (url.pathname === "/api/login" && request.method === "POST") {
+      const body = await request.json<{ username?: string; password?: string }>();
+      return Response.json({
+        success: body.username === "${USERNAME}",
+        error: body.username === "${USERNAME}" ? undefined : "Invalid credentials",
+      });
+    }
+    if (env.ASSETS && shouldServeAsset(request)) {
+      const response = await env.ASSETS.fetch(request);
+      if (response.status !== 404) return response;
+    }
+    return requestHandler(request, { cloudflare: { env, ctx } });
+  },
+} satisfies ExportedHandler<Env>;
+`,
+};
+
+async function jsonRecord(response: Response): Promise<Record<string, unknown>> {
+  try {
+    const value = await response.json();
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function appUrl(app: EvalDeployedApp, path: string): string {
+  return new URL(path, app.url).toString();
+}
+
+describe("login flow rescue agent eval", () => {
+  maybeIt(
+    "repairs invalid-login, session, protected-route, and client-flow behavior",
+    async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const email = `login-flow-rescue-${suffix}@example.com`;
+      const { userId } = await createUser(
+        testEnv,
+        email,
+        "password123",
+        "Login Flow Rescue Eval",
+      );
+      const { org, defaultWorkspaceId } = await createOrg(
+        testEnv,
+        `Login Flow Rescue ${suffix}`,
+        userId,
+      );
+      const workspaceFs = testEnv.WORKSPACE_FS.get(
+        testEnv.WORKSPACE_FS.idFromName(defaultWorkspaceId),
+      );
+      const { project, files } = await seedDoProjectFiles(workspaceFs, testEnv, {
+        workspaceId: defaultWorkspaceId,
+        name: PROJECT_NAME,
+        description: "A seeded operations portal with a broken login flow.",
+        files: SEEDED_FILES,
+      });
+      const initialSnapshot = await snapshotProjectFiles(files);
+      const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+      await configureEvalModel(testEnv, orgStub, userId);
+      const thread = await orgStub.createThread(
+        defaultWorkspaceId,
+        "Login flow rescue eval",
+        userId,
+        undefined,
+        testEnv.EVAL_MODEL,
+      );
+      const chatThread = testEnv.CHAT_THREAD.get(
+        testEnv.CHAT_THREAD.idFromName(thread.id),
+      );
+      const result = await chatThread.runAgentEvalSession({
+        threadId: thread.id,
+        workspaceId: defaultWorkspaceId,
+        orgId: org.id,
+        userId,
+        userName: "Login Flow Rescue Eval",
+        userEmail: email,
+        messageSource: "eval",
+        timeoutMs: SESSION_TIMEOUT_MS,
+        message: [
+          `Fix the existing project "${PROJECT_NAME}" without recreating or redesigning it.`,
+          "The login screen gets stuck on Signing in, wrong passwords are accepted, and /admin is not protected.",
+          `For this sanitized fixture, the only valid credentials are username "${USERNAME}" and password "${CORRECT_PASSWORD}".`,
+          "A wrong password must fail. A correct login must issue a secure session cookie. An unauthenticated /admin request must redirect to /login or return 401/403, while an authenticated request must render the existing admin console.",
+          `Preserve the existing operations home marker "${HOME_MARKER}".`,
+          `Deploy the same project with script_name "${PROJECT_NAME}".`,
+          "Verify the negative login, successful login, protected route, and deployed login page. Do not claim the flow works from only a successful POST.",
+          "Reply with the live URL and concise verification evidence.",
+        ].join(" "),
+      });
+
+      let deployedApp: EvalDeployedApp | undefined;
+      let deployError: string | undefined;
+      try {
+        deployedApp = assertDeployedApp(result, {
+          name: PROJECT_NAME,
+          hostSuffix: ".evals.camelai.app",
+        });
+      } catch (error) {
+        deployError = error instanceof Error ? error.message : String(error);
+      }
+
+      const smoke = {
+        wrongLogin: undefined as
+          | { status: number; body: Record<string, unknown> }
+          | undefined,
+        correctLogin: undefined as
+          | {
+              status: number;
+              body: Record<string, unknown>;
+              hasCookie: boolean;
+              hasSecureCookieFlags: boolean;
+            }
+          | undefined,
+        anonymousAdmin: undefined as
+          | { status: number; location: string | null }
+          | undefined,
+        authenticatedAdmin: undefined as
+          | { status: number; hasMarker: boolean }
+          | undefined,
+        loginPage: undefined as
+          | { status: number; hasFormMarker: boolean; hasSigningInText: boolean }
+          | undefined,
+        failures: [] as string[],
+      };
+
+      if (!deployedApp) {
+        smoke.failures.push(deployError ?? "no deployed app was captured");
+      } else {
+        try {
+          const wrongResponse = await fetchWithRetry(appUrl(deployedApp, "/api/login"), {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ username: USERNAME, password: WRONG_PASSWORD }),
+          });
+          const wrongBody = await jsonRecord(wrongResponse);
+          smoke.wrongLogin = { status: wrongResponse.status, body: wrongBody };
+
+          const correctResponse = await fetchWithRetry(
+            appUrl(deployedApp, "/api/login"),
+            {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ username: USERNAME, password: CORRECT_PASSWORD }),
+            },
+          );
+          const correctBody = await jsonRecord(correctResponse);
+          const setCookie = correctResponse.headers.get("set-cookie");
+          const cookie = setCookie?.split(";")[0];
+          smoke.correctLogin = {
+            status: correctResponse.status,
+            body: correctBody,
+            hasCookie: Boolean(cookie),
+            hasSecureCookieFlags: Boolean(
+              setCookie &&
+                /\bHttpOnly\b/i.test(setCookie) &&
+                /\bSecure\b/i.test(setCookie) &&
+                /\bSameSite=(?:Lax|Strict)\b/i.test(setCookie),
+            ),
+          };
+
+          const anonymousAdmin = await fetchWithRetry(
+            appUrl(deployedApp, "/admin"),
+            { redirect: "manual" },
+          );
+          smoke.anonymousAdmin = {
+            status: anonymousAdmin.status,
+            location: anonymousAdmin.headers.get("location"),
+          };
+          await anonymousAdmin.body?.cancel();
+
+          const authenticatedAdmin = await fetchWithRetry(
+            appUrl(deployedApp, "/admin"),
+            { headers: cookie ? { cookie } : {} },
+          );
+          const authenticatedAdminBody = await authenticatedAdmin.text();
+          smoke.authenticatedAdmin = {
+            status: authenticatedAdmin.status,
+            hasMarker: authenticatedAdminBody.includes(ADMIN_MARKER),
+          };
+
+          const loginPage = await fetchWithRetry(appUrl(deployedApp, "/login"));
+          const loginPageBody = await loginPage.text();
+          smoke.loginPage = {
+            status: loginPage.status,
+            hasFormMarker: loginPageBody.includes(LOGIN_MARKER),
+            hasSigningInText: loginPageBody.includes("Signing in"),
+          };
+        } catch (error) {
+          smoke.failures.push(
+            `live verification failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+
+      const finalWorker = await files.readFile("/workers/app.ts");
+      const finalLogin = await files.readFile("/app/routes/login.tsx");
+      const finalHome = await files.readFile("/app/routes/home.tsx");
+      const workerSource = finalWorker.content ?? "";
+      const loginSource = finalLogin.content ?? "";
+      const homeSource = finalHome.content ?? "";
+      const sourceInspection = {
+        readSuccess: finalWorker.success && finalLogin.success && finalHome.success,
+        homePreserved: homeSource.includes(HOME_MARKER),
+        loginPreserved: loginSource.includes(LOGIN_MARKER),
+        avoidsNavigateDuringRender:
+          !/^\s*if\s*\([^\n]*\)\s*navigate\s*\(/m.test(loginSource),
+        clearsLoading:
+          /setLoading\s*\(\s*false\s*\)/.test(loginSource) ||
+          /finally\s*\{[\s\S]{0,300}setLoading\s*\(\s*false\s*\)/.test(loginSource),
+        checksPassword:
+          workerSource.includes(CORRECT_PASSWORD) ||
+          /\bpassword\b[\s\S]{0,100}(?:===|!==|timingSafeEqual|verify)/i.test(workerSource),
+      };
+
+      let projectDiff: ProjectFileDiff | undefined;
+      let projectDiffError: string | undefined;
+      try {
+        projectDiff = diffProjectFileSnapshots(
+          initialSnapshot,
+          await snapshotProjectFiles(files),
+        );
+      } catch (error) {
+        projectDiffError = error instanceof Error ? error.message : String(error);
+      }
+      const scoredChangedPaths = (projectDiff?.changedPaths ?? []).filter(
+        (path) => !GENERATED_BUILD_PATHS.has(path),
+      );
+      const wrongLoginRejected = Boolean(
+        smoke.wrongLogin &&
+          [400, 401, 403].includes(smoke.wrongLogin.status) &&
+          smoke.wrongLogin.body.success !== true,
+      );
+      const correctLoginAccepted = Boolean(
+        smoke.correctLogin &&
+          smoke.correctLogin.status >= 200 &&
+          smoke.correctLogin.status < 300 &&
+          smoke.correctLogin.body.success === true &&
+          smoke.correctLogin.hasCookie &&
+          smoke.correctLogin.hasSecureCookieFlags,
+      );
+      const anonymousAdminBlocked = Boolean(
+        smoke.anonymousAdmin &&
+          ([401, 403].includes(smoke.anonymousAdmin.status) ||
+            (smoke.anonymousAdmin.status >= 300 &&
+              smoke.anonymousAdmin.status < 400 &&
+              /\/login\b/.test(smoke.anonymousAdmin.location ?? ""))),
+      );
+      const authenticatedAdminAllowed = Boolean(
+        smoke.authenticatedAdmin?.status === 200 &&
+          smoke.authenticatedAdmin.hasMarker,
+      );
+      const loginPageAvailable = Boolean(
+        smoke.loginPage?.status === 200 && smoke.loginPage.hasFormMarker,
+      );
+      const sourceFlowRepaired =
+        sourceInspection.avoidsNavigateDuringRender &&
+        sourceInspection.clearsLoading;
+      const signal = evaluateAgentEvalSignal(
+        result,
+        getEvalSignalThresholds(testEnv, {
+          maxAssistantTurns: 24,
+          maxBadToolCalls: 4,
+        }),
+      );
+      const legacyFailures = legacyDeployPathEvidence(result.events);
+      const finalResult = result.result ?? "";
+      const finalHasEvidence =
+        Boolean(deployedApp && finalResult.includes(new URL(deployedApp.url).hostname)) &&
+        /\b(?:wrong|invalid|negative)\b/i.test(finalResult) &&
+        /\b(?:protected|unauthenticated|admin)\b/i.test(finalResult);
+      const evaluation = buildEvalCriteriaSummary({
+        passFail: [
+          buildSessionCompletedCriterion(result),
+          passFailCriterion({
+            id: "invalid_credentials_rejected",
+            label: "Wrong password is rejected",
+            passed: wrongLoginRejected,
+            reason: wrongLoginRejected
+              ? undefined
+              : `wrong-login status=${smoke.wrongLogin?.status ?? "missing"}, success=${String(smoke.wrongLogin?.body.success)}`,
+            details: smoke.wrongLogin,
+          }),
+          passFailCriterion({
+            id: "valid_credentials_issue_session",
+            label: "Correct credentials succeed and issue a session cookie",
+            passed: correctLoginAccepted,
+            reason: correctLoginAccepted
+              ? undefined
+              : `correct-login status=${smoke.correctLogin?.status ?? "missing"}, success=${String(smoke.correctLogin?.body.success)}, cookie=${smoke.correctLogin?.hasCookie ?? false}, secureFlags=${smoke.correctLogin?.hasSecureCookieFlags ?? false}`,
+            details: smoke.correctLogin,
+          }),
+          passFailCriterion({
+            id: "protected_route_enforces_session",
+            label: "Admin route blocks anonymous access and allows the authenticated session",
+            passed: anonymousAdminBlocked && authenticatedAdminAllowed,
+            reason:
+              anonymousAdminBlocked && authenticatedAdminAllowed
+                ? undefined
+                : `anonymousBlocked=${anonymousAdminBlocked}, authenticatedAllowed=${authenticatedAdminAllowed}`,
+            details: {
+              anonymousAdmin: smoke.anonymousAdmin,
+              authenticatedAdmin: smoke.authenticatedAdmin,
+            },
+          }),
+          passFailCriterion({
+            id: "deployed_login_flow_present",
+            label: "Deployed login page and client flow are repaired",
+            passed: loginPageAvailable && sourceFlowRepaired,
+            reason:
+              loginPageAvailable && sourceFlowRepaired
+                ? undefined
+                : `loginPage=${loginPageAvailable}, avoidsRenderNavigation=${sourceInspection.avoidsNavigateDuringRender}, clearsLoading=${sourceInspection.clearsLoading}`,
+            details: { loginPage: smoke.loginPage, sourceInspection },
+          }),
+          passFailCriterion({
+            id: "existing_app_preserved",
+            label: "Existing operations home remains intact",
+            passed: sourceInspection.homePreserved,
+            reason: sourceInspection.homePreserved
+              ? undefined
+              : `The repair removed ${HOME_MARKER}.`,
+            details: sourceInspection,
+          }),
+          buildNoAssistantErrorCriterion(result),
+          buildRuntimeEventsCriterion(result),
+          buildResultEventCriterion(result),
+        ],
+        scorecard: [
+          scoreCriterion({
+            id: "scoped_diff",
+            label: "Repair stays within five non-generated project files",
+            points: scoredChangedPaths.length <= 5 ? 4 : 0,
+            maxPoints: 4,
+            reason:
+              projectDiffError ??
+              `${scoredChangedPaths.length} non-generated project files changed.`,
+            details: { projectDiff, scoredChangedPaths },
+          }),
+          scoreSignalEfficiency(signal, {
+            maxPoints: 4,
+            fallbackPoints: 1,
+            tiers: [
+              { maxAssistantTurns: 18, maxBadToolCalls: 2, points: 4 },
+              { maxAssistantTurns: 24, maxBadToolCalls: 4, points: 3 },
+              { maxAssistantTurns: 32, maxBadToolCalls: 7, points: 2 },
+            ],
+          }),
+          scoreCriterion({
+            id: "verified_handoff",
+            label: "Final response includes URL and negative/protected-route evidence",
+            points: finalHasEvidence ? 2 : 0,
+            maxPoints: 2,
+            reason: finalHasEvidence
+              ? undefined
+              : "Final response lacked the live URL or specific verification evidence.",
+          }),
+          scoreCriterion({
+            id: "avoided_legacy_paths",
+            label: "Avoided legacy deploy paths",
+            points: legacyFailures.length === 0 ? 2 : 0,
+            maxPoints: 2,
+            reason: legacyFailures.length ? legacyFailures.join("; ") : undefined,
+          }),
+        ],
+      });
+
+      emitEvalTranscript({
+        status: result.status,
+        rubric: RUBRIC,
+        evaluation,
+        error: result.error,
+        model: testEnv.EVAL_MODEL,
+        signal,
+        project,
+        deployedApps: result.deployedApps,
+        smoke,
+        sourceInspection,
+        projectDiff,
+        projectDiffError,
+        runtimeAssertions: {
+          wrongLoginRejected,
+          correctLoginAccepted,
+          anonymousAdminBlocked,
+          authenticatedAdminAllowed,
+          loginPageAvailable,
+          sourceFlowRepaired,
+          finalHasEvidence,
+          legacyFailures,
+        },
+        result: result.result,
+        events: result.events,
+        messages: result.messages,
+      });
+
+      assertPassFailCriteria(evaluation);
+    },
+    SESSION_TIMEOUT_MS + 120_000,
+  );
+});

--- a/workers/main/tests/evals/manifest.json
+++ b/workers/main/tests/evals/manifest.json
@@ -25,9 +25,16 @@
     },
     {
       "id": "project-update-redeploy-state-live",
-      "description": "Update and redeploy a DO-backed app while preserving Durable Object state",
+      "description": "Make a scoped update and redeploy a DO-backed app while preserving existing UI and Durable Object state",
       "kind": "skill",
       "realDeploy": true
+    },
+    {
+      "id": "login-flow-rescue-live",
+      "description": "Repair and verify an existing login flow across invalid credentials, sessions, protected routes, and the deployed UI",
+      "kind": "skill",
+      "realDeploy": true,
+      "tier": "hard"
     },
     {
       "id": "space-matching-game-live",
@@ -194,8 +201,18 @@
     },
     {
       "id": "output-file-delivery-live",
-      "description": "Generate a spreadsheet from an uploaded CSV and deliver it as a downloadable file in workspace outputs",
+      "description": "Generate a spreadsheet from an uploaded CSV and link the exact downloadable file written to workspace outputs",
       "kind": "skill"
+    },
+    {
+      "id": "tcpdump-capability-restraint-live",
+      "description": "Explain the packet-capture capability boundary without wasting time on impossible sandbox attempts",
+      "kind": "unit"
+    },
+    {
+      "id": "product-keyword-intent-recovery-live",
+      "description": "Recover from a frustrated correction by separating removal and prompt-based image-fill intent",
+      "kind": "unit"
     },
     {
       "id": "analysis-tools-reachable-live",

--- a/workers/main/tests/evals/output-file-delivery-live.test.ts
+++ b/workers/main/tests/evals/output-file-delivery-live.test.ts
@@ -56,6 +56,47 @@ type OutputFileEvalEnv = TestEnv & EvalModelEnv & EvalSignalEnv & {
 const testEnv = env as unknown as OutputFileEvalEnv;
 const maybeIt = testEnv.RUN_AGENT_EVALS === "1" ? it : it.skip;
 const SESSION_TIMEOUT_MS = getEvalTimeoutMs(testEnv, 300_000);
+const RUBRIC = {
+  version: 1,
+  objective:
+    "Turn the uploaded data into a correct spreadsheet and hand the user a download link that resolves to the file actually written to workspace outputs.",
+  passThreshold: 75,
+  criticalMinimum: 3,
+  criteria: [
+    {
+      id: "spreadsheet_delivery",
+      description:
+        "A non-empty, well-formed spreadsheet containing the requested calculation lands in workspace outputs.",
+      weight: 45,
+      critical: true,
+      evidenceHints: ["runtimeAssertions", "evaluation"],
+    },
+    {
+      id: "download_link_accuracy",
+      description:
+        "The final response links to the delivered output filename using the workspace output route and does not invent an unrelated host.",
+      weight: 30,
+      critical: true,
+      evidenceHints: ["result", "runtimeAssertions"],
+    },
+    {
+      id: "appropriate_delivery_path",
+      description:
+        "The agent uses the file-output workflow instead of deploying an app solely to serve one spreadsheet.",
+      weight: 15,
+      critical: false,
+      evidenceHints: ["trajectory", "runtimeAssertions.deployedAnApp"],
+    },
+    {
+      id: "clear_handoff",
+      description:
+        "The response briefly states what was exported and makes the download action obvious.",
+      weight: 10,
+      critical: false,
+      evidenceHints: ["result"],
+    },
+  ],
+} as const;
 
 /** A .xlsx is a ZIP: every real one starts with the local file header "PK\x03\x04". */
 const ZIP_MAGIC = [0x50, 0x4b, 0x03, 0x04];
@@ -170,6 +211,21 @@ describe("output file delivery agent eval", () => {
       const deployedAnApp = (signal.toolCallsByName?.deploy_project ?? 0) > 0;
 
       const answerText = JSON.stringify(result.messages);
+      const finalResult = result.result ?? "";
+      const deliveredFilename = deliveredKey?.split("/").at(-1) ?? null;
+      const finalMentionsDeliveredFile = Boolean(
+        deliveredFilename &&
+          (finalResult.includes(deliveredFilename) ||
+            finalResult.includes(encodeURIComponent(deliveredFilename))),
+      );
+      const finalUsesWorkspaceOutputRoute =
+        /(?:\/api\/workspaces\/[^)\s]+\/outputs\/|\/outputs\/)/i.test(finalResult);
+      const finalUsesWrongCamelAiHost =
+        /https?:\/\/(?:www\.)?camelai\.com(?:\/|$)/i.test(finalResult);
+      const downloadableHandoff =
+        finalMentionsDeliveredFile &&
+        finalUsesWorkspaceOutputRoute &&
+        !finalUsesWrongCamelAiHost;
       // 102*145.50 = 14841, 144*88.25 = 12708, 60*145.50 = 8730.
       const citedATotal = /14[,.]?841|12[,.]?708|8[,.]?730/.test(answerText);
 
@@ -206,6 +262,33 @@ describe("output file delivery agent eval", () => {
               : undefined,
             details: { toolCallsByName: signal.toolCallsByName },
           }),
+          passFailCriterion({
+            id: "final_response_links_delivered_file",
+            label: "Final response links to the file that exists in workspace outputs",
+            passed: downloadableHandoff,
+            reason: downloadableHandoff
+              ? undefined
+              : [
+                  finalMentionsDeliveredFile
+                    ? null
+                    : "final response did not reference the delivered filename",
+                  finalUsesWorkspaceOutputRoute
+                    ? null
+                    : "final response did not use a workspace output route",
+                  finalUsesWrongCamelAiHost
+                    ? "final response used the unrelated camelai.com host"
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join("; "),
+            details: {
+              deliveredFilename,
+              finalResult,
+              finalMentionsDeliveredFile,
+              finalUsesWorkspaceOutputRoute,
+              finalUsesWrongCamelAiHost,
+            },
+          }),
           buildNoAssistantErrorCriterion(result),
           buildRuntimeEventsCriterion(result),
           buildResultEventCriterion(result),
@@ -225,6 +308,7 @@ describe("output file delivery agent eval", () => {
 
       emitEvalTranscript({
         status: result.status,
+        rubric: RUBRIC,
         evaluation,
         error: result.error,
         model: testEnv.EVAL_MODEL,
@@ -234,15 +318,23 @@ describe("output file delivery agent eval", () => {
         messages: result.messages,
         runtimeAssertions: {
           deliveredKey,
+          deliveredFilename,
           byteLength: deliveredBytes?.length ?? 0,
           wellFormed,
           deployedAnApp,
+          downloadableHandoff,
+          finalMentionsDeliveredFile,
+          finalUsesWorkspaceOutputRoute,
+          finalUsesWrongCamelAiHost,
           citedATotal,
           outputKeys: listed.objects.map((object) => object.key).slice(0, 20),
           failures: [
             ...(deliveredFile ? [] : ["no file delivered to workspace outputs"]),
             ...(wellFormed ? [] : ["delivered file was empty or malformed"]),
             ...(deployedAnApp ? ["deployed an app to serve a file"] : []),
+            ...(downloadableHandoff
+              ? []
+              : ["final response did not provide a valid link to the delivered output file"]),
           ],
         },
       });

--- a/workers/main/tests/evals/product-keyword-intent-recovery-live.test.ts
+++ b/workers/main/tests/evals/product-keyword-intent-recovery-live.test.ts
@@ -1,0 +1,250 @@
+import { env } from "cloudflare:test";
+import { describe, it } from "vitest";
+
+import type { ChatThreadDO } from "../../src/chat-thread-do";
+import { createOrg, createUser, type TestEnv } from "../test-helpers";
+import {
+  assertPassFailCriteria,
+  buildEvalCriteriaSummary,
+  buildNoAssistantErrorCriterion,
+  buildResultEventCriterion,
+  buildRuntimeEventsCriterion,
+  buildSessionCompletedCriterion,
+  passFailCriterion,
+  scoreSignalEfficiency,
+} from "./eval-criteria";
+import { emitEvalTranscript } from "./eval-transcript";
+import {
+  evaluateAgentEvalSignal,
+  getEvalSignalThresholds,
+  type EvalSignalEnv,
+} from "./eval-signal";
+import {
+  configureEvalModel,
+  getEvalTimeoutMs,
+  type EvalModelEnv,
+} from "./model-config";
+
+type ProductKeywordEvalEnv = TestEnv & EvalModelEnv & EvalSignalEnv & {
+  CHAT_THREAD: DurableObjectNamespace<ChatThreadDO>;
+  RUN_AGENT_EVALS?: string;
+};
+
+const testEnv = env as unknown as ProductKeywordEvalEnv;
+const maybeIt = testEnv.RUN_AGENT_EVALS === "1" ? it : it.skip;
+const SESSION_TIMEOUT_MS = getEvalTimeoutMs(testEnv, 180_000);
+const RUBRIC = {
+  version: 1,
+  objective:
+    "Recover from a frustrated clarification by separating removal intent from prompt-based replacement intent and giving a defensible SEO category recommendation.",
+  passThreshold: 75,
+  criticalMinimum: 3,
+  criteria: [
+    {
+      id: "intent_distinction",
+      description:
+        "The answer explicitly distinguishes erase/remove workflows from brush-and-prompt fill or replacement workflows.",
+      weight: 40,
+      critical: true,
+      evidenceHints: ["result"],
+    },
+    {
+      id: "correct_category",
+      description:
+        "The primary recommendation is Generative Fill or AI Inpainting, while Magic Eraser is treated only as a removal term rather than the product's category.",
+      weight: 35,
+      critical: true,
+      evidenceHints: ["result", "referenceEvidence"],
+    },
+    {
+      id: "uses_supplied_evidence",
+      description:
+        "The recommendation uses the supplied keyword metrics and does not invent unsupported volume data.",
+      weight: 15,
+      critical: false,
+      evidenceHints: ["result", "referenceEvidence"],
+    },
+    {
+      id: "frustration_recovery",
+      description:
+        "The response acknowledges and corrects the misunderstanding directly without defensiveness or repeating the same conflation.",
+      weight: 10,
+      critical: false,
+      evidenceHints: ["result", "messages"],
+    },
+  ],
+} as const;
+
+describe("product keyword intent recovery agent eval", () => {
+  maybeIt(
+    "separates removal and generative-fill intent after a correction",
+    async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const email = `keyword-intent-${suffix}@example.com`;
+      const { userId } = await createUser(
+        testEnv,
+        email,
+        "password123",
+        "Keyword Intent Eval",
+      );
+      const { org, defaultWorkspaceId } = await createOrg(
+        testEnv,
+        `Keyword Intent Eval ${suffix}`,
+        userId,
+      );
+      const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+      await configureEvalModel(testEnv, orgStub, userId);
+      const thread = await orgStub.createThread(
+        defaultWorkspaceId,
+        "Product keyword intent recovery eval",
+        userId,
+        undefined,
+        testEnv.EVAL_MODEL,
+      );
+      const chatThread = testEnv.CHAT_THREAD.get(
+        testEnv.CHAT_THREAD.idFromName(thread.id),
+      );
+      const firstResult = await chatThread.runAgentEvalSession({
+        threadId: thread.id,
+        workspaceId: defaultWorkspaceId,
+        orgId: org.id,
+        userId,
+        userName: "Keyword Intent Eval",
+        userEmail: email,
+        messageSource: "eval",
+        timeoutMs: SESSION_TIMEOUT_MS,
+        message:
+          "We are launching an AI image tool that users brush over and then type a prompt. Should we call it Magic Eraser or Inpainting for SEO?",
+      });
+      const secondResult = await chatThread.runAgentEvalSession({
+        threadId: thread.id,
+        workspaceId: defaultWorkspaceId,
+        orgId: org.id,
+        userId,
+        userName: "Keyword Intent Eval",
+        userEmail: email,
+        messageSource: "eval",
+        timeoutMs: SESSION_TIMEOUT_MS,
+        message: [
+          "You're mixing up two different intents. Magic Eraser removes something.",
+          "Our product fills the brushed region with whatever the user prompts.",
+          "Reassess using only these frozen US monthly metrics:",
+          "generative fill 2400, AI generative fill 880, image inpainting 390, AI inpainting 320, magic eraser 8100.",
+          "Recommend one primary category name and a secondary technical keyword.",
+        ].join(" "),
+      });
+      const result = {
+        status:
+          firstResult.status === "completed" && secondResult.status === "completed"
+            ? "completed"
+            : "error",
+        error: [firstResult.error, secondResult.error].filter(Boolean).join("; ") || undefined,
+        result: secondResult.result,
+        events: [...firstResult.events, ...secondResult.events],
+        messages: secondResult.messages,
+      };
+      const finalResult = secondResult.result ?? "";
+      const distinguishesIntents =
+        /\b(?:erase|eraser|remove|removal)\b/i.test(finalResult) &&
+        /\b(?:fill|replace|replacement|inpaint)\b/i.test(finalResult) &&
+        /\bprompt/i.test(finalResult);
+      const recommendsCorrectCategory =
+        /\b(?:AI\s+)?Generative Fill\b/i.test(finalResult) ||
+        /\b(?:AI\s+)?Inpainting\b/i.test(finalResult);
+      const recommendsMagicEraserAsPrimary =
+        /\b(?:primary (?:name|category)|call (?:it|the product)|recommendation(?: is|:))\s*(?:\*\*)?Magic Eraser\b/i.test(
+          finalResult,
+        );
+      const usesFrozenMetrics =
+        /2[,.]?400/.test(finalResult) &&
+        /(?:390|320)/.test(finalResult);
+      const signal = evaluateAgentEvalSignal(
+        result,
+        getEvalSignalThresholds(testEnv, {
+          maxAssistantTurns: 5,
+          maxBadToolCalls: 0,
+        }),
+      );
+      const evaluation = buildEvalCriteriaSummary({
+        passFail: [
+          buildSessionCompletedCriterion(result),
+          passFailCriterion({
+            id: "removal_and_fill_intents_distinguished",
+            label: "Final answer distinguishes removal from prompt-based fill",
+            passed: distinguishesIntents,
+            reason: distinguishesIntents
+              ? undefined
+              : "The final answer did not clearly separate the two product intents.",
+            details: { finalResult },
+          }),
+          passFailCriterion({
+            id: "primary_category_matches_product",
+            label: "Final recommendation matches the prompt-based fill capability",
+            passed: recommendsCorrectCategory && !recommendsMagicEraserAsPrimary,
+            reason:
+              recommendsCorrectCategory && !recommendsMagicEraserAsPrimary
+                ? undefined
+                : "The final answer did not recommend Generative Fill/Inpainting cleanly, or still treated Magic Eraser as the primary category.",
+            details: {
+              finalResult,
+              recommendsCorrectCategory,
+              recommendsMagicEraserAsPrimary,
+            },
+          }),
+          passFailCriterion({
+            id: "supplied_keyword_metrics_used",
+            label: "Final recommendation uses the supplied keyword metrics",
+            passed: usesFrozenMetrics,
+            reason: usesFrozenMetrics
+              ? undefined
+              : "The final answer did not ground the recommendation in the supplied volumes.",
+            details: { finalResult },
+          }),
+          buildNoAssistantErrorCriterion(result),
+          buildRuntimeEventsCriterion(result),
+          buildResultEventCriterion(result),
+        ],
+        scorecard: [
+          scoreSignalEfficiency(signal, {
+            maxPoints: 5,
+            fallbackPoints: 1,
+            tiers: [
+              { maxAssistantTurns: 3, maxBadToolCalls: 0, points: 5 },
+              { maxAssistantTurns: 5, maxBadToolCalls: 0, points: 4 },
+              { maxAssistantTurns: 8, maxBadToolCalls: 1, points: 2 },
+            ],
+          }),
+        ],
+      });
+
+      emitEvalTranscript({
+        status: result.status,
+        rubric: RUBRIC,
+        referenceEvidence: {
+          source: "sanitized synthetic fixture derived from a July 25 user correction",
+          facts: [
+            "Magic Eraser describes object removal.",
+            "The product replaces a brushed region using a text prompt.",
+            "Frozen monthly volumes: generative fill 2400, AI generative fill 880, image inpainting 390, AI inpainting 320, magic eraser 8100.",
+          ],
+        },
+        evaluation,
+        error: result.error,
+        model: testEnv.EVAL_MODEL,
+        signal,
+        result: result.result,
+        events: result.events,
+        messages: result.messages,
+        runtimeAssertions: {
+          distinguishesIntents,
+          recommendsCorrectCategory,
+          recommendsMagicEraserAsPrimary,
+          usesFrozenMetrics,
+        },
+      });
+
+      assertPassFailCriteria(evaluation);
+    },
+    SESSION_TIMEOUT_MS * 2 + 30_000,
+  );
+});

--- a/workers/main/tests/evals/project-update-redeploy-state-live.test.ts
+++ b/workers/main/tests/evals/project-update-redeploy-state-live.test.ts
@@ -62,6 +62,8 @@ type SourceInspection = {
   sourceHasDurableObject: boolean;
   sourceHasUpdatedMarker: boolean;
   sourceHasInitialMarker: boolean;
+  sourcePreservesReportForm: boolean;
+  sourcePreservesHistoryPanel: boolean;
   error?: string;
 };
 
@@ -71,6 +73,8 @@ type AppSmoke = {
     bodyLength?: number;
     hasUpdatedMarker: boolean;
     hasInitialMarker: boolean;
+    preservesReportForm: boolean;
+    preservesHistoryPanel: boolean;
     attempts: number;
     durationMs: number;
   };
@@ -111,6 +115,8 @@ type SeedSmoke = {
 const PROJECT_NAME = "stateful-checkins";
 const INITIAL_MARKER = "INITIAL_STATEFUL_CHECKINS_MARKER";
 const UPDATED_MARKER = "UPDATED_STATEFUL_CHECKINS_MARKER";
+const EXISTING_REPORT_FORM_MARKER = "EXISTING_REPORT_FORM_MARKER";
+const EXISTING_HISTORY_PANEL_MARKER = "EXISTING_HISTORY_PANEL_MARKER";
 const SEEDED_NAME = "eval-seed-before-redeploy";
 const testEnv = env as unknown as ProjectUpdateRedeployStateEvalEnv;
 const maybeIt = isRealEvalDeployEnabled(testEnv) ? it : it.skip;
@@ -206,6 +212,8 @@ async function inspectProjectSource(
       text.includes("DurableObjectState"),
     sourceHasUpdatedMarker: text.includes(UPDATED_MARKER),
     sourceHasInitialMarker: text.includes(INITIAL_MARKER),
+    sourcePreservesReportForm: text.includes(EXISTING_REPORT_FORM_MARKER),
+    sourcePreservesHistoryPanel: text.includes(EXISTING_HISTORY_PANEL_MARKER),
     error: packageRead.error ?? wranglerRead.error ?? workerRead.error ?? homeRouteRead.error,
   };
 }
@@ -235,13 +243,17 @@ async function smokeCheckDeployedApp(
         bodyLength: body.length,
         hasUpdatedMarker: body.includes(UPDATED_MARKER),
         hasInitialMarker: body.includes(INITIAL_MARKER),
+        preservesReportForm: body.includes(EXISTING_REPORT_FORM_MARKER),
+        preservesHistoryPanel: body.includes(EXISTING_HISTORY_PANEL_MARKER),
         attempts: rootAttempts,
         durationMs: Date.now() - rootStartedAt,
       };
       if (
         smoke.root.status === 200 &&
         smoke.root.hasUpdatedMarker &&
-        !smoke.root.hasInitialMarker
+        !smoke.root.hasInitialMarker &&
+        smoke.root.preservesReportForm &&
+        smoke.root.preservesHistoryPanel
       ) {
         break;
       }
@@ -250,11 +262,19 @@ async function smokeCheckDeployedApp(
     if (smoke.root.status !== 200) failures.push(`root returned HTTP ${smoke.root.status}`);
     if (!smoke.root.hasUpdatedMarker) failures.push("root did not include updated marker");
     if (smoke.root.hasInitialMarker) failures.push("root still included initial marker");
+    if (!smoke.root.preservesReportForm) {
+      failures.push(`root lost ${EXISTING_REPORT_FORM_MARKER}`);
+    }
+    if (!smoke.root.preservesHistoryPanel) {
+      failures.push(`root lost ${EXISTING_HISTORY_PANEL_MARKER}`);
+    }
   } catch (error) {
     smoke.root = {
       ...smoke.root,
       hasUpdatedMarker: smoke.root?.hasUpdatedMarker ?? false,
       hasInitialMarker: smoke.root?.hasInitialMarker ?? false,
+      preservesReportForm: smoke.root?.preservesReportForm ?? false,
+      preservesHistoryPanel: smoke.root?.preservesHistoryPanel ?? false,
       attempts: rootAttempts,
       durationMs: Date.now() - rootStartedAt,
     };
@@ -444,6 +464,7 @@ describe("project update redeploy state agent eval", () => {
           "Use the default deployable React Router scaffold; do not use the data-analysis template.",
           "Implement a Durable Object-backed check-in counter with binding name CHECKINS. GET /api/checkins must return JSON with numeric count and names: string[] of submitted check-in names. POST /api/checkins must accept JSON { name: string }, persist that name in the Durable Object, increment the count, and return JSON with numeric count and names: string[].",
           `Make the root page contain the exact text "${INITIAL_MARKER}".`,
+          `The root page must also contain the exact existing-feature markers "${EXISTING_REPORT_FORM_MARKER}" and "${EXISTING_HISTORY_PANEL_MARKER}". Treat them as an already-working report form and history panel that later changes must preserve.`,
           `Deploy it using js_exec with await tools.deploy_project({ project: "${PROJECT_NAME}", script_name: "${PROJECT_NAME}" }); deploy_project is not a top-level tool.`,
           "Do not use legacy VM work, create-worker, wrangler deploy, or bun run deploy for this DO-backed project.",
           "Leave live-app verification to the eval harness, which will verify the public app and seed one live check-in before asking for the update.",
@@ -475,6 +496,7 @@ describe("project update redeploy state agent eval", () => {
         message: [
           `The eval harness has now called the live deployed app's POST /api/checkins once. The Durable Object count should be at least 1.`,
           `Update only the user-visible root page marker to exact text "${UPDATED_MARKER}" and remove "${INITIAL_MARKER}" from the page.`,
+          `Keep the existing report form and history panel intact, including exact text "${EXISTING_REPORT_FORM_MARKER}" and "${EXISTING_HISTORY_PANEL_MARKER}".`,
           "Preserve the same Durable Object binding name CHECKINS, Durable Object class, API behavior, and migrations so existing live state is preserved.",
           `Redeploy the same project using js_exec with await tools.deploy_project({ project: "${PROJECT_NAME}", script_name: "${PROJECT_NAME}" }) again, using the same script_name.`,
           "Do not use legacy VM work, create-worker, wrangler deploy, bun run deploy, rollback_deploy, or a new project.",
@@ -576,17 +598,21 @@ describe("project update redeploy state agent eval", () => {
               sourceInspection.wranglerHasDurableObjectBinding &&
               sourceInspection.wranglerHasMigration &&
               sourceInspection.sourceHasUpdatedMarker &&
-              !sourceInspection.sourceHasInitialMarker,
+              !sourceInspection.sourceHasInitialMarker &&
+              sourceInspection.sourcePreservesReportForm &&
+              sourceInspection.sourcePreservesHistoryPanel,
             reason:
               sourceInspection.readSuccess &&
               sourceInspection.packageHasReactRouter &&
               sourceInspection.wranglerHasDurableObjectBinding &&
               sourceInspection.wranglerHasMigration &&
               sourceInspection.sourceHasUpdatedMarker &&
-              !sourceInspection.sourceHasInitialMarker
+              !sourceInspection.sourceHasInitialMarker &&
+              sourceInspection.sourcePreservesReportForm &&
+              sourceInspection.sourcePreservesHistoryPanel
                 ? undefined
                 : sourceInspection.error ??
-                  `reactRouter=${sourceInspection.packageHasReactRouter}, binding=${sourceInspection.wranglerHasDurableObjectBinding}, migration=${sourceInspection.wranglerHasMigration}, do=${sourceInspection.sourceHasDurableObject}, updated=${sourceInspection.sourceHasUpdatedMarker}, initial=${sourceInspection.sourceHasInitialMarker}`,
+                  `reactRouter=${sourceInspection.packageHasReactRouter}, binding=${sourceInspection.wranglerHasDurableObjectBinding}, migration=${sourceInspection.wranglerHasMigration}, do=${sourceInspection.sourceHasDurableObject}, updated=${sourceInspection.sourceHasUpdatedMarker}, initial=${sourceInspection.sourceHasInitialMarker}, reportForm=${sourceInspection.sourcePreservesReportForm}, history=${sourceInspection.sourcePreservesHistoryPanel}`,
             details: sourceInspection,
           }),
           passFailCriterion({

--- a/workers/main/tests/evals/tcpdump-capability-restraint-live.test.ts
+++ b/workers/main/tests/evals/tcpdump-capability-restraint-live.test.ts
@@ -1,0 +1,229 @@
+import { env } from "cloudflare:test";
+import { describe, it } from "vitest";
+
+import type { ChatThreadDO } from "../../src/chat-thread-do";
+import type { WorkspaceFilesystemDO } from "../../src/workspace-filesystem-do";
+import { createOrg, createUser, type TestEnv } from "../test-helpers";
+import {
+  assertPassFailCriteria,
+  buildEvalCriteriaSummary,
+  buildNoAssistantErrorCriterion,
+  buildResultEventCriterion,
+  buildRuntimeEventsCriterion,
+  buildSessionCompletedCriterion,
+  passFailCriterion,
+  scoreSignalEfficiency,
+} from "./eval-criteria";
+import { emitEvalTranscript } from "./eval-transcript";
+import {
+  evaluateAgentEvalSignal,
+  getEvalSignalThresholds,
+  type EvalSignalEnv,
+} from "./eval-signal";
+import {
+  configureEvalModel,
+  getEvalTimeoutMs,
+  type EvalModelEnv,
+} from "./model-config";
+import { usedTool } from "./project-eval-helpers";
+
+type TcpdumpCapabilityEvalEnv = TestEnv & EvalModelEnv & EvalSignalEnv & {
+  CHAT_THREAD: DurableObjectNamespace<ChatThreadDO>;
+  WORKSPACE_FS: DurableObjectNamespace<WorkspaceFilesystemDO>;
+  RUN_AGENT_EVALS?: string;
+};
+
+const testEnv = env as unknown as TcpdumpCapabilityEvalEnv;
+const maybeIt = testEnv.RUN_AGENT_EVALS === "1" ? it : it.skip;
+const SESSION_TIMEOUT_MS = getEvalTimeoutMs(testEnv, 120_000);
+const RUBRIC = {
+  version: 1,
+  objective:
+    "Answer a simple packet-capture capability question promptly, without burning time on sandbox attempts that cannot obtain raw network access.",
+  passThreshold: 75,
+  criticalMinimum: 3,
+  criteria: [
+    {
+      id: "capability_boundary",
+      description:
+        "The response clearly explains that camelAI cannot run tcpdump here because the environment lacks privileged raw-socket or packet-capture access.",
+      weight: 40,
+      critical: true,
+      evidenceHints: ["result"],
+    },
+    {
+      id: "restraint",
+      description:
+        "The agent answers from the known runtime boundary instead of attempting long installs, notebook runs, deployments, or packet captures.",
+      weight: 30,
+      critical: true,
+      evidenceHints: ["trajectory", "runtimeAssertions"],
+    },
+    {
+      id: "useful_alternative",
+      description:
+        "The response gives a practical tcpdump command the user can run on a Linux host they control.",
+      weight: 20,
+      critical: false,
+      evidenceHints: ["result"],
+    },
+    {
+      id: "concise_handoff",
+      description:
+        "The answer is direct and proportionate to the question, without implying that a capture was performed.",
+      weight: 10,
+      critical: false,
+      evidenceHints: ["result", "trajectory"],
+    },
+  ],
+} as const;
+
+describe("tcpdump capability restraint agent eval", () => {
+  maybeIt(
+    "answers the packet-capture boundary without a long sandbox detour",
+    async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const email = `tcpdump-capability-${suffix}@example.com`;
+      const { userId } = await createUser(
+        testEnv,
+        email,
+        "password123",
+        "Tcpdump Capability Eval",
+      );
+      const { org, defaultWorkspaceId } = await createOrg(
+        testEnv,
+        `Tcpdump Capability Eval ${suffix}`,
+        userId,
+      );
+      const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+      await configureEvalModel(testEnv, orgStub, userId);
+      const workspaceFs = testEnv.WORKSPACE_FS.get(
+        testEnv.WORKSPACE_FS.idFromName(defaultWorkspaceId),
+      );
+      const projectsBefore = await workspaceFs.listProjectsForMigrationReset();
+      const thread = await orgStub.createThread(
+        defaultWorkspaceId,
+        "Tcpdump capability restraint eval",
+        userId,
+        undefined,
+        testEnv.EVAL_MODEL,
+      );
+      const chatThread = testEnv.CHAT_THREAD.get(
+        testEnv.CHAT_THREAD.idFromName(thread.id),
+      );
+      const startedAt = Date.now();
+      const result = await chatThread.runAgentEvalSession({
+        threadId: thread.id,
+        workspaceId: defaultWorkspaceId,
+        orgId: org.id,
+        userId,
+        userName: "Tcpdump Capability Eval",
+        userEmail: email,
+        messageSource: "eval",
+        timeoutMs: SESSION_TIMEOUT_MS,
+        message: "How do I use tcpdump, and can you run it from here for me?",
+      });
+      const elapsedMs = Date.now() - startedAt;
+      const projectsAfter = await workspaceFs.listProjectsForMigrationReset();
+      const finalResult = result.result ?? "";
+      const statesBoundary =
+        /tcpdump/i.test(finalResult) &&
+        /\b(?:can(?:not|'t)|unable|not available|not supported)\b/i.test(finalResult) &&
+        /\b(?:raw socket|packet capture|cap_net_raw|cap_net_admin|privileg|root)\b/i.test(
+          finalResult,
+        );
+      const providesHostCommand =
+        /(?:sudo\s+)?tcpdump\s+(?:-[A-Za-z]|-i\s+)/i.test(finalResult);
+      const createdProject = usedTool(result.events, "create_project");
+      const deployedProject = usedTool(result.events, "deploy_project");
+      const ranNotebook = usedTool(result.events, "run_notebook");
+      const mutatedWorkspace =
+        projectsAfter.length !== projectsBefore.length ||
+        createdProject ||
+        deployedProject;
+      const signal = evaluateAgentEvalSignal(
+        result,
+        getEvalSignalThresholds(testEnv, {
+          maxAssistantTurns: 3,
+          maxBadToolCalls: 0,
+        }),
+      );
+      const evaluation = buildEvalCriteriaSummary({
+        passFail: [
+          buildSessionCompletedCriterion(result),
+          passFailCriterion({
+            id: "packet_capture_boundary_explained",
+            label: "Final response explains the packet-capture capability boundary",
+            passed: statesBoundary,
+            reason: statesBoundary
+              ? undefined
+              : "The final response did not clearly state why tcpdump cannot run in this environment.",
+            details: { finalResult },
+          }),
+          passFailCriterion({
+            id: "useful_host_command_provided",
+            label: "Final response gives a tcpdump command for the user's own host",
+            passed: providesHostCommand,
+            reason: providesHostCommand
+              ? undefined
+              : "The final response did not include a practical tcpdump command.",
+            details: { finalResult },
+          }),
+          passFailCriterion({
+            id: "workspace_left_untouched",
+            label: "Capability question did not create or deploy a project",
+            passed: !mutatedWorkspace,
+            reason: mutatedWorkspace
+              ? "The agent mutated the workspace while answering a capability question."
+              : undefined,
+            details: {
+              projectsBefore: projectsBefore.length,
+              projectsAfter: projectsAfter.length,
+              createdProject,
+              deployedProject,
+            },
+          }),
+          buildNoAssistantErrorCriterion(result),
+          buildRuntimeEventsCriterion(result),
+          buildResultEventCriterion(result),
+        ],
+        scorecard: [
+          scoreSignalEfficiency(signal, {
+            maxPoints: 5,
+            fallbackPoints: 0,
+            tiers: [
+              { maxAssistantTurns: 1, maxBadToolCalls: 0, points: 5 },
+              { maxAssistantTurns: 2, maxBadToolCalls: 0, points: 4 },
+              { maxAssistantTurns: 3, maxBadToolCalls: 1, points: 2 },
+            ],
+          }),
+        ],
+      });
+
+      emitEvalTranscript({
+        status: result.status,
+        rubric: RUBRIC,
+        evaluation,
+        error: result.error,
+        model: testEnv.EVAL_MODEL,
+        signal,
+        result: result.result,
+        events: result.events,
+        messages: result.messages,
+        runtimeAssertions: {
+          elapsedMs,
+          statesBoundary,
+          providesHostCommand,
+          createdProject,
+          deployedProject,
+          ranNotebook,
+          projectsBefore: projectsBefore.length,
+          projectsAfter: projectsAfter.length,
+        },
+      });
+
+      assertPassFailCriteria(evaluation);
+    },
+    SESSION_TIMEOUT_MS + 30_000,
+  );
+});


### PR DESCRIPTION
## Summary

Adds focused, sanitized eval coverage derived from the July 25 user-session frustration review. The change is eval-only: it does not alter product behavior.

## Frustration patterns covered

- **Login fixes declared successful after API-only checks.** A new seeded rescue eval requires invalid-password rejection, a hardened session cookie, anonymous protected-route enforcement, authenticated access, repaired client loading/navigation behavior, a live deployment, and preservation of the existing app shell.
- **Scoped requests rewriting or dropping existing behavior.** The existing stateful redeploy eval now requires two pre-existing UI surfaces to survive the requested marker-only change, in addition to preserving Durable Object data and API behavior.
- **Generated files handed off with broken or invented links.** The output-file eval now verifies that the final response names the exact file written to workspace outputs, uses the workspace output route, and does not use an unrelated host.
- **Long attempts at an unavailable platform capability.** A new tcpdump eval requires a direct raw-socket/privilege boundary explanation, a useful host-side command, zero project/deploy mutations, and a tight turn/tool budget.
- **Product intent conflation after a frustrated correction.** A new two-turn eval requires removal and prompt-based fill intent to be separated, a defensible category recommendation grounded only in frozen synthetic metrics, and a non-defensive recovery.

All fixtures use synthetic names, credentials, data, and keyword volumes. No raw user messages, identifying data, or production secrets are included.

## How the evals work

Each new eval is registered in the existing manifest and emits the shared transcript format. Product correctness is gated by deterministic persisted-state/live-HTTP checks where possible, with task-specific weighted rubrics for semantic quality. Shared root causes are consolidated into the existing output-delivery and state-preserving redeploy evals rather than creating session-specific duplicates.

## Validation

- Focused Worker/Vitest suite after rebase: **19 passed, 5 eval-gated skipped**.
- `tcpdump-capability-restraint-live`: product checks passed; rubric judge **97.5/100**.
- `product-keyword-intent-recovery-live`: product checks passed; rubric judge **100/100**.
- `output-file-delivery-live`: strengthened product checks passed; rubric judge **100/100**.
- `login-flow-rescue-live`: all live auth/UI/preservation checks passed; rubric judge **100/100**.
- `project-update-redeploy-state-live`: live UI, API, and persisted-state checks passed; rubric judge **100/100**.
- `git diff --check`: passed.

### Existing/baseline failures observed

These are separate from the product assertions added here:

- Full `bun run typecheck` currently fails in `workers/main/src/chat-thread-do.ts` because three `ChatMemoryStoreStats` values are missing the existing required `measured` property.
- The local eval runner exits nonzero after otherwise passing runs when agent verification first hits known missing local bindings: `IMAGES` for a CSV `read` attempt in output delivery, and `DISPATCHER` for early deployed-app fetch attempts in the two real-deploy evals. The agents recovered, and the independent live harness checks plus rubric judges passed.

## Limitations / intentionally uncovered

- Broad project-specific debugging chains and vague “not working” reports were consolidated into the login-verification and scoped-change gates rather than encoded as noisy one-off evals.
- A burst of empty, duplicate thread creations looked operationally suspicious but did not contain enough user evidence to classify as frustration, so no speculative eval was added.
- The evals reproduce agent behavior and handoff failures; they do not fix the underlying product or local eval-runner binding issues.