### PR TITLE
Include Fable 5 in platform model defaults

### DIFF
--- a/src/lib/model-catalog.ts
+++ b/src/lib/model-catalog.ts
@@ -278,7 +278,6 @@ export interface ResolvedModelCatalogEntry extends ModelCatalogEntry {
   addedAt: number;
 }
 
-const EXPLICIT_OPT_IN_MODELS = new Set<LlmModel>(["fable-5"]);
 const PINNED_MODEL_IDS = new Set<LlmModel>(["deepseek-v4-auto"]);
 
 export function compareModelCatalogEntries(
@@ -311,14 +310,11 @@ export function resolveModelPickerCatalog(args: {
       allowOpenAiSubscription: args.allowOpenAiSubscription,
     }).map((option) => option.value),
   );
-  const platformDefaultModelIds = new Set(
-    [...visibleModelIds].filter((id) => !EXPLICIT_OPT_IN_MODELS.has(id)),
-  );
 
   const sourceModels =
     args.effectiveConfig.use_platform_defaults === false
       ? args.effectiveConfig.models
-      : [...platformDefaultModelIds].map((id) => ({ id, added_at: Date.now() }));
+      : [...visibleModelIds].map((id) => ({ id, added_at: Date.now() }));
 
   const entries = sourceModels
     .filter((model) => visibleModelIds.has(model.id))

--- a/tests/chat-do-model-picker-state.test.ts
+++ b/tests/chat-do-model-picker-state.test.ts
@@ -236,9 +236,11 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     async function loadState({
       billingStatus,
       openAiSubscription = null,
+      usePlatformDefaults = false,
     }: {
       billingStatus: 'inactive' | 'active';
       openAiSubscription?: object | null;
+      usePlatformDefaults?: boolean;
     }) {
       const workspaceStub = {
         getInfo: vi.fn().mockResolvedValue({ org_id: 'org_123' }),
@@ -259,15 +261,24 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
           .fn()
           .mockResolvedValue({ claude_proxy_models: false }),
         getOpenAiSubscription: vi.fn().mockResolvedValue(openAiSubscription),
-        getModelPickerConfig: vi.fn().mockResolvedValue({
-          use_platform_defaults: false,
-          models: [
-            { id: 'sonnet', added_at: 3 },
-            { id: 'gpt-5.6-sol', added_at: 2 },
-            { id: 'grok-4.5', added_at: 1 },
-          ],
-          default_model: 'sonnet',
-        }),
+        getModelPickerConfig: vi.fn().mockResolvedValue(
+          usePlatformDefaults
+            ? {
+                use_platform_defaults: true,
+                models: [],
+                default_model: null,
+              }
+            : {
+                use_platform_defaults: false,
+                models: [
+                  { id: 'fable-5', added_at: 4 },
+                  { id: 'sonnet', added_at: 3 },
+                  { id: 'gpt-5.6-sol', added_at: 2 },
+                  { id: 'grok-4.5', added_at: 1 },
+                ],
+                default_model: 'sonnet',
+              },
+        ),
       };
 
       getEnvMock.mockReturnValue({
@@ -295,6 +306,9 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
       freeState?.modelOptions.find((option) => option.id === 'sonnet'),
     ).toMatchObject({ locked: true, unlockHint: 'generic' });
     expect(
+      freeState?.modelOptions.find((option) => option.id === 'fable-5'),
+    ).toMatchObject({ locked: true, unlockHint: 'generic' });
+    expect(
       freeState?.modelOptions.find((option) => option.id === 'gpt-5.6-sol'),
     ).toMatchObject({ locked: true, unlockHint: 'openai' });
     expect(
@@ -319,8 +333,24 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
       openAiState?.modelOptions.find((option) => option.id === 'grok-4.5'),
     ).toMatchObject({ locked: true, unlockHint: 'generic' });
 
-    const paidState = await loadState({ billingStatus: 'active' });
+    const platformFreeState = await loadState({
+      billingStatus: 'inactive',
+      usePlatformDefaults: true,
+    });
+    expect(
+      platformFreeState?.modelOptions.find(
+        (option) => option.id === 'fable-5',
+      ),
+    ).toMatchObject({ locked: true, unlockHint: 'generic' });
+
+    const paidState = await loadState({
+      billingStatus: 'active',
+      usePlatformDefaults: true,
+    });
     expect(paidState?.billingAccessMode).toBe('subscription');
+    expect(
+      paidState?.modelOptions.find((option) => option.id === 'fable-5'),
+    ).toMatchObject({ id: 'fable-5' });
     expect(paidState?.modelOptions.some((option) => option.locked)).toBe(false);
   });
 
@@ -570,7 +600,7 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     expect(orgStub.createThread).not.toHaveBeenCalled();
   });
 
-  it('keeps Fable 5 out of platform-default new threads', async () => {
+  it('allows Fable 5 in platform-default new threads', async () => {
     const workspaceStub = {
       getInfo: vi.fn().mockResolvedValue({ org_id: 'org_123' }),
       getModelPickerConfig: vi.fn().mockResolvedValue({
@@ -600,7 +630,17 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
         ],
         default_model: null,
       }),
-      createThread: vi.fn(),
+      createThread: vi.fn().mockResolvedValue({
+        id: 'thread_123',
+        workspace_id: 'ws_123',
+        title: 'New Chat',
+        created_by: 'user_123',
+        model: 'fable-5',
+        created_at: 1,
+        updated_at: 2,
+        user_message_count: 0,
+        first_user_message: null,
+      }),
     };
 
     getEnvMock.mockReturnValue({
@@ -615,17 +655,31 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     });
 
     const state = await getWorkspaceModelPickerState({}, 'ws_123');
-    expect(state?.allowedThreadModels).not.toContain('fable-5');
+    const modelIds = state?.modelOptions.map((option) => option.id) ?? [];
+    expect(modelIds).toContain('fable-5');
+    expect(state?.allowedThreadModels).toContain('fable-5');
     expect(state?.allowedThreadModels[0]).toBe('deepseek-v4-auto');
     expect(state?.allowedThreadModels).toContain('opus-4.8');
+    expect(modelIds.indexOf('opus-4.8')).toBeLessThan(
+      modelIds.indexOf('fable-5'),
+    );
+    expect(modelIds.indexOf('fable-5')).toBeLessThan(
+      modelIds.indexOf('sonnet'),
+    );
 
     await expect(
       createThread({}, 'ws_123', 'New Chat', 'user_123', undefined, 'fable-5'),
-    ).rejects.toThrow('Invalid thread model');
-    expect(orgStub.createThread).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({ id: 'thread_123', model: 'fable-5' });
+    expect(orgStub.createThread).toHaveBeenCalledWith(
+      'ws_123',
+      'New Chat',
+      'user_123',
+      undefined,
+      'fable-5',
+    );
   });
 
-  it('allows Fable 5 for new threads when explicitly enabled', async () => {
+  it('allows Fable 5 when a custom list includes it', async () => {
     const workspaceStub = {
       getInfo: vi.fn().mockResolvedValue({ org_id: 'org_123' }),
       getModelPickerConfig: vi.fn().mockResolvedValue({

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -317,6 +317,7 @@ describe('MODEL_CATALOG', () => {
     expect(visible.map((entry) => entry.id)).toEqual([
       'deepseek-v4-auto',
       'opus-4.8',
+      'fable-5',
       'sonnet',
       'haiku',
       'gpt-5.6-sol',
@@ -332,7 +333,7 @@ describe('MODEL_CATALOG', () => {
     ]);
   });
 
-  it('keeps Fable out of platform defaults unless explicitly added', () => {
+  it('includes Fable in compatible platform defaults', () => {
     const platformDefaults = resolveModelPickerCatalog({
       effectiveConfig: {
         source: 'org',
@@ -342,18 +343,7 @@ describe('MODEL_CATALOG', () => {
       },
       orgProvider: null,
     });
-    expect(platformDefaults.map((entry) => entry.id)).not.toContain('fable-5');
-
-    const explicitOverride = resolveModelPickerCatalog({
-      effectiveConfig: {
-        source: 'org',
-        use_platform_defaults: false,
-        default_model: null,
-        models: [{ id: 'fable-5', added_at: 1 }],
-      },
-      orgProvider: null,
-    });
-    expect(explicitOverride.map((entry) => entry.id)).toEqual(['fable-5']);
+    expect(platformDefaults.map((entry) => entry.id)).toContain('fable-5');
   });
 
   it('keeps camelCode in hosted camelAI platform models', () => {
@@ -382,5 +372,6 @@ describe('MODEL_CATALOG', () => {
     });
 
     expect(visible.map((entry) => entry.id)).toEqual(['sonnet']);
+    expect(visible.map((entry) => entry.id)).not.toContain('fable-5');
   });
 });

--- a/tests/model-picker-config.test.ts
+++ b/tests/model-picker-config.test.ts
@@ -188,7 +188,7 @@ describe('model picker config parsing', () => {
     expect(parsed).toEqual(defaultOrgModelPickerConfig());
   });
 
-  it('drops old customized picker configs that omitted Fable', () => {
+  it('drops legacy picker configs without an explicit platform-default flag', () => {
     const parsed = parseOrgModelPickerConfig({
       models: [
         { id: 'opus-4.8', added_at: 2 },

--- a/tests/model-settings-action.test.ts
+++ b/tests/model-settings-action.test.ts
@@ -820,7 +820,7 @@ describe('organization model settings loader', () => {
     expect(result.config.capacity.used).toBe(4);
   });
 
-  it('shows camelCode plus Claude-family models for Anthropic BYOK orgs', async () => {
+  it('shows all provider-compatible Claude-family models for Anthropic BYOK orgs', async () => {
     mockAuthContext({
       currentOrgLlmProviderConfig: providerRecord('anthropic'),
     });
@@ -844,10 +844,11 @@ describe('organization model settings loader', () => {
     expect(result.config.inPicker.map((row) => row.entry.id)).toEqual([
       'deepseek-v4-auto',
       'opus-4.8',
+      'fable-5',
       'sonnet',
       'haiku',
     ]);
     expect(result.config.additional).toEqual([]);
-    expect(result.config.capacity.used).toBe(4);
+    expect(result.config.capacity.used).toBe(5);
   });
 });


### PR DESCRIPTION
Includes Fable 5 in compatible platform-default model pickers and allows new threads to select it, while retaining provider compatibility filtering and catalog ordering. The prior explicit-opt-in exclusion made the platform-default picker diverge from the visible compatible catalog. Updates catalog, picker-state, config, and settings coverage for the normalized behavior. Validation: the focused Vitest suite passes all 81 tests; the full typecheck remains blocked by three pre-existing `ChatMemoryStoreStats.measured` errors in unchanged `workers/main/src/chat-thread-do.ts`.