### PR TITLE
Automate TLS for self-hosted deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           }
           trap cleanup EXIT
           {
-            echo "SELFHOST_POMERIUM_TLS_MODE=upstream"
+            echo "SELFHOST_TLS_MODE=external"
             echo "POMERIUM_IDP_PROVIDER_URL=https://accounts.example.com"
             echo "POMERIUM_IDP_CLIENT_ID=ci-client"
             echo "POMERIUM_IDP_CLIENT_SECRET=ci-secret"

--- a/.github/workflows/selfhost-images.yml
+++ b/.github/workflows/selfhost-images.yml
@@ -82,6 +82,9 @@ jobs:
           - image: local-artifacts
             context: .
             dockerfile: infra/selfhost/local-artifacts.Dockerfile
+          - image: caddy
+            context: .
+            dockerfile: infra/selfhost/caddy.Dockerfile
     steps:
       - uses: actions/checkout@v4
 
@@ -96,6 +99,13 @@ jobs:
           tags: camelai-selfhost-${{ matrix.image }}:release-validation
           cache-from: type=gha,scope=selfhost-${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=selfhost-${{ matrix.image }}
+
+      - name: Validate Caddy DNS providers
+        if: matrix.image == 'caddy'
+        run: |
+          modules="$(docker run --rm camelai-selfhost-caddy:release-validation caddy list-modules)"
+          grep -qx 'dns.providers.cloudflare' <<<"$modules"
+          grep -qx 'dns.providers.route53' <<<"$modules"
 
   validate-runtimes:
     name: Validate attached container runtimes
@@ -215,6 +225,9 @@ jobs:
           - image: container-egress
             context: workers/main/eval-egress-fix
             dockerfile: workers/main/eval-egress-fix/Dockerfile
+          - image: caddy
+            context: .
+            dockerfile: infra/selfhost/caddy.Dockerfile
     steps:
       - uses: actions/checkout@v4
 
@@ -300,7 +313,7 @@ jobs:
             '{schema: 1, release: $release, revision: $revision, images: {}}' \
             > selfhost-release.json
 
-          for image in app local-artifacts project-build analysis db-query container-egress; do
+          for image in app local-artifacts project-build analysis db-query container-egress caddy; do
             ref="ghcr.io/${owner}/${repo}-selfhost-${image}:${tag}"
             digest="$(
               docker buildx imagetools inspect "$ref" |

--- a/.github/workflows/selfhost-images.yml
+++ b/.github/workflows/selfhost-images.yml
@@ -47,7 +47,7 @@ jobs:
           }
           trap cleanup EXIT
           {
-            echo "SELFHOST_POMERIUM_TLS_MODE=upstream"
+            echo "SELFHOST_TLS_MODE=external"
             echo "POMERIUM_IDP_PROVIDER_URL=https://accounts.example.com"
             echo "POMERIUM_IDP_CLIENT_ID=release-validation"
             echo "POMERIUM_IDP_CLIENT_SECRET=release-validation-secret"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,7 @@ if any of them drift apart.
 
 - Session/auth helpers are split between app-side loaders/actions in `src/lib/` and Worker-side helpers in `workers/main/src/helpers/`.
 - Reverse-proxy identity providers (auto-login behind Cloudflare Access or Pomerium) share one engine in `workers/main/src/helpers/proxy-auth-core.ts` (JWT verify, JWKS, org mapping, revalidation); per-provider adapters are `access-session.ts` (RS256, get-identity endpoint) and `pomerium-session.ts` (ES256, inline-group claims). The registry/dispatcher is `proxy-auth-providers.ts`; app-side silent login/provisioning is `src/lib/proxy-auth.server.ts`. To add a provider, implement `ProxyAuthProvider` and register it. Tests: `tests/{pomerium,cloudflare-access}-*.test.ts`. Docs: `docs/pomerium-auth.md`, `docs/cloudflare-access-auth.md`.
+- Self-host Compose uses containerized Caddy as its ingress/TLS service. Bundled Pomerium is plaintext on loopback `127.0.0.1:5444`; do not restore direct Pomerium TLS or a host-installed Caddy service. TLS modes are `automatic` (Cloudflare/Route 53 DNS validation), `external`, and `provided`.
 - Password auth, OAuth account creation, email verification, onboarding, bans, and blocked signup policies all have tests in `workers/main/tests/`; update or add focused tests when touching these flows.
 - First-touch marketing attribution and the durable first-accepted-message definition of `new_camel_activation` are documented in `MARKETING_ATTRIBUTION.md`.
 - Superuser UI routes live under `/qaml-backdoor`.

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -20,10 +20,11 @@ SELFHOST_PROJECT_BUILD_IMAGE=ghcr.io/your-org/camelai-selfhost-project-build@sha
 SELFHOST_ANALYSIS_IMAGE=ghcr.io/your-org/camelai-selfhost-analysis@sha256:...
 SELFHOST_DB_QUERY_IMAGE=ghcr.io/your-org/camelai-selfhost-db-query@sha256:...
 SELFHOST_CONTAINER_EGRESS_IMAGE=ghcr.io/your-org/camelai-selfhost-container-egress@sha256:...
+SELFHOST_CADDY_IMAGE=ghcr.io/your-org/camelai-selfhost-caddy@sha256:...
 SELFHOST_POMERIUM_IMAGE=pomerium/pomerium@sha256:...
 ```
 
-Pin all seven dependency references from the same release manifest. Six are
+Pin all eight dependency references from the same release manifest. Seven are
 camelAI images; Pomerium is the tested upstream image. The container-egress
 wrapper is required for the known Docker 29 bridge-interception bug and is
 covered by the attached-container functional smoke.
@@ -47,15 +48,15 @@ Initialize and validate the installation with:
 
 ```bash
 bun run selfhost:init
-# Edit .env.selfhost and install the TLS certificate/key described below.
+# Edit .env.selfhost with identity, TLS, DNS, and AI settings.
 bun run selfhost:configure
 bun run selfhost:doctor
 bun run selfhost:up
 ```
 
 `SELFHOST_AUTH_MODE=bundled-pomerium` is the default production path.
-`selfhost:up` automatically adds the Pomerium overlay and, when HTTPS
-terminates on the VM, its loopback-JWKS overlay.
+`selfhost:up` automatically adds the Caddy front door, the Pomerium overlay,
+and, when HTTPS terminates on the VM, its loopback-JWKS overlay.
 External Pomerium and Cloudflare Access remain supported for enterprises that
 already operate an identity-aware proxy.
 
@@ -148,6 +149,93 @@ For a present binding, `configured` means the namespace and image were wired;
 it does not claim Docker execution was tested by the lightweight HTTP probe.
 Run the named deep-smoke command in `verification.command` for that evidence.
 
+## TLS front door
+
+Caddy is the ingress service for every supported Compose installation.
+In automatic and provided modes it is the public TLS front door; in external
+mode it is a private origin behind the enterprise TLS terminator. Pomerium and
+the camelAI application remain on loopback. The default mode automatically
+obtains and renews certificates with ACME DNS validation, which is required
+because deployed applications use a wildcard hostname.
+
+Choose exactly one mode in `.env.selfhost`:
+
+### Automatic certificates (recommended)
+
+For a DNS zone hosted by Cloudflare:
+
+```dotenv
+SELFHOST_TLS_MODE=automatic
+SELFHOST_TLS_DNS_PROVIDER=cloudflare
+SELFHOST_TLS_ACME_EMAIL=platform-ops@example.com
+SELFHOST_TLS_CLOUDFLARE_API_TOKEN=...
+```
+
+Create a narrowly scoped Cloudflare API token with Zone Read and DNS Edit on
+only the zone containing the camelAI, Pomerium authenticate, and app wildcard
+hostnames. `selfhost:configure` copies it into a protected, read-only secret
+mount for Caddy. It is not passed to the container as an environment variable.
+
+For Route 53:
+
+```dotenv
+SELFHOST_TLS_MODE=automatic
+SELFHOST_TLS_DNS_PROVIDER=route53
+SELFHOST_TLS_ACME_EMAIL=platform-ops@example.com
+SELFHOST_TLS_ROUTE53_HOSTED_ZONE_ID=Z0123456789EXAMPLE
+SELFHOST_TLS_AWS_REGION=us-east-1
+```
+
+On EC2, prefer an instance role and leave the access-key fields blank. The AWS
+templates create a role policy restricted to TXT ACME challenge records in the
+selected hosted zone. A non-AWS VM may set
+`SELFHOST_TLS_AWS_ACCESS_KEY_ID`, `SELFHOST_TLS_AWS_SECRET_ACCESS_KEY`, and an
+optional session token; the generator writes them to a protected credentials
+file.
+
+### Existing enterprise TLS terminator
+
+If an ingress controller, load balancer, or enterprise reverse proxy already
+owns certificates:
+
+```dotenv
+SELFHOST_TLS_MODE=external
+SELFHOST_TLS_EXTERNAL_BIND_ADDRESS=127.0.0.1
+SELFHOST_TLS_EXTERNAL_PORT=8080
+```
+
+Point the trusted proxy at that HTTP origin and preserve the original `Host`
+header. Keep the origin on loopback when the proxy is on the VM. If it must be
+reachable over the network, set the bind address to `0.0.0.0` and restrict the
+VM firewall/security group to the proxy addresses. Never expose this plaintext
+origin directly to users. External Cloudflare Access or Pomerium authentication
+must use this TLS mode because those proxies own the public TLS boundary.
+
+### Operator-provided certificate
+
+Use this fallback when automated DNS credentials are not permitted:
+
+```dotenv
+SELFHOST_TLS_MODE=provided
+SELFHOST_TLS_CERTIFICATE_FILE=/secure/path/tls.crt
+SELFHOST_TLS_PRIVATE_KEY_FILE=/secure/path/tls.key
+```
+
+The unencrypted PEM key and certificate chain must cover the main hostname,
+Pomerium authenticate hostname, every deployed-app wildcard, and a separate
+iframe wildcard when configured. Files installed as
+`.selfhost/tls/tls.crt` and `.selfhost/tls/tls.key` are also detected. Existing
+deployments with direct Pomerium TLS are migrated automatically from
+`.selfhost/pomerium/tls.crt` and `.selfhost/pomerium/tls.key`.
+
+After changing any TLS setting, run:
+
+```bash
+bun run selfhost:configure
+bun run selfhost:doctor
+bun run selfhost:up
+```
+
 ## Authentication and email-dependent flows
 
 Self-host mode has no outbound email transport. Setting
@@ -159,8 +247,6 @@ The recommended Compose deployment includes Pomerium Core in all-in-one mode:
 ```dotenv
 SELFHOST_AUTH_MODE=bundled-pomerium
 SELFHOST_MAIN_HOSTNAME=camel.example.com
-SELFHOST_POMERIUM_TLS_MODE=direct
-SELFHOST_POMERIUM_LOOPBACK_HTTPS=1
 POMERIUM_AUTHENTICATE_URL=https://authenticate.example.com
 POMERIUM_AUTHENTICATE_HOSTNAME=authenticate.example.com
 POMERIUM_IDP_PROVIDER=oidc
@@ -174,19 +260,12 @@ POMERIUM_AUDIENCE=camel.example.com
 
 Register `https://authenticate.example.com/oauth2/callback` with the OIDC
 provider. The authenticate hostname must be distinct from the camelAI hostname.
-For direct Compose TLS, install a certificate chain and key at
-`.selfhost/pomerium/tls.crt` and `.selfhost/pomerium/tls.key`; it must cover the
-main hostname, authenticate hostname, and deployed-app wildcard domains.
 `selfhost:configure` writes Pomerium's Docker-mounted secret files with
 restrictive permissions so the client, cookie, and shared secrets are not
-visible in `docker inspect`. The container retains only `NET_BIND_SERVICE` and
-`DAC_OVERRIDE`; the latter lets it read those operator-owned `0600` mounts on
-Linux without weakening their host permissions.
-
-Set `SELFHOST_POMERIUM_LOOPBACK_HTTPS=0` only when an external load balancer
-terminates TLS. In that mode, the VM must be able to reach its public camelAI
-HTTPS hostname through the load balancer so the app can retrieve Pomerium's
-JWKS.
+visible in `docker inspect`. Pomerium binds only to
+`127.0.0.1:5444` behind Caddy and retains only `DAC_OVERRIDE`, which lets it
+read operator-owned `0600` mounts on Linux without weakening their host
+permissions. Never expose that plaintext listener.
 
 Set `SELFHOST_AUTH_MODE=external-pomerium` or `cloudflare-access` to use an
 existing enterprise proxy instead. Password signup is rejected before creating

--- a/docker-compose.selfhost.caddy-source.yml
+++ b/docker-compose.selfhost.caddy-source.yml
@@ -1,0 +1,6 @@
+services:
+  caddy:
+    image: camelai-selfhost-caddy:source
+    build:
+      context: .
+      dockerfile: infra/selfhost/caddy.Dockerfile

--- a/docker-compose.selfhost.caddy.yml
+++ b/docker-compose.selfhost.caddy.yml
@@ -1,0 +1,33 @@
+services:
+  app:
+    depends_on:
+      caddy:
+        condition: service_healthy
+
+  caddy:
+    image: ${SELFHOST_CADDY_IMAGE:?Set SELFHOST_CADDY_IMAGE to the immutable camelAI Caddy image}
+    network_mode: host
+    restart: unless-stopped
+    cap_drop: ["ALL"]
+    cap_add: ["DAC_OVERRIDE", "NET_BIND_SERVICE"]
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      AWS_REGION: ${SELFHOST_TLS_AWS_REGION:-us-east-1}
+      AWS_PROFILE: ${SELFHOST_TLS_AWS_PROFILE:-default}
+      AWS_SHARED_CREDENTIALS_FILE: /run/camelai-secrets/aws-credentials
+    volumes:
+      - ./.selfhost/caddy:/etc/caddy:ro
+      - ./.selfhost/caddy/secrets:/run/camelai-secrets:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--output-document=-", "http://127.0.0.1:2019/config/"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/docker-compose.selfhost.pomerium.yml
+++ b/docker-compose.selfhost.pomerium.yml
@@ -9,10 +9,9 @@ services:
     network_mode: host
     restart: unless-stopped
     cap_drop: ["ALL"]
-    # Pomerium's image runs as root, but dropping every capability also drops
-    # the ability to read operator-owned 0600 bind-mounted config and secrets
-    # on Linux. Restore only that access plus low-port binding.
-    cap_add: ["DAC_OVERRIDE", "NET_BIND_SERVICE"]
+    # Pomerium stays on loopback behind the TLS front door. Restore only the
+    # capability needed to read operator-owned 0600 bind-mounted secrets.
+    cap_add: ["DAC_OVERRIDE"]
     security_opt:
       - no-new-privileges:true
     environment:

--- a/infra/selfhost/README.md
+++ b/infra/selfhost/README.md
@@ -341,8 +341,7 @@ release. The instance role is for SSM and bootstrap secret reads only. Bedrock
 model access and regional availability still apply.
 
 The standalone default is the supported Bedrock model configured by the model
-catalog. camelCode is a camelAI-hosted route and is not offered by this
-standalone provider path.
+catalog.
 
 Anthropic, OpenAI, and OpenRouter use the same key fields:
 

--- a/infra/selfhost/README.md
+++ b/infra/selfhost/README.md
@@ -5,7 +5,7 @@ stack runs the application with local `workerd`, persists state and project git
 repositories in Docker volumes, and starts attached Docker containers for
 project builds, notebook analysis, SQL queries, and container egress.
 
-Production installations consume six version-matched release images:
+Production installations consume seven version-matched release images:
 
 ```text
 ghcr.io/qaml-ai/camelai-selfhost-app:<release>
@@ -14,11 +14,12 @@ ghcr.io/qaml-ai/camelai-selfhost-project-build:<release>
 ghcr.io/qaml-ai/camelai-selfhost-analysis:<release>
 ghcr.io/qaml-ai/camelai-selfhost-db-query:<release>
 ghcr.io/qaml-ai/camelai-selfhost-container-egress:<release>
+ghcr.io/qaml-ai/camelai-selfhost-caddy:<release>
 ```
 
-Tags named `selfhost-v*` publish all six camelAI images and a release manifest
+Tags named `selfhost-v*` publish all seven camelAI images and a release manifest
 through `.github/workflows/selfhost-images.yml`. The manifest also pins the
-tested upstream Pomerium image. Use all seven dependency references from one
+tested upstream Pomerium image. Use all eight dependency references from one
 manifest.
 
 ## Capability status
@@ -59,10 +60,10 @@ loopback behind the reverse proxy.
 - an OIDC identity provider for bundled Pomerium, or an existing Cloudflare
   Access/Pomerium deployment
 
-Keep the application and local-artifacts ports on loopback. The bundled
-Pomerium overlay is the default identity-aware proxy. It can terminate TLS
-directly for a manual Compose deployment or listen only on loopback behind the
-AWS Caddy configuration.
+Keep the application and local-artifacts ports on loopback. Caddy is the
+supported ingress service and either terminates TLS or provides a private
+origin to the enterprise TLS proxy. The bundled Pomerium overlay is the default
+identity-aware proxy and listens only on loopback behind Caddy.
 
 ## Manual release install
 
@@ -76,7 +77,7 @@ bun install --frozen-lockfile
 bun run selfhost:init
 ```
 
-Set release mode, the six version-matched image references, hostnames, and an AI
+Set release mode, the seven version-matched image references, hostnames, and an AI
 provider in `.env.selfhost`:
 
 ```dotenv
@@ -87,6 +88,7 @@ SELFHOST_PROJECT_BUILD_IMAGE=ghcr.io/qaml-ai/camelai-selfhost-project-build:self
 SELFHOST_ANALYSIS_IMAGE=ghcr.io/qaml-ai/camelai-selfhost-analysis:selfhost-vX.Y.Z
 SELFHOST_DB_QUERY_IMAGE=ghcr.io/qaml-ai/camelai-selfhost-db-query:selfhost-vX.Y.Z
 SELFHOST_CONTAINER_EGRESS_IMAGE=ghcr.io/qaml-ai/camelai-selfhost-container-egress:selfhost-vX.Y.Z
+SELFHOST_CADDY_IMAGE=ghcr.io/qaml-ai/camelai-selfhost-caddy:selfhost-vX.Y.Z
 
 SELFHOST_PUBLIC_BASE_URL=https://camel.example.com
 SELFHOST_MAIN_HOSTNAME=camel.example.com
@@ -94,8 +96,6 @@ LOCAL_APP_VANITY_DOMAIN=apps.example.com
 LOCAL_APP_IFRAME_DOMAIN=apps.example.com
 
 SELFHOST_AUTH_MODE=bundled-pomerium
-SELFHOST_POMERIUM_TLS_MODE=direct
-SELFHOST_POMERIUM_LOOPBACK_HTTPS=1
 POMERIUM_AUTHENTICATE_URL=https://authenticate.example.com
 POMERIUM_AUTHENTICATE_HOSTNAME=authenticate.example.com
 POMERIUM_ISSUER=camel.example.com
@@ -109,6 +109,11 @@ POMERIUM_IDP_CLIENT_SECRET=...
 SELFHOST_AI_PROVIDER=bedrock
 SELFHOST_AI_API_KEY=bedrock-api-key-...
 SELFHOST_AI_AWS_REGION=us-east-1
+
+SELFHOST_TLS_MODE=automatic
+SELFHOST_TLS_DNS_PROVIDER=cloudflare
+SELFHOST_TLS_ACME_EMAIL=platform-ops@example.com
+SELFHOST_TLS_CLOUDFLARE_API_TOKEN=...
 ```
 
 Register this callback URL with the OIDC provider:
@@ -117,18 +122,21 @@ Register this callback URL with the OIDC provider:
 https://authenticate.example.com/oauth2/callback
 ```
 
-Install an unencrypted PEM key and matching certificate chain:
+Automatic TLS uses DNS validation so Caddy can obtain both ordinary and
+wildcard certificates. For Cloudflare, use a token scoped to Zone Read and DNS
+Edit on this DNS zone. For Route 53 instead, use:
 
-```bash
-install -d -m 0700 .selfhost/pomerium
-install -m 0600 /secure/path/tls.crt .selfhost/pomerium/tls.crt
-install -m 0600 /secure/path/tls.key .selfhost/pomerium/tls.key
-bun run selfhost:configure
+```dotenv
+SELFHOST_TLS_MODE=automatic
+SELFHOST_TLS_DNS_PROVIDER=route53
+SELFHOST_TLS_ROUTE53_HOSTED_ZONE_ID=Z0123456789EXAMPLE
+SELFHOST_TLS_AWS_REGION=us-east-1
 ```
 
-The certificate must cover `camel.example.com`,
-`authenticate.example.com`, `*.apps.example.com`, and the separate iframe
-wildcard when configured.
+Use an EC2 instance role or the standard optional
+`SELFHOST_TLS_AWS_ACCESS_KEY_ID`/`SELFHOST_TLS_AWS_SECRET_ACCESS_KEY`
+credentials. See [TLS modes](#tls-modes) for external termination and
+operator-provided PEM certificates.
 
 If the GHCR packages are private, authenticate Docker before starting:
 
@@ -160,12 +168,14 @@ files explicitly:
 docker compose \
   --env-file .env.selfhost \
   -f docker-compose.selfhost.yml \
+  -f docker-compose.selfhost.caddy.yml \
   -f docker-compose.selfhost.pomerium.yml \
   -f docker-compose.selfhost.pomerium-loopback.yml \
   pull
 docker compose \
   --env-file .env.selfhost \
   -f docker-compose.selfhost.yml \
+  -f docker-compose.selfhost.caddy.yml \
   -f docker-compose.selfhost.pomerium.yml \
   -f docker-compose.selfhost.pomerium-loopback.yml \
   up --detach --wait
@@ -173,6 +183,32 @@ docker compose \
 
 The defaults bind the app at `127.0.0.1:3001` and local Artifacts at
 `127.0.0.1:7001`. Do not expose the Docker socket or either port directly.
+
+## TLS modes
+
+`selfhost:up` selects the Caddy Compose overlay and renders its configuration
+from `.env.selfhost`.
+
+- `SELFHOST_TLS_MODE=automatic` is recommended. Choose `cloudflare` or
+  `route53` with `SELFHOST_TLS_DNS_PROVIDER`. Caddy uses ACME DNS validation,
+  obtains all required wildcard certificates, and renews them automatically.
+- `SELFHOST_TLS_MODE=external` exposes a plaintext Caddy origin for an existing
+  load balancer or enterprise proxy. It defaults to `127.0.0.1:8080`. If the
+  proxy is remote, bind to `0.0.0.0` only with firewall rules that admit that
+  proxy and nothing else.
+- `SELFHOST_TLS_MODE=provided` copies an existing PEM chain and unencrypted key
+  from `SELFHOST_TLS_CERTIFICATE_FILE` and `SELFHOST_TLS_PRIVATE_KEY_FILE`, or
+  from `.selfhost/tls/tls.crt` and `.selfhost/tls/tls.key`.
+
+Automatic and provided TLS are paired with bundled Pomerium. Existing
+Cloudflare Access or external Pomerium deployments must use external TLS
+because the enterprise proxy owns the public TLS boundary. In every mode,
+Pomerium's upstream listener is plaintext on `127.0.0.1:5444`; it is never a
+public socket.
+
+The protected `.selfhost/caddy` directory contains generated configuration and
+secret mounts. Caddy certificate/account state is stored in the `caddy-data`
+volume and included in `selfhost:backup`.
 
 ## AWS single-node deployment
 
@@ -186,7 +222,8 @@ contract. Both provision:
 - SSM Session Manager access;
 - least-privilege reads for the configured Secrets Manager entries;
 - an Elastic IP and optional Route53 main/authenticate/wildcard records;
-- Caddy with either operator-provided PEM material or an external TLS origin;
+- Caddy with automatic Route 53 DNS-validated certificates,
+  operator-provided PEM material, or an external TLS origin;
 - bundled Pomerium on a loopback-only listener, or an operator-managed
   Cloudflare Access/Pomerium proxy;
 - a systemd unit that pulls the images and starts canonical Compose plus the
@@ -202,14 +239,20 @@ Store each value as the raw `SecretString`, not a JSON object:
 
 - AI provider API key;
 - bundled Pomerium OIDC client secret;
-- PEM certificate chain; and
-- matching unencrypted PEM private key.
+- PEM certificate chain and matching unencrypted PEM private key only when
+  `TlsMode=provided`.
 
-For bundled Pomerium the certificate must cover the main hostname,
+For provided TLS the certificate must cover the main hostname,
 authenticate hostname, and every configured wildcard app domain. The bootstrap
 writes `.env.selfhost`, Pomerium secret files, and TLS files with restrictive
 permissions. Secret values are read from Secrets Manager rather than placed in
 CloudFormation parameters or Terraform state.
+
+`TlsMode=automatic` is the AWS default. It requires
+`Route53HostedZoneId`/`route53_zone_id`; the instance role receives only the
+Route 53 permissions Caddy needs to create and remove TXT challenge records in
+that zone. `CreateRoute53Records` remains optional and separately controls the
+application A records.
 
 For `TlsMode=external`, port 80 is an origin port. Restrict
 `WebIngressCidr`/`web_ingress_cidrs` to the upstream proxy; never expose that
@@ -220,7 +263,7 @@ mode directly to the internet.
 ```bash
 cd infra/selfhost/terraform
 cp terraform.tfvars.example terraform.tfvars
-# Edit region, subnet/domain settings, secret ARNs, release ref, and six images.
+# Edit region, subnet/domain settings, secret ARNs, release ref, and seven images.
 terraform init
 terraform plan
 terraform apply
@@ -231,7 +274,8 @@ to start an SSM session and inspect bootstrap:
 
 ```bash
 aws ssm start-session --target <instance-id>
-sudo journalctl -u camelai-selfhost -u caddy --no-pager
+sudo journalctl -u camelai-selfhost --no-pager
+sudo camelai-selfhost-compose logs --tail=200 caddy pomerium app
 sudo cloud-init status --wait
 ```
 
@@ -255,6 +299,7 @@ aws cloudformation deploy \
     AnalysisImage=ghcr.io/qaml-ai/camelai-selfhost-analysis:selfhost-vX.Y.Z \
     DbQueryImage=ghcr.io/qaml-ai/camelai-selfhost-db-query:selfhost-vX.Y.Z \
     ContainerEgressImage=ghcr.io/qaml-ai/camelai-selfhost-container-egress:selfhost-vX.Y.Z \
+    CaddyImage=ghcr.io/qaml-ai/camelai-selfhost-caddy:selfhost-vX.Y.Z \
     MainHostname=camel.example.com \
     AppVanityDomain=apps.example.com \
     AuthProvider=bundled-pomerium \
@@ -266,8 +311,8 @@ aws cloudformation deploy \
     PomeriumIdpClientId=camelai \
     PomeriumIdpClientSecretArn=arn:aws:secretsmanager:... \
     SelfhostAiApiKeySecretArn=arn:aws:secretsmanager:... \
-    TlsCertificateSecretArn=arn:aws:secretsmanager:... \
-    TlsPrivateKeySecretArn=arn:aws:secretsmanager:...
+    TlsMode=automatic \
+    Route53HostedZoneId=Z0123456789EXAMPLE
 ```
 
 CloudFormation waits up to 30 minutes for the health check before completing.
@@ -324,8 +369,8 @@ Cloudflare Access or Pomerium assertions.
 
 ### Bundled Pomerium (recommended)
 
-`SELFHOST_AUTH_MODE=bundled-pomerium` adds the Pomerium overlay. When
-`SELFHOST_POMERIUM_LOOPBACK_HTTPS=1`, it also adds
+`SELFHOST_AUTH_MODE=bundled-pomerium` adds the Pomerium overlay. When TLS
+terminates on the VM, `selfhost:up` also adds
 `docker-compose.selfhost.pomerium-loopback.yml` so the app retrieves signing
 keys through the VM's local HTTPS endpoint. Pomerium runs in all-in-one mode
 with a persistent file-backed databroker. The control-plane hostname requires
@@ -334,19 +379,16 @@ deployed app wildcard hostnames remain public and route separately.
 
 Pomerium is pinned by immutable digest. Its client, cookie, and shared secrets
 are passed through mounted files rather than container environment values.
-The container drops all Linux capabilities except `NET_BIND_SERVICE` and
-`DAC_OVERRIDE`; the latter is required for Pomerium to read the operator-owned
+The container drops all Linux capabilities except `DAC_OVERRIDE`, which is
+required for Pomerium to read the operator-owned
 `0600` bind mounts on Linux without making those files group- or world-readable.
 Backups include the `pomerium-data` volume, but `.env.selfhost` remains a
 separate operator-owned secret and must also be protected.
 
-For manual direct TLS use `SELFHOST_POMERIUM_TLS_MODE=direct`. AWS templates use
-`upstream`, where Caddy terminates TLS and Pomerium binds only to
-`127.0.0.1:5444`. Never expose that plaintext loopback listener.
-The AWS templates set `SELFHOST_POMERIUM_LOOPBACK_HTTPS=1` with
-operator-provided VM TLS and `0` when an external load balancer terminates TLS.
-External TLS must allow the VM to reach its public camelAI HTTPS hostname
-through that load balancer; the app uses that path to retrieve Pomerium's JWKS.
+Caddy terminates TLS and Pomerium binds only to `127.0.0.1:5444`. Never expose
+that plaintext loopback listener. An external TLS proxy must allow the VM to
+reach its public camelAI HTTPS hostname through the proxy because the app uses
+that path to retrieve Pomerium's JWKS.
 
 Cloudflare Access minimum:
 
@@ -379,6 +421,7 @@ curl --fail http://127.0.0.1:3001/api/selfhost/health
 docker compose --env-file .env.selfhost -f docker-compose.selfhost.yml ps
 docker compose --env-file .env.selfhost \
   -f docker-compose.selfhost.yml \
+  -f docker-compose.selfhost.caddy.yml \
   -f docker-compose.selfhost.pomerium.yml \
   -f docker-compose.selfhost.pomerium-loopback.yml \
   logs --tail=200 app pomerium
@@ -443,10 +486,10 @@ phase to the target release's upgrader. Subsequent upgrades do this handoff
 automatically.
 
 The helper requires a clean tracked worktree. It verifies that the selected Git
-ref matches the manifest revision and that all six camelAI images plus Pomerium
+ref matches the manifest revision and that all seven camelAI images plus Pomerium
 are digest-pinned, backs up the durable volumes, and saves the previous checkout
 plus `.env.selfhost` under `.selfhost/releases/`. It then checks out the
-release, updates all seven dependency references, pulls them, waits for Compose
+release, updates all eight dependency references, pulls them, waits for Compose
 health, and runs the doctor plus all three attached-runtime smokes. A failure
 before the new runtime starts automatically restores the saved checkout and
 image configuration. After startup begins, migrations may have run, so the
@@ -483,9 +526,10 @@ required.
 
 The supported production Compose file never builds on the VM. For local
 development only, `SELFHOST_DEPLOYMENT_MODE=source` selects
-`docker-compose.selfhost.source.yml` and builds the six images from the current
-checkout. This path is useful for testing changes, not for an immutable
-enterprise release.
+`docker-compose.selfhost.source.yml` and
+`docker-compose.selfhost.caddy-source.yml`, then builds the seven images from
+the current checkout. This path is useful for testing changes, not for an
+immutable enterprise release.
 
 ## Validation
 

--- a/infra/selfhost/caddy.Dockerfile
+++ b/infra/selfhost/caddy.Dockerfile
@@ -1,0 +1,17 @@
+ARG CADDY_VERSION=2.11.4
+
+FROM caddy:${CADDY_VERSION}-builder-alpine AS builder
+
+RUN xcaddy build \
+  --with github.com/caddy-dns/cloudflare@v0.2.4 \
+  --with github.com/caddy-dns/route53@v1.6.2
+
+FROM caddy:${CADDY_VERSION}-alpine
+
+ARG OCI_VERSION=dev
+ARG OCI_REVISION=unknown
+LABEL org.opencontainers.image.source="https://github.com/qaml-ai/camelAI" \
+  org.opencontainers.image.version="${OCI_VERSION}" \
+  org.opencontainers.image.revision="${OCI_REVISION}"
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/infra/selfhost/cloudformation/aws-single-node.yaml
+++ b/infra/selfhost/cloudformation/aws-single-node.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
   camelAI supported single-node self-host release on Ubuntu, Docker Compose,
-  encrypted EBS, SSM, Secrets Manager, and Caddy. The six runtime images are
+  encrypted EBS, SSM, Secrets Manager, and Caddy. The seven runtime images are
   prebuilt release artifacts; this stack does not build application images.
 
 Metadata:
@@ -33,6 +33,7 @@ Metadata:
           - AnalysisImage
           - DbQueryImage
           - ContainerEgressImage
+          - CaddyImage
       - Label:
           default: Hostnames, TLS, and DNS
         Parameters:
@@ -155,6 +156,10 @@ Parameters:
     Type: String
     Description: Immutable camelai-selfhost-container-egress tag or digest.
     AllowedPattern: "(?!.*:latest$)[A-Za-z0-9._/@:-]+"
+  CaddyImage:
+    Type: String
+    Description: Immutable camelai-selfhost-caddy tag or digest.
+    AllowedPattern: "(?!.*:latest$)[A-Za-z0-9._/@:-]+"
 
   MainHostname:
     Type: String
@@ -171,13 +176,15 @@ Parameters:
     AllowedPattern: "[A-Za-z0-9.-]*"
   TlsMode:
     Type: String
-    Default: provided
+    Default: automatic
     AllowedValues:
+      - automatic
       - provided
       - external
     Description: >-
+      automatic obtains wildcard certificates through Route 53 DNS validation;
       provided installs PEM secrets on Caddy; external exposes an HTTP origin
-      intended only for a TLS-terminating upstream proxy.
+      intended only for a trusted TLS-terminating upstream proxy.
   TlsCertificateSecretArn:
     Type: String
     Default: ""
@@ -311,10 +318,17 @@ Rules:
       - Assert: !Not [!Equals [!Ref TlsPrivateKeySecretArn, ""]]
         AssertDescription: TlsPrivateKeySecretArn is required for provided TLS.
   Route53RequiresZone:
-    RuleCondition: !Equals [!Ref CreateRoute53Records, "true"]
+    RuleCondition: !Or
+      - !Equals [!Ref CreateRoute53Records, "true"]
+      - !Equals [!Ref TlsMode, automatic]
     Assertions:
       - Assert: !Not [!Equals [!Ref Route53HostedZoneId, ""]]
-        AssertDescription: Route53HostedZoneId is required when creating records.
+        AssertDescription: Route53HostedZoneId is required for automatic TLS or when creating records.
+  LocalTlsRequiresBundledPomerium:
+    RuleCondition: !Not [!Equals [!Ref TlsMode, external]]
+    Assertions:
+      - Assert: !Equals [!Ref AuthProvider, bundled-pomerium]
+        AssertDescription: automatic and provided TLS require bundled-pomerium authentication.
   CloudflareAccessRequiresSettings:
     RuleCondition: !Equals [!Ref AuthProvider, cloudflare-access]
     Assertions:
@@ -352,7 +366,11 @@ Conditions:
   HasSshCidr: !Not [!Equals [!Ref SshIngressCidr, ""]]
   HasKeyName: !Not [!Equals [!Ref KeyName, ""]]
   HasSeparateIframeDomain: !Not [!Equals [!Ref AppIframeDomain, ""]]
+  IsAutomaticTls: !Equals [!Ref TlsMode, automatic]
   IsProvidedTls: !Equals [!Ref TlsMode, provided]
+  IsLocalTls: !Or
+    - !Condition IsAutomaticTls
+    - !Condition IsProvidedTls
   IsBundledPomerium: !Equals [!Ref AuthProvider, bundled-pomerium]
   CreateBundledPomeriumDns: !And
     - !Condition CreateDns
@@ -377,7 +395,7 @@ Resources:
           ToPort: 80
           CidrIp: !Ref WebIngressCidr
         - !If
-          - IsProvidedTls
+          - IsLocalTls
           - IpProtocol: tcp
             FromPort: 443
             ToPort: 443
@@ -427,6 +445,37 @@ Resources:
                   Resource:
                     - !Sub "${TlsCertificateSecretArn}*"
                     - !Sub "${TlsPrivateKeySecretArn}*"
+                - !Ref AWS::NoValue
+              - !If
+                - IsAutomaticTls
+                - Effect: Allow
+                  Action:
+                    - route53:ListHostedZones
+                    - route53:ListHostedZonesByName
+                  Resource: "*"
+                - !Ref AWS::NoValue
+              - !If
+                - IsAutomaticTls
+                - Effect: Allow
+                  Action: route53:ListResourceRecordSets
+                  Resource: !Sub "arn:${AWS::Partition}:route53:::hostedzone/${Route53HostedZoneId}"
+                - !Ref AWS::NoValue
+              - !If
+                - IsAutomaticTls
+                - Effect: Allow
+                  Action: route53:GetChange
+                  Resource: !Sub "arn:${AWS::Partition}:route53:::change/*"
+                - !Ref AWS::NoValue
+              - !If
+                - IsAutomaticTls
+                - Effect: Allow
+                  Action: route53:ChangeResourceRecordSets
+                  Resource: !Sub "arn:${AWS::Partition}:route53:::hostedzone/${Route53HostedZoneId}"
+                  Condition:
+                    ForAllValues:StringEquals:
+                      route53:ChangeResourceRecordSetsRecordTypes: TXT
+                    ForAllValues:StringLike:
+                      route53:ChangeResourceRecordSetsNormalizedRecordNames: "_acme-challenge.*"
                 - !Ref AWS::NoValue
       Tags:
         - Key: Name
@@ -517,6 +566,10 @@ Resources:
               - !Ref DbQueryImage
               - "'\nCONTAINER_EGRESS_IMAGE='"
               - !Ref ContainerEgressImage
+              - "'\nCADDY_IMAGE='"
+              - !Ref CaddyImage
+              - "'\nAWS_REGION='"
+              - !Ref AWS::Region
               - "'\nMAIN_HOSTNAME='"
               - !Ref MainHostname
               - "'\nAPP_VANITY_DOMAIN='"
@@ -529,6 +582,8 @@ Resources:
               - !Ref TlsCertificateSecretArn
               - "'\nTLS_PRIVATE_KEY_SECRET_ARN='"
               - !Ref TlsPrivateKeySecretArn
+              - "'\nROUTE53_ZONE_ID='"
+              - !Ref Route53HostedZoneId
               - "'\nAUTH_PROVIDER='"
               - !Ref AuthProvider
               - "'\nAUTH_DEFAULT_ORG_NAME='"
@@ -577,7 +632,7 @@ Resources:
                 '
 
                 apt-get update
-                apt-get install -y ca-certificates curl git jq awscli caddy xfsprogs
+                apt-get install -y ca-certificates curl git jq awscli xfsprogs
                 install -m 0755 -d /etc/apt/keyrings
                 curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
                 chmod a+r /etc/apt/keyrings/docker.asc
@@ -633,15 +688,13 @@ Resources:
                   [[ "$POMERIUM_IDP_CLIENT_SECRET" != *$'\n'* ]] || { echo "Pomerium IdP client secret must be one line" >&2; exit 1; }
                 fi
 
-                export APP_IMAGE LOCAL_ARTIFACTS_IMAGE PROJECT_BUILD_IMAGE ANALYSIS_IMAGE DB_QUERY_IMAGE CONTAINER_EGRESS_IMAGE
+                export APP_IMAGE LOCAL_ARTIFACTS_IMAGE PROJECT_BUILD_IMAGE ANALYSIS_IMAGE DB_QUERY_IMAGE CONTAINER_EGRESS_IMAGE CADDY_IMAGE
+                export AWS_REGION ROUTE53_ZONE_ID TLS_MODE
                 export MAIN_HOSTNAME APP_VANITY_DOMAIN APP_IFRAME_DOMAIN SELFHOST_AI_PROVIDER SELFHOST_AI_API_KEY
                 export SELFHOST_AI_AWS_REGION SELFHOST_AI_BASE_URL SELFHOST_AI_MODEL SELFHOST_AI_NAME SELFHOST_AI_API SELFHOST_AI_AUTH_TYPE
                 export AUTH_PROVIDER AUTH_DEFAULT_ORG_NAME CLOUDFLARE_ACCESS_TEAM_DOMAIN CLOUDFLARE_ACCESS_AUD
                 export POMERIUM_AUTHENTICATE_URL POMERIUM_AUTHENTICATE_HOSTNAME POMERIUM_JWKS_URL POMERIUM_ISSUER POMERIUM_AUDIENCE
                 export POMERIUM_IMAGE POMERIUM_IDP_PROVIDER POMERIUM_IDP_PROVIDER_URL POMERIUM_IDP_CLIENT_ID POMERIUM_IDP_CLIENT_SECRET
-                POMERIUM_LOOPBACK_HTTPS=0
-                [ "$TLS_MODE" = provided ] && POMERIUM_LOOPBACK_HTTPS=1
-                export POMERIUM_LOOPBACK_HTTPS
                 node <<'NODE'
                 import fs from "node:fs";
                 const e = process.env;
@@ -653,11 +706,16 @@ Resources:
                   SELFHOST_ANALYSIS_IMAGE: e.ANALYSIS_IMAGE,
                   SELFHOST_DB_QUERY_IMAGE: e.DB_QUERY_IMAGE,
                   SELFHOST_CONTAINER_EGRESS_IMAGE: e.CONTAINER_EGRESS_IMAGE,
+                  SELFHOST_CADDY_IMAGE: e.CADDY_IMAGE,
                   SELFHOST_PUBLIC_BASE_URL: `https://${e.MAIN_HOSTNAME}`,
                   SELFHOST_MAIN_HOSTNAME: e.MAIN_HOSTNAME,
                   SELFHOST_AUTH_MODE: e.AUTH_PROVIDER === "pomerium" ? "external-pomerium" : e.AUTH_PROVIDER,
-                  SELFHOST_POMERIUM_TLS_MODE: "upstream",
-                  SELFHOST_POMERIUM_LOOPBACK_HTTPS: e.POMERIUM_LOOPBACK_HTTPS,
+                  SELFHOST_TLS_MODE: e.TLS_MODE,
+                  SELFHOST_TLS_DNS_PROVIDER: e.TLS_MODE === "automatic" ? "route53" : "",
+                  SELFHOST_TLS_ROUTE53_HOSTED_ZONE_ID: e.TLS_MODE === "automatic" ? e.ROUTE53_ZONE_ID : "",
+                  SELFHOST_TLS_AWS_REGION: e.AWS_REGION,
+                  SELFHOST_TLS_EXTERNAL_BIND_ADDRESS: e.TLS_MODE === "external" ? "0.0.0.0" : "127.0.0.1",
+                  SELFHOST_TLS_EXTERNAL_PORT: e.TLS_MODE === "external" ? "80" : "8080",
                   SELFHOST_POMERIUM_IMAGE: e.POMERIUM_IMAGE,
                   LOCAL_APP_VANITY_DOMAIN: e.APP_VANITY_DOMAIN,
                   LOCAL_APP_IFRAME_DOMAIN: e.APP_IFRAME_DOMAIN,
@@ -702,71 +760,13 @@ Resources:
                 NODE
                 unset SELFHOST_AI_API_KEY POMERIUM_IDP_CLIENT_SECRET
                 chmod 600 .env.selfhost
-                bun run selfhost:configure
-
-                install -d -m 0700 /etc/camelai
-                http_sites="http://*.$APP_VANITY_DOMAIN"
-                [ "$APP_IFRAME_DOMAIN" = "$APP_VANITY_DOMAIN" ] || http_sites="$http_sites, http://*.$APP_IFRAME_DOMAIN"
                 if [ "$TLS_MODE" = provided ]; then
-                  aws secretsmanager get-secret-value --secret-id "$TLS_CERTIFICATE_SECRET_ARN" --query SecretString --output text > /etc/camelai/tls.crt
-                  aws secretsmanager get-secret-value --secret-id "$TLS_PRIVATE_KEY_SECRET_ARN" --query SecretString --output text > /etc/camelai/tls.key
-                  chmod 0600 /etc/camelai/tls.crt /etc/camelai/tls.key
-                  chown root:caddy /etc/camelai/tls.crt /etc/camelai/tls.key
-                  app_sites="https://*.$APP_VANITY_DOMAIN"
-                  [ "$APP_IFRAME_DOMAIN" = "$APP_VANITY_DOMAIN" ] || app_sites="$app_sites, https://*.$APP_IFRAME_DOMAIN"
-                  main_upstream=127.0.0.1:3001
-                  auth_http_site=""
-                  if [ "$AUTH_PROVIDER" = bundled-pomerium ]; then
-                    main_upstream=127.0.0.1:5444
-                    auth_http_site=", http://$POMERIUM_AUTHENTICATE_HOSTNAME"
-                  fi
-                  cat > /etc/caddy/Caddyfile <<CADDY
-                http://$MAIN_HOSTNAME, $http_sites$auth_http_site {
-                  redir https://{host}{uri} permanent
-                }
-                https://$MAIN_HOSTNAME {
-                  tls /etc/camelai/tls.crt /etc/camelai/tls.key
-                  reverse_proxy $main_upstream
-                }
-                $app_sites {
-                  tls /etc/camelai/tls.crt /etc/camelai/tls.key
-                  reverse_proxy 127.0.0.1:3001
-                }
-                CADDY
-                  if [ "$AUTH_PROVIDER" = bundled-pomerium ]; then
-                    cat >> /etc/caddy/Caddyfile <<CADDY
-                https://$POMERIUM_AUTHENTICATE_HOSTNAME {
-                  tls /etc/camelai/tls.crt /etc/camelai/tls.key
-                  reverse_proxy 127.0.0.1:5444
-                }
-                CADDY
-                  fi
-                else
-                  if [ "$AUTH_PROVIDER" = bundled-pomerium ]; then
-                    cat > /etc/caddy/Caddyfile <<CADDY
-                http://$MAIN_HOSTNAME, http://$POMERIUM_AUTHENTICATE_HOSTNAME {
-                  reverse_proxy 127.0.0.1:5444 {
-                    header_up X-Forwarded-Proto https
-                  }
-                }
-                $http_sites {
-                  reverse_proxy 127.0.0.1:3001 {
-                    header_up X-Forwarded-Proto https
-                  }
-                }
-                CADDY
-                  else
-                    cat > /etc/caddy/Caddyfile <<CADDY
-                http://$MAIN_HOSTNAME, $http_sites {
-                  reverse_proxy 127.0.0.1:3001 {
-                    header_up X-Forwarded-Proto https
-                  }
-                }
-                CADDY
-                  fi
+                  install -d -m 0700 .selfhost/tls
+                  aws secretsmanager get-secret-value --secret-id "$TLS_CERTIFICATE_SECRET_ARN" --query SecretString --output text > .selfhost/tls/tls.crt
+                  aws secretsmanager get-secret-value --secret-id "$TLS_PRIVATE_KEY_SECRET_ARN" --query SecretString --output text > .selfhost/tls/tls.key
+                  chmod 0600 .selfhost/tls/tls.crt .selfhost/tls/tls.key
                 fi
-                caddy validate --config /etc/caddy/Caddyfile
-                systemctl enable --now caddy
+                bun run selfhost:configure
 
                 cat > /usr/local/sbin/camelai-selfhost-compose <<'COMPOSE'
                 #!/usr/bin/env bash
@@ -775,7 +775,10 @@ Resources:
                 args=(--env-file .env.selfhost -f docker-compose.selfhost.yml)
                 if grep -q '^SELFHOST_AUTH_MODE=bundled-pomerium$' .env.selfhost; then
                   args+=(-f docker-compose.selfhost.pomerium.yml)
-                  grep -q '^SELFHOST_POMERIUM_LOOPBACK_HTTPS=1$' .env.selfhost && args+=(-f docker-compose.selfhost.pomerium-loopback.yml)
+                fi
+                args+=(-f docker-compose.selfhost.caddy.yml)
+                if grep -Eq '^SELFHOST_TLS_MODE=(automatic|provided)$' .env.selfhost; then
+                  args+=(-f docker-compose.selfhost.pomerium-loopback.yml)
                 fi
                 exec /usr/bin/docker compose "${args[@]}" "$@"
                 COMPOSE

--- a/infra/selfhost/terraform/cloud-init.sh.tpl
+++ b/infra/selfhost/terraform/cloud-init.sh.tpl
@@ -13,6 +13,7 @@ decode() {
   printf '%s' "$1" | base64 --decode
 }
 
+AWS_REGION="$(decode "${aws_region_b64}")"
 DATA_VOLUME_ID="$(decode "${data_volume_id_b64}")"
 REPOSITORY_URL="$(decode "${repository_url_b64}")"
 REPOSITORY_REF="$(decode "${repository_ref_b64}")"
@@ -22,12 +23,14 @@ PROJECT_BUILD_IMAGE="$(decode "${project_build_image_b64}")"
 ANALYSIS_IMAGE="$(decode "${analysis_image_b64}")"
 DB_QUERY_IMAGE="$(decode "${db_query_image_b64}")"
 CONTAINER_EGRESS_IMAGE="$(decode "${container_egress_image_b64}")"
+CADDY_IMAGE="$(decode "${caddy_image_b64}")"
 MAIN_HOSTNAME="$(decode "${main_hostname_b64}")"
 APP_VANITY_DOMAIN="$(decode "${app_vanity_domain_b64}")"
 APP_IFRAME_DOMAIN="$(decode "${app_iframe_domain_b64}")"
 TLS_MODE="$(decode "${tls_mode_b64}")"
 TLS_CERTIFICATE_SECRET_ARN="$(decode "${tls_certificate_secret_arn_b64}")"
 TLS_PRIVATE_KEY_SECRET_ARN="$(decode "${tls_private_key_secret_arn_b64}")"
+ROUTE53_ZONE_ID="$(decode "${route53_zone_id_b64}")"
 AUTH_PROVIDER="$(decode "${auth_provider_b64}")"
 AUTH_DEFAULT_ORG_NAME="$(decode "${auth_default_org_name_b64}")"
 CLOUDFLARE_ACCESS_TEAM_DOMAIN="$(decode "${cloudflare_access_team_domain_b64}")"
@@ -61,12 +64,8 @@ chmod a+r /etc/apt/keyrings/docker.asc
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
 
 curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key -o /etc/apt/keyrings/caddy.asc
-chmod a+r /etc/apt/keyrings/caddy.asc
-echo "deb [signed-by=/etc/apt/keyrings/caddy.asc] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" > /etc/apt/sources.list.d/caddy.list
-
 apt-get update
-apt-get install -y caddy docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin nodejs
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin nodejs
 npm install --global bun@1.3.14
 
 if ! command -v aws >/dev/null 2>&1; then
@@ -174,6 +173,7 @@ export CFG_SELFHOST_PROJECT_BUILD_IMAGE="$${PROJECT_BUILD_IMAGE}"
 export CFG_SELFHOST_ANALYSIS_IMAGE="$${ANALYSIS_IMAGE}"
 export CFG_SELFHOST_DB_QUERY_IMAGE="$${DB_QUERY_IMAGE}"
 export CFG_SELFHOST_CONTAINER_EGRESS_IMAGE="$${CONTAINER_EGRESS_IMAGE}"
+export CFG_SELFHOST_CADDY_IMAGE="$${CADDY_IMAGE}"
 export CFG_SELFHOST_DEPLOYMENT_MODE="release"
 export CFG_SELFHOST_PUBLIC_BASE_URL="https://$${MAIN_HOSTNAME}"
 export CFG_SELFHOST_MAIN_HOSTNAME="$${MAIN_HOSTNAME}"
@@ -181,10 +181,18 @@ export CFG_SELFHOST_AUTH_MODE="$${AUTH_PROVIDER}"
 if [ "$${AUTH_PROVIDER}" = "pomerium" ]; then
   export CFG_SELFHOST_AUTH_MODE="external-pomerium"
 fi
-export CFG_SELFHOST_POMERIUM_TLS_MODE="upstream"
-export CFG_SELFHOST_POMERIUM_LOOPBACK_HTTPS="0"
-if [ "$${TLS_MODE}" = "provided" ]; then
-  export CFG_SELFHOST_POMERIUM_LOOPBACK_HTTPS="1"
+export CFG_SELFHOST_TLS_MODE="$${TLS_MODE}"
+export CFG_SELFHOST_TLS_DNS_PROVIDER=""
+export CFG_SELFHOST_TLS_ROUTE53_HOSTED_ZONE_ID=""
+export CFG_SELFHOST_TLS_AWS_REGION="$${AWS_REGION}"
+export CFG_SELFHOST_TLS_EXTERNAL_BIND_ADDRESS="127.0.0.1"
+export CFG_SELFHOST_TLS_EXTERNAL_PORT="8080"
+if [ "$${TLS_MODE}" = "automatic" ]; then
+  export CFG_SELFHOST_TLS_DNS_PROVIDER="route53"
+  export CFG_SELFHOST_TLS_ROUTE53_HOSTED_ZONE_ID="$${ROUTE53_ZONE_ID}"
+elif [ "$${TLS_MODE}" = "external" ]; then
+  export CFG_SELFHOST_TLS_EXTERNAL_BIND_ADDRESS="0.0.0.0"
+  export CFG_SELFHOST_TLS_EXTERNAL_PORT="80"
 fi
 export CFG_SELFHOST_POMERIUM_IMAGE="$${POMERIUM_IMAGE}"
 export CFG_LOCAL_APP_VANITY_DOMAIN="$${APP_VANITY_DOMAIN}"
@@ -270,96 +278,29 @@ fs.writeFileSync(envPath, `$${output.join("\n").replace(/\n+$/, "")}\n`, {
 NODE
 unset SELFHOST_AI_API_KEY CFG_SELFHOST_AI_API_KEY POMERIUM_IDP_CLIENT_SECRET CFG_POMERIUM_IDP_CLIENT_SECRET
 chmod 600 .env.selfhost
-bun run selfhost:configure
-
-install -d -m 0700 /etc/camelai
-APP_HTTP_SITE_ADDRESSES="http://*.$${APP_VANITY_DOMAIN}"
-if [ "$${APP_IFRAME_DOMAIN}" != "$${APP_VANITY_DOMAIN}" ]; then
-  APP_HTTP_SITE_ADDRESSES="$${APP_HTTP_SITE_ADDRESSES}, http://*.$${APP_IFRAME_DOMAIN}"
-fi
 if [ "$${TLS_MODE}" = "provided" ]; then
+  install -d -m 0700 .selfhost/tls
   aws secretsmanager get-secret-value \
     --secret-id "$${TLS_CERTIFICATE_SECRET_ARN}" \
     --query SecretString \
-    --output text > /etc/camelai/tls.crt
+    --output text > .selfhost/tls/tls.crt
   aws secretsmanager get-secret-value \
     --secret-id "$${TLS_PRIVATE_KEY_SECRET_ARN}" \
     --query SecretString \
-    --output text > /etc/camelai/tls.key
-  chmod 600 /etc/camelai/tls.crt /etc/camelai/tls.key
-  chown root:caddy /etc/camelai/tls.crt /etc/camelai/tls.key
-  chmod 640 /etc/camelai/tls.crt /etc/camelai/tls.key
-
-  APP_SITE_ADDRESSES="https://*.$${APP_VANITY_DOMAIN}"
-  if [ "$${APP_IFRAME_DOMAIN}" != "$${APP_VANITY_DOMAIN}" ]; then
-    APP_SITE_ADDRESSES="$${APP_SITE_ADDRESSES}, https://*.$${APP_IFRAME_DOMAIN}"
-  fi
-  AUTH_SITE_ADDRESS=""
-  MAIN_UPSTREAM="127.0.0.1:3001"
-  if [ "$${AUTH_PROVIDER}" = "bundled-pomerium" ]; then
-    AUTH_SITE_ADDRESS=", http://$${POMERIUM_AUTHENTICATE_HOSTNAME}"
-    MAIN_UPSTREAM="127.0.0.1:5444"
-  fi
-  cat > /etc/caddy/Caddyfile <<EOF
-http://$${MAIN_HOSTNAME}, $${APP_HTTP_SITE_ADDRESSES}$${AUTH_SITE_ADDRESS} {
-  redir https://{host}{uri} permanent
-}
-
-https://$${MAIN_HOSTNAME} {
-  tls /etc/camelai/tls.crt /etc/camelai/tls.key
-  reverse_proxy $${MAIN_UPSTREAM}
-}
-
-$${APP_SITE_ADDRESSES} {
-  tls /etc/camelai/tls.crt /etc/camelai/tls.key
-  reverse_proxy 127.0.0.1:3001
-}
-EOF
-  if [ "$${AUTH_PROVIDER}" = "bundled-pomerium" ]; then
-    cat >> /etc/caddy/Caddyfile <<EOF
-
-https://$${POMERIUM_AUTHENTICATE_HOSTNAME} {
-  tls /etc/camelai/tls.crt /etc/camelai/tls.key
-  reverse_proxy 127.0.0.1:5444
-}
-EOF
-  fi
-else
-  if [ "$${AUTH_PROVIDER}" = "bundled-pomerium" ]; then
-    cat > /etc/caddy/Caddyfile <<EOF
-http://$${MAIN_HOSTNAME}, http://$${POMERIUM_AUTHENTICATE_HOSTNAME} {
-  reverse_proxy 127.0.0.1:5444 {
-    header_up X-Forwarded-Proto https
-  }
-}
-
-$${APP_HTTP_SITE_ADDRESSES} {
-  reverse_proxy 127.0.0.1:3001 {
-    header_up X-Forwarded-Proto https
-  }
-}
-EOF
-  else
-    cat > /etc/caddy/Caddyfile <<'EOF'
-:80 {
-  reverse_proxy 127.0.0.1:3001 {
-    header_up X-Forwarded-Proto https
-  }
-}
-EOF
-  fi
+    --output text > .selfhost/tls/tls.key
+  chmod 600 .selfhost/tls/tls.crt .selfhost/tls/tls.key
 fi
-caddy validate --config /etc/caddy/Caddyfile
-systemctl enable --now caddy
+bun run selfhost:configure
 
 cat > /usr/local/sbin/camelai-selfhost-compose <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
 cd /srv/camelai/repo
 args=(--env-file .env.selfhost -f docker-compose.selfhost.yml)
+args+=(-f docker-compose.selfhost.caddy.yml)
 if grep -q '^SELFHOST_AUTH_MODE=bundled-pomerium$' .env.selfhost; then
   args+=(-f docker-compose.selfhost.pomerium.yml)
-  if grep -q '^SELFHOST_POMERIUM_LOOPBACK_HTTPS=1$' .env.selfhost; then
+  if grep -Eq '^SELFHOST_TLS_MODE=(automatic|provided)$' .env.selfhost; then
     args+=(-f docker-compose.selfhost.pomerium-loopback.yml)
   fi
 fi

--- a/infra/selfhost/terraform/main.tf
+++ b/infra/selfhost/terraform/main.tf
@@ -63,8 +63,15 @@ check "tls_secrets" {
 
 check "route53_zone" {
   assert {
-    condition     = !var.create_route53_records || var.route53_zone_id != ""
-    error_message = "route53_zone_id is required when create_route53_records=true."
+    condition     = (!var.create_route53_records && var.tls_mode != "automatic") || var.route53_zone_id != ""
+    error_message = "route53_zone_id is required for automatic TLS or when create_route53_records=true."
+  }
+}
+
+check "tls_auth_compatibility" {
+  assert {
+    condition     = var.tls_mode == "external" || var.auth_provider == "bundled-pomerium"
+    error_message = "automatic and provided TLS require auth_provider=bundled-pomerium; external identity proxies must terminate TLS upstream."
   }
 }
 
@@ -110,7 +117,7 @@ resource "aws_security_group" "selfhost" {
   dynamic "ingress" {
     for_each = var.web_ingress_cidrs
     content {
-      description = var.tls_mode == "provided" ? "HTTP redirect" : "HTTP origin for external TLS proxy"
+      description = contains(["automatic", "provided"], var.tls_mode) ? "HTTP redirect and ACME fallback" : "HTTP origin for external TLS proxy"
       protocol    = "tcp"
       from_port   = 80
       to_port     = 80
@@ -119,7 +126,7 @@ resource "aws_security_group" "selfhost" {
   }
 
   dynamic "ingress" {
-    for_each = var.tls_mode == "provided" ? var.web_ingress_cidrs : []
+    for_each = contains(["automatic", "provided"], var.tls_mode) ? var.web_ingress_cidrs : []
     content {
       description = "HTTPS"
       protocol    = "tcp"
@@ -181,6 +188,45 @@ resource "aws_iam_role_policy" "secrets" {
   })
 }
 
+resource "aws_iam_role_policy" "tls_dns01" {
+  count = var.tls_mode == "automatic" ? 1 : 0
+  name  = "ManageCamelAITlsDnsChallenge"
+  role  = aws_iam_role.selfhost.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ListHostedZones", "route53:ListHostedZonesByName"]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ListResourceRecordSets"]
+        Resource = "arn:aws:route53:::hostedzone/${var.route53_zone_id}"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["route53:GetChange"]
+        Resource = "arn:aws:route53:::change/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ChangeResourceRecordSets"]
+        Resource = "arn:aws:route53:::hostedzone/${var.route53_zone_id}"
+        Condition = {
+          "ForAllValues:StringEquals" = {
+            "route53:ChangeResourceRecordSetsRecordTypes" = "TXT"
+          }
+          "ForAllValues:StringLike" = {
+            "route53:ChangeResourceRecordSetsNormalizedRecordNames" = "_acme-challenge.*"
+          }
+        }
+      },
+    ]
+  })
+}
+
 resource "aws_iam_instance_profile" "selfhost" {
   name_prefix = "${var.name}-"
   role        = aws_iam_role.selfhost.name
@@ -198,6 +244,7 @@ resource "aws_ebs_volume" "data" {
 
 locals {
   cloud_init = templatefile("${path.module}/cloud-init.sh.tpl", {
+    aws_region_b64                     = base64encode(var.aws_region)
     data_volume_id_b64                 = base64encode(aws_ebs_volume.data.id)
     repository_url_b64                 = base64encode(var.repository_url)
     repository_ref_b64                 = base64encode(var.repository_ref)
@@ -207,12 +254,14 @@ locals {
     analysis_image_b64                 = base64encode(var.analysis_image)
     db_query_image_b64                 = base64encode(var.db_query_image)
     container_egress_image_b64         = base64encode(var.container_egress_image)
+    caddy_image_b64                    = base64encode(var.caddy_image)
     main_hostname_b64                  = base64encode(lower(var.main_hostname))
     app_vanity_domain_b64              = base64encode(lower(var.app_vanity_domain))
     app_iframe_domain_b64              = base64encode(lower(local.app_iframe_domain))
     tls_mode_b64                       = base64encode(var.tls_mode)
     tls_certificate_secret_arn_b64     = base64encode(var.tls_certificate_secret_arn)
     tls_private_key_secret_arn_b64     = base64encode(var.tls_private_key_secret_arn)
+    route53_zone_id_b64                = base64encode(var.route53_zone_id)
     auth_provider_b64                  = base64encode(var.auth_provider)
     auth_default_org_name_b64          = base64encode(var.auth_default_org_name)
     cloudflare_access_team_domain_b64  = base64encode(var.cloudflare_access_team_domain)
@@ -270,6 +319,7 @@ resource "aws_instance" "selfhost" {
   depends_on = [
     aws_iam_role_policy_attachment.ssm,
     aws_iam_role_policy.secrets,
+    aws_iam_role_policy.tls_dns01,
   ]
 }
 

--- a/infra/selfhost/terraform/terraform.tfvars.example
+++ b/infra/selfhost/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ name       = "camelai-selfhost"
 repository_url = "https://github.com/qaml-ai/camelAI.git"
 repository_ref = "REPLACE_WITH_TESTED_TAG_OR_COMMIT"
 
-# Use the six references from the same self-host release. Digest-pinned
+# Use the seven references from the same self-host release. Digest-pinned
 # references are preferred; release or commit tags are accepted.
 app_image             = "ghcr.io/qaml-ai/camelai-selfhost-app:selfhost-v0.1.0"
 local_artifacts_image = "ghcr.io/qaml-ai/camelai-selfhost-local-artifacts:selfhost-v0.1.0"
@@ -13,21 +13,23 @@ project_build_image   = "ghcr.io/qaml-ai/camelai-selfhost-project-build:selfhost
 analysis_image        = "ghcr.io/qaml-ai/camelai-selfhost-analysis:selfhost-v0.1.0"
 db_query_image        = "ghcr.io/qaml-ai/camelai-selfhost-db-query:selfhost-v0.1.0"
 container_egress_image = "ghcr.io/qaml-ai/camelai-selfhost-container-egress:selfhost-v0.1.0"
+caddy_image            = "ghcr.io/qaml-ai/camelai-selfhost-caddy:selfhost-v0.1.0"
 
-# A certificate in tls_certificate_secret_arn must cover all three names below:
-# camel.example.com, authenticate.example.com, and *.apps.example.com.
+# Automatic TLS uses the instance role to complete Route53 DNS-01 challenges
+# and renew the certificate without operator-provided PEM files.
 main_hostname     = "camel.example.com"
 app_vanity_domain = "apps.example.com"
-tls_mode          = "provided"
+tls_mode          = "automatic"
 
-# SecretString values are the raw PEM certificate chain and private key.
-tls_certificate_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:camelai/tls-cert-AbCdEf"
-tls_private_key_secret_arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:camelai/tls-key-AbCdEf"
-
-# Set this to true when the domain is in Route53. Otherwise create equivalent
-# main + wildcard records with your DNS provider using the public_ip output.
+# Automatic mode requires a Route53 public hosted zone. Set this to true to
+# create the main, authenticate, and wildcard A records too.
 create_route53_records = true
 route53_zone_id        = "Z0123456789EXAMPLE"
+
+# Private-PKI or air-gapped fallback:
+# tls_mode = "provided"
+# tls_certificate_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:camelai/tls-cert-AbCdEf"
+# tls_private_key_secret_arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:camelai/tls-key-AbCdEf"
 
 # Prefer SSM Session Manager. Add a narrowly scoped CIDR and key only for
 # break-glass SSH.

--- a/infra/selfhost/terraform/variables.tf
+++ b/infra/selfhost/terraform/variables.tf
@@ -111,6 +111,15 @@ variable "container_egress_image" {
   }
 }
 
+variable "caddy_image" {
+  description = "Immutable ghcr.io/qaml-ai/camelai-selfhost-caddy image with Cloudflare and Route53 DNS modules."
+  type        = string
+  validation {
+    condition     = var.caddy_image != "" && !endswith(lower(var.caddy_image), ":latest")
+    error_message = "caddy_image must be a non-latest release tag or digest."
+  }
+}
+
 variable "main_hostname" {
   description = "Public camelAI hostname without scheme, for example camel.example.com."
   type        = string
@@ -136,12 +145,12 @@ variable "app_iframe_domain" {
 }
 
 variable "tls_mode" {
-  description = "provided installs a certificate/key from Secrets Manager on Caddy; external expects an upstream TLS proxy and exposes HTTP origin port 80."
+  description = "automatic obtains and renews a wildcard certificate through Route53 DNS; provided reads PEM secrets; external exposes an HTTP origin to a trusted TLS proxy."
   type        = string
-  default     = "provided"
+  default     = "automatic"
   validation {
-    condition     = contains(["provided", "external"], var.tls_mode)
-    error_message = "tls_mode must be provided or external."
+    condition     = contains(["automatic", "provided", "external"], var.tls_mode)
+    error_message = "tls_mode must be automatic, provided, or external."
   }
 }
 
@@ -158,7 +167,7 @@ variable "tls_private_key_secret_arn" {
 }
 
 variable "web_ingress_cidrs" {
-  description = "CIDRs allowed to reach Caddy. Restrict these to an upstream proxy when tls_mode=external."
+  description = "CIDRs allowed to reach Caddy. Restrict these to the trusted upstream proxy when tls_mode=external."
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
@@ -182,7 +191,7 @@ variable "create_route53_records" {
 }
 
 variable "route53_zone_id" {
-  description = "Route53 public hosted zone id used when create_route53_records is true."
+  description = "Route53 public hosted zone id used for automatic DNS-01 TLS and optional DNS records."
   type        = string
   default     = ""
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"check:pi-bedrock-build": "node scripts/check-pi-bedrock-build.mjs",
 		"start": "node scripts/wrangler-dev.mjs",
 		"selfhost:init": "node scripts/selfhost-init.mjs",
-		"selfhost:configure": "node scripts/selfhost-pomerium-config.mjs",
+		"selfhost:configure": "node scripts/selfhost-configure.mjs",
 		"selfhost:doctor": "node scripts/selfhost-doctor.mjs",
 		"selfhost:up": "node scripts/selfhost-up.mjs",
 		"selfhost:workerd:build": "bun run build:cf && node scripts/selfhost-workerd-config.mjs",

--- a/scripts/selfhost-caddy-config.mjs
+++ b/scripts/selfhost-caddy-config.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  envFile,
+  readSelfhostEnv,
+  repoRoot,
+} from "./selfhost-common.mjs";
+import {
+  selfhostTlsMode,
+} from "./selfhost-tls-mode.mjs";
+
+export const caddyDirectory = path.join(repoRoot, ".selfhost", "caddy");
+export const caddyConfigFile = path.join(caddyDirectory, "Caddyfile");
+export const caddySecretsDirectory = path.join(caddyDirectory, "secrets");
+
+export async function writeCaddyConfig(env, { strict = true } = {}) {
+  const tlsMode = selfhostTlsMode(env);
+  if (!new Set(["automatic", "external", "provided"]).has(tlsMode)) {
+    throw new Error(
+      'SELFHOST_TLS_MODE must be "automatic", "external", or "provided"',
+    );
+  }
+
+  const authMode = (env.SELFHOST_AUTH_MODE || "").trim();
+  if (
+    tlsMode !== "external" &&
+    authMode !== "bundled-pomerium" &&
+    authMode !== "local"
+  ) {
+    throw new Error(
+      `SELFHOST_TLS_MODE=${tlsMode} requires bundled-pomerium authentication; ` +
+        "external identity proxies must use SELFHOST_TLS_MODE=external",
+    );
+  }
+
+  const mainHostname = requiredHostname(
+    env.SELFHOST_MAIN_HOSTNAME ||
+      new URL(requiredValue(env.SELFHOST_PUBLIC_BASE_URL, "SELFHOST_PUBLIC_BASE_URL"))
+        .hostname,
+    "SELFHOST_MAIN_HOSTNAME",
+  );
+  const authenticateHostname =
+    authMode === "bundled-pomerium"
+      ? requiredHostname(
+          env.POMERIUM_AUTHENTICATE_HOSTNAME ||
+            new URL(
+              requiredValue(
+                env.POMERIUM_AUTHENTICATE_URL,
+                "POMERIUM_AUTHENTICATE_URL",
+              ),
+            ).hostname,
+          "POMERIUM_AUTHENTICATE_HOSTNAME",
+        )
+      : "";
+  const appDomains = uniqueDomains([
+    env.LOCAL_APP_VANITY_DOMAIN,
+    env.LOCAL_APP_IFRAME_DOMAIN,
+  ]);
+  const upstream =
+    authMode === "bundled-pomerium"
+      ? "http://127.0.0.1:5444"
+      : `http://127.0.0.1:${validPort(env.SELFHOST_APP_PORT || "3001")}`;
+
+  await fs.mkdir(caddySecretsDirectory, {
+    recursive: true,
+    mode: 0o700,
+  });
+  await fs.chmod(caddySecretsDirectory, 0o700);
+  await removeUnusedSecrets(env, tlsMode);
+
+  let tlsBlock = "";
+  if (tlsMode === "automatic") {
+    tlsBlock = await automaticTlsBlock(env, { strict });
+  } else if (tlsMode === "provided") {
+    await copyProvidedTls(env, { strict });
+    tlsBlock = [
+      "\ttls /run/camelai-secrets/tls.crt /run/camelai-secrets/tls.key",
+    ].join("\n");
+  }
+
+  const globalOptions = ["{", "\tadmin 127.0.0.1:2019"];
+  if ((env.SELFHOST_TLS_ACME_EMAIL || "").trim()) {
+    globalOptions.push(
+      `\temail ${caddyToken(env.SELFHOST_TLS_ACME_EMAIL, "SELFHOST_TLS_ACME_EMAIL")}`,
+    );
+  }
+  globalOptions.push("}");
+
+  let config;
+  if (tlsMode === "external") {
+    const bindAddress = validBindAddress(
+      env.SELFHOST_TLS_EXTERNAL_BIND_ADDRESS || "127.0.0.1",
+    );
+    const port = validPort(env.SELFHOST_TLS_EXTERNAL_PORT || "8080");
+    config = [
+      ...globalOptions,
+      "",
+      `http://:${port} {`,
+      `\tbind ${bindAddress}`,
+      proxyBlock(upstream),
+      "}",
+    ];
+  } else {
+    const siteAddresses = [
+      mainHostname,
+      ...(authenticateHostname ? [authenticateHostname] : []),
+      ...appDomains.map((domain) => `*.${domain}`),
+    ].map((hostname) => `https://${hostname}`);
+    config = [
+      ...globalOptions,
+      "",
+      `${siteAddresses.join(", ")} {`,
+      tlsBlock,
+      proxyBlock(upstream),
+      "}",
+    ];
+  }
+
+  await fs.mkdir(caddyDirectory, { recursive: true, mode: 0o700 });
+  await fs.chmod(caddyDirectory, 0o700);
+  await fs.writeFile(caddyConfigFile, `${config.join("\n")}\n`, {
+    mode: 0o600,
+  });
+  return caddyConfigFile;
+}
+
+async function automaticTlsBlock(env, { strict }) {
+  const provider = (env.SELFHOST_TLS_DNS_PROVIDER || "").trim().toLowerCase();
+  if (!new Set(["cloudflare", "route53"]).has(provider)) {
+    throw new Error(
+      'SELFHOST_TLS_DNS_PROVIDER must be "cloudflare" or "route53" when SELFHOST_TLS_MODE=automatic',
+    );
+  }
+
+  if (provider === "cloudflare") {
+    const token = (env.SELFHOST_TLS_CLOUDFLARE_API_TOKEN || "").trim();
+    if (strict && !token) {
+      throw new Error(
+        "SELFHOST_TLS_CLOUDFLARE_API_TOKEN is required for automatic Cloudflare DNS validation",
+      );
+    }
+    await writeSecret("cloudflare-api-token", token);
+    return [
+      "\ttls {",
+      "\t\tdns cloudflare {file./run/camelai-secrets/cloudflare-api-token}",
+      "\t}",
+    ].join("\n");
+  }
+
+  await writeAwsCredentials(env, { strict });
+  const hostedZoneId = (env.SELFHOST_TLS_ROUTE53_HOSTED_ZONE_ID || "").trim();
+  return [
+    "\ttls {",
+    "\t\tdns route53 {",
+    ...(hostedZoneId
+      ? [
+          `\t\t\thosted_zone_id ${caddyToken(
+            hostedZoneId,
+            "SELFHOST_TLS_ROUTE53_HOSTED_ZONE_ID",
+          )}`,
+        ]
+      : []),
+    "\t\t}",
+    "\t}",
+  ].join("\n");
+}
+
+async function copyProvidedTls(env, { strict }) {
+  const configuredCertificate = (
+    env.SELFHOST_TLS_CERTIFICATE_FILE || ""
+  ).trim();
+  const configuredPrivateKey = (
+    env.SELFHOST_TLS_PRIVATE_KEY_FILE || ""
+  ).trim();
+  const certificateSource = configuredCertificate
+    ? resolveOperatorPath(configuredCertificate)
+    : firstExisting([
+        path.join(repoRoot, ".selfhost", "tls", "tls.crt"),
+        path.join(repoRoot, ".selfhost", "pomerium", "tls.crt"),
+      ]);
+  const privateKeySource = configuredPrivateKey
+    ? resolveOperatorPath(configuredPrivateKey)
+    : firstExisting([
+        path.join(repoRoot, ".selfhost", "tls", "tls.key"),
+        path.join(repoRoot, ".selfhost", "pomerium", "tls.key"),
+      ]);
+
+  if (strict && (!certificateSource || !existsSync(certificateSource))) {
+    throw new Error(
+      "missing provided TLS certificate; set SELFHOST_TLS_CERTIFICATE_FILE or install .selfhost/tls/tls.crt",
+    );
+  }
+  if (strict && (!privateKeySource || !existsSync(privateKeySource))) {
+    throw new Error(
+      "missing provided TLS private key; set SELFHOST_TLS_PRIVATE_KEY_FILE or install .selfhost/tls/tls.key",
+    );
+  }
+  if (certificateSource && existsSync(certificateSource)) {
+    await copySecret(certificateSource, "tls.crt");
+  }
+  if (privateKeySource && existsSync(privateKeySource)) {
+    await copySecret(privateKeySource, "tls.key");
+  }
+}
+
+async function removeUnusedSecrets(env, tlsMode) {
+  const dnsProvider = (
+    env.SELFHOST_TLS_DNS_PROVIDER || ""
+  ).trim().toLowerCase();
+  const retained = new Set(
+    tlsMode === "provided"
+      ? ["tls.crt", "tls.key"]
+      : tlsMode === "automatic" && dnsProvider === "cloudflare"
+        ? ["cloudflare-api-token"]
+        : tlsMode === "automatic" && dnsProvider === "route53"
+          ? ["aws-credentials"]
+          : [],
+  );
+  for (const name of [
+    "aws-credentials",
+    "cloudflare-api-token",
+    "tls.crt",
+    "tls.key",
+  ]) {
+    if (!retained.has(name)) {
+      await fs.rm(path.join(caddySecretsDirectory, name), { force: true });
+    }
+  }
+}
+
+async function writeAwsCredentials(env, { strict }) {
+  const accessKeyId = (env.SELFHOST_TLS_AWS_ACCESS_KEY_ID || "").trim();
+  const secretAccessKey = (
+    env.SELFHOST_TLS_AWS_SECRET_ACCESS_KEY || ""
+  ).trim();
+  const sessionToken = (env.SELFHOST_TLS_AWS_SESSION_TOKEN || "").trim();
+  for (const [name, value] of [
+    ["SELFHOST_TLS_AWS_ACCESS_KEY_ID", accessKeyId],
+    ["SELFHOST_TLS_AWS_SECRET_ACCESS_KEY", secretAccessKey],
+    ["SELFHOST_TLS_AWS_SESSION_TOKEN", sessionToken],
+  ]) {
+    if (/[\r\n]/.test(value)) {
+      throw new Error(`${name} must be a single line`);
+    }
+  }
+  if (Boolean(accessKeyId) !== Boolean(secretAccessKey)) {
+    throw new Error(
+      "SELFHOST_TLS_AWS_ACCESS_KEY_ID and SELFHOST_TLS_AWS_SECRET_ACCESS_KEY must be set together",
+    );
+  }
+  if (strict && sessionToken && !accessKeyId) {
+    throw new Error(
+      "SELFHOST_TLS_AWS_SESSION_TOKEN requires explicit AWS access-key credentials",
+    );
+  }
+  if (!accessKeyId) {
+    await fs.rm(path.join(caddySecretsDirectory, "aws-credentials"), {
+      force: true,
+    });
+    return;
+  }
+  const profile =
+    (env.SELFHOST_TLS_AWS_PROFILE || "default").trim() || "default";
+  if (!/^[A-Za-z0-9_.-]+$/.test(profile)) {
+    throw new Error(
+      "SELFHOST_TLS_AWS_PROFILE contains unsupported characters",
+    );
+  }
+  const lines = [
+    `[${profile}]`,
+    `aws_access_key_id=${accessKeyId}`,
+    `aws_secret_access_key=${secretAccessKey}`,
+    ...(sessionToken ? [`aws_session_token=${sessionToken}`] : []),
+  ];
+  await writeSecret("aws-credentials", `${lines.join("\n")}\n`);
+}
+
+function proxyBlock(upstream) {
+  return [
+    `\treverse_proxy ${upstream} {`,
+    "\t\theader_up X-Forwarded-Proto https",
+    "\t}",
+  ].join("\n");
+}
+
+async function writeSecret(name, value) {
+  const destination = path.join(caddySecretsDirectory, name);
+  if (!value) {
+    await fs.rm(destination, { force: true });
+    return;
+  }
+  await fs.writeFile(destination, value, { mode: 0o600 });
+  await fs.chmod(destination, 0o600);
+}
+
+async function copySecret(source, name) {
+  const destination = path.join(caddySecretsDirectory, name);
+  await fs.copyFile(source, destination);
+  await fs.chmod(destination, 0o600);
+}
+
+function firstExisting(paths) {
+  return paths.find((candidate) => existsSync(candidate)) || paths[0];
+}
+
+function resolveOperatorPath(value) {
+  return path.isAbsolute(value) ? value : path.resolve(repoRoot, value);
+}
+
+function uniqueDomains(values) {
+  return [
+    ...new Set(
+      values
+        .filter((value) => (value || "").trim())
+        .map((value) => requiredHostname(value, "deployed app domain")),
+    ),
+  ];
+}
+
+function requiredValue(value, name) {
+  const result = String(value || "").trim();
+  if (!result) throw new Error(`${name} is required`);
+  return result;
+}
+
+function requiredHostname(value, name) {
+  const hostname = requiredValue(value, name).toLowerCase();
+  if (
+    !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/.test(
+      hostname,
+    )
+  ) {
+    throw new Error(`${name} must be a DNS hostname`);
+  }
+  return hostname;
+}
+
+function validPort(value) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`invalid TCP port: ${value}`);
+  }
+  return port;
+}
+
+function validBindAddress(value) {
+  const address = String(value || "").trim();
+  if (!new Set(["127.0.0.1", "0.0.0.0", "::1", "::"]).has(address)) {
+    throw new Error(
+      "SELFHOST_TLS_EXTERNAL_BIND_ADDRESS must be a loopback or wildcard IP address",
+    );
+  }
+  return address;
+}
+
+function caddyToken(value, name) {
+  const token = requiredValue(value, name);
+  if (!/^[A-Za-z0-9_.:+@/-]+$/.test(token)) {
+    throw new Error(`${name} contains unsupported Caddyfile characters`);
+  }
+  return token;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const env = await readSelfhostEnv(true);
+  await writeCaddyConfig(env);
+  console.log(`Wrote ${path.relative(repoRoot, caddyConfigFile)}.`);
+  console.log(`Using ${path.relative(repoRoot, envFile)}.`);
+}

--- a/scripts/selfhost-common.mjs
+++ b/scripts/selfhost-common.mjs
@@ -3,6 +3,10 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import {
+  tlsTerminatesOnVm,
+  usesCaddy,
+} from "./selfhost-tls-mode.mjs";
 
 export const repoRoot = path.resolve(import.meta.dirname, "..");
 export const composeFile = path.join(repoRoot, "docker-compose.selfhost.yml");
@@ -18,6 +22,14 @@ export const pomeriumLoopbackComposeFile = path.join(
   repoRoot,
   "docker-compose.selfhost.pomerium-loopback.yml",
 );
+export const caddyComposeFile = path.join(
+  repoRoot,
+  "docker-compose.selfhost.caddy.yml",
+);
+export const caddySourceComposeFile = path.join(
+  repoRoot,
+  "docker-compose.selfhost.caddy-source.yml",
+);
 export const envFile = path.resolve(
   repoRoot,
   process.env.SELFHOST_ENV_FILE || ".env.selfhost",
@@ -26,10 +38,12 @@ export const defaultProjectName = "camelai-selfhost";
 export const volumeNames = ["app-state", "local-artifacts-repos"];
 
 export function volumeNamesForEnv(env = {}) {
-  return (env.SELFHOST_AUTH_MODE || process.env.SELFHOST_AUTH_MODE) ===
+  const names =
+    (env.SELFHOST_AUTH_MODE || process.env.SELFHOST_AUTH_MODE) ===
     "bundled-pomerium"
     ? [...volumeNames, "pomerium-data"]
     : volumeNames;
+  return usesCaddy(env) ? [...names, "caddy-data", "caddy-config"] : names;
 }
 
 export async function readSelfhostEnv(required = false) {
@@ -81,10 +95,8 @@ export function composeArgs(env, args) {
     (env.SELFHOST_AUTH_MODE || process.env.SELFHOST_AUTH_MODE) ===
     "bundled-pomerium";
   const pomeriumLoopbackHttps =
-    bundledPomerium &&
-    (env.SELFHOST_POMERIUM_LOOPBACK_HTTPS ||
-      process.env.SELFHOST_POMERIUM_LOOPBACK_HTTPS ||
-      "1") !== "0";
+    bundledPomerium && tlsTerminatesOnVm(env);
+  const caddy = usesCaddy(env);
   return [
     "compose",
     "--env-file",
@@ -93,6 +105,8 @@ export function composeArgs(env, args) {
     composeFile,
     ...(sourceMode ? ["-f", sourceComposeFile] : []),
     ...(bundledPomerium ? ["-f", pomeriumComposeFile] : []),
+    ...(caddy ? ["-f", caddyComposeFile] : []),
+    ...(sourceMode && caddy ? ["-f", caddySourceComposeFile] : []),
     ...(pomeriumLoopbackHttps ? ["-f", pomeriumLoopbackComposeFile] : []),
     ...args,
   ];
@@ -128,6 +142,10 @@ export function scriptEnv(env = {}, extra = {}) {
           env.SELFHOST_CONTAINER_EGRESS_IMAGE ||
           process.env.SELFHOST_CONTAINER_EGRESS_IMAGE ||
           "camelai-selfhost-container-egress:0.12.0",
+        SELFHOST_CADDY_IMAGE:
+          env.SELFHOST_CADDY_IMAGE ||
+          process.env.SELFHOST_CADDY_IMAGE ||
+          "camelai-selfhost-caddy:source",
       }
     : {};
   return {

--- a/scripts/selfhost-configure.mjs
+++ b/scripts/selfhost-configure.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import path from "node:path";
+import {
+  readSelfhostEnv,
+  repoRoot,
+} from "./selfhost-common.mjs";
+import {
+  caddyConfigFile,
+  writeCaddyConfig,
+} from "./selfhost-caddy-config.mjs";
+import {
+  pomeriumConfigFile,
+  writePomeriumConfig,
+} from "./selfhost-pomerium-config.mjs";
+
+const env = await readSelfhostEnv(true);
+const pomerium = await writePomeriumConfig(env);
+const caddy = await writeCaddyConfig(env);
+
+for (const file of [pomerium, caddy]) {
+  if (file) console.log(`Wrote ${path.relative(repoRoot, file)}.`);
+}
+if (!pomerium) {
+  console.log(`Pomerium configuration is external; ${path.relative(repoRoot, pomeriumConfigFile)} was not changed.`);
+}
+console.log(`TLS front door: ${path.relative(repoRoot, caddyConfigFile)}.`);

--- a/scripts/selfhost-doctor.mjs
+++ b/scripts/selfhost-doctor.mjs
@@ -15,6 +15,15 @@ import {
   volumeName,
   volumeNamesForEnv,
 } from "./selfhost-common.mjs";
+import {
+  selfhostTlsMode,
+  usesCaddy,
+} from "./selfhost-tls-mode.mjs";
+import {
+  caddyDirectory,
+  caddySecretsDirectory,
+  writeCaddyConfig,
+} from "./selfhost-caddy-config.mjs";
 import { writePomeriumConfig } from "./selfhost-pomerium-config.mjs";
 
 const checks = [];
@@ -75,6 +84,7 @@ const imageKeys = [
   "SELFHOST_ANALYSIS_IMAGE",
   "SELFHOST_DB_QUERY_IMAGE",
   "SELFHOST_CONTAINER_EGRESS_IMAGE",
+  ...(usesCaddy(env) ? ["SELFHOST_CADDY_IMAGE"] : []),
 ];
 
 await check("container images", async () => {
@@ -245,13 +255,6 @@ await check("authentication", async () => {
     if (!/@sha256:[0-9a-f]{64}$/i.test(env.SELFHOST_POMERIUM_IMAGE || "")) {
       fail("SELFHOST_POMERIUM_IMAGE must be pinned by sha256 digest");
     }
-    if (
-      !new Set(["0", "1"]).has(
-        (env.SELFHOST_POMERIUM_LOOPBACK_HTTPS || "1").trim(),
-      )
-    ) {
-      fail("SELFHOST_POMERIUM_LOOPBACK_HTTPS must be 0 or 1");
-    }
     for (const key of [
       "POMERIUM_ISSUER",
       "POMERIUM_AUDIENCE",
@@ -261,7 +264,6 @@ await check("authentication", async () => {
     }
     await writePomeriumConfig(env);
     note("bundled Pomerium configuration rendered");
-    note(`TLS mode: ${env.SELFHOST_POMERIUM_TLS_MODE || "direct"}`);
     return;
   }
   if (mode === "external-pomerium") {
@@ -297,6 +299,80 @@ await check("authentication", async () => {
     fail("SELFHOST_AUTH_MODE=local requires LOCAL_AUTH_BYPASS=1");
   }
   warn("local authentication bypass is for smoke tests only");
+});
+
+await check("TLS front door", async () => {
+  const mode = selfhostTlsMode(env);
+  if (!new Set(["automatic", "external", "provided"]).has(mode)) {
+    fail(
+      `SELFHOST_TLS_MODE must be automatic, external, or provided; got ${mode}`,
+    );
+  }
+  if (!/@sha256:[0-9a-f]{64}$/i.test(env.SELFHOST_CADDY_IMAGE || "") &&
+      deploymentMode === "release") {
+    fail("SELFHOST_CADDY_IMAGE must be pinned by sha256 digest in release mode");
+  }
+  await writeCaddyConfig(env);
+  note(`SELFHOST_TLS_MODE: ${mode}`);
+  if (mode === "automatic") {
+    note(`DNS provider: ${env.SELFHOST_TLS_DNS_PROVIDER}`);
+    if ((env.SELFHOST_TLS_DNS_PROVIDER || "").trim() === "route53") {
+      note(
+        (env.SELFHOST_TLS_AWS_ACCESS_KEY_ID || "").trim()
+          ? "Route 53 credentials: protected generated credentials file"
+          : "Route 53 credentials: AWS instance role or ambient SDK credentials",
+      );
+    }
+  } else if (mode === "external") {
+    const bindAddress = (
+      env.SELFHOST_TLS_EXTERNAL_BIND_ADDRESS || "127.0.0.1"
+    ).trim();
+    if (bindAddress === "0.0.0.0" || bindAddress === "::") {
+      warn(
+        "external TLS origin listens on all interfaces; restrict ingress to the trusted TLS proxy",
+      );
+    }
+    note(
+      `HTTP origin: ${bindAddress}:${env.SELFHOST_TLS_EXTERNAL_PORT || "8080"}`,
+    );
+  } else {
+    note("operator-provided certificate copied into the protected Caddy mount");
+  }
+  note("Caddy configuration rendered");
+
+  const caddyImage = effectiveEnv.SELFHOST_CADDY_IMAGE;
+  const inspect = await capture("docker", ["image", "inspect", caddyImage], {
+    env: effectiveEnv,
+  });
+  if (inspect.code === 0) {
+    const validation = await capture(
+      "docker",
+      [
+        "run",
+        "--rm",
+        "--volume",
+        `${caddyDirectory}:/etc/caddy:ro`,
+        "--volume",
+        `${caddySecretsDirectory}:/run/camelai-secrets:ro`,
+        "--env",
+        `AWS_REGION=${env.SELFHOST_TLS_AWS_REGION || "us-east-1"}`,
+        caddyImage,
+        "caddy",
+        "validate",
+        "--config",
+        "/etc/caddy/Caddyfile",
+      ],
+      { env: effectiveEnv },
+    );
+    if (validation.code !== 0) {
+      fail(validation.stderr.trim() || "Caddy configuration validation failed");
+    }
+    note("Caddy configuration validated with the configured image");
+  } else {
+    note(
+      "Caddy image is not local yet; image-level validation deferred until pull/build",
+    );
+  }
 });
 
 await check("compose config", async () => {

--- a/scripts/selfhost-init.mjs
+++ b/scripts/selfhost-init.mjs
@@ -10,6 +10,7 @@ import {
   repoRoot,
   writeEnvValue,
 } from "./selfhost-common.mjs";
+import { writeCaddyConfig } from "./selfhost-caddy-config.mjs";
 import { writePomeriumConfig } from "./selfhost-pomerium-config.mjs";
 
 const force = process.argv.includes("--force");
@@ -33,14 +34,27 @@ const values = {
   SELFHOST_DB_QUERY_IMAGE: "camelai-selfhost-db-query:0.12.0",
   SELFHOST_CONTAINER_EGRESS_IMAGE:
     "camelai-selfhost-container-egress:0.12.0",
+  SELFHOST_CADDY_IMAGE: "camelai-selfhost-caddy:source",
   SELFHOST_BIND_ADDRESS: "127.0.0.1",
   SELFHOST_APP_PORT: "3001",
   SELFHOST_PUBLIC_BASE_URL: "https://camel.example.com",
   SELFHOST_INTERNAL_APP_URL: "http://127.0.0.1:3001",
   SELFHOST_AUTH_MODE: "bundled-pomerium",
   SELFHOST_MAIN_HOSTNAME: "camel.example.com",
-  SELFHOST_POMERIUM_TLS_MODE: "direct",
-  SELFHOST_POMERIUM_LOOPBACK_HTTPS: "1",
+  SELFHOST_TLS_MODE: "automatic",
+  SELFHOST_TLS_DNS_PROVIDER: "cloudflare",
+  SELFHOST_TLS_ACME_EMAIL: "",
+  SELFHOST_TLS_CLOUDFLARE_API_TOKEN: "",
+  SELFHOST_TLS_ROUTE53_HOSTED_ZONE_ID: "",
+  SELFHOST_TLS_AWS_REGION: "us-east-1",
+  SELFHOST_TLS_AWS_PROFILE: "default",
+  SELFHOST_TLS_AWS_ACCESS_KEY_ID: "",
+  SELFHOST_TLS_AWS_SECRET_ACCESS_KEY: "",
+  SELFHOST_TLS_AWS_SESSION_TOKEN: "",
+  SELFHOST_TLS_CERTIFICATE_FILE: "",
+  SELFHOST_TLS_PRIVATE_KEY_FILE: "",
+  SELFHOST_TLS_EXTERNAL_BIND_ADDRESS: "127.0.0.1",
+  SELFHOST_TLS_EXTERNAL_PORT: "8080",
   SELFHOST_POMERIUM_IMAGE:
     "pomerium/pomerium@sha256:aae6010af6ba4c864bbd3f748cf37843a140b1ddef74d7d2ac1aa87660f8da1f",
   LOCAL_APP_VANITY_DOMAIN: "apps.example.com",
@@ -101,9 +115,10 @@ ${Object.entries(values)
 
 await fs.writeFile(envFile, content, { mode: 0o600 });
 await writePomeriumConfig(values, { strict: false });
+await writeCaddyConfig(values, { strict: false });
 console.log(`Wrote ${path.relative(repoRoot, envFile)}.`);
 console.log("Next steps:");
-console.log("  Configure identity, DNS, TLS, and AI settings in .env.selfhost");
+console.log("  Configure identity, automatic TLS, DNS, and AI settings in .env.selfhost");
 console.log("  bun run selfhost:configure");
 console.log("  bun run selfhost:doctor");
 console.log("  bun run selfhost:up");

--- a/scripts/selfhost-pomerium-config.mjs
+++ b/scripts/selfhost-pomerium-config.mjs
@@ -7,6 +7,7 @@ import {
   readSelfhostEnv,
   repoRoot,
 } from "./selfhost-common.mjs";
+import { usesCaddy } from "./selfhost-tls-mode.mjs";
 
 export const pomeriumConfigFile = path.join(
   repoRoot,
@@ -55,7 +56,9 @@ export async function writePomeriumConfig(env, { strict = true } = {}) {
   }
 
   const appPort = validPort(env.SELFHOST_APP_PORT || "3001");
-  const tlsMode = (env.SELFHOST_POMERIUM_TLS_MODE || "direct").trim();
+  const tlsMode = usesCaddy(env)
+    ? "upstream"
+    : (env.SELFHOST_POMERIUM_TLS_MODE || "upstream").trim();
   if (!new Set(["direct", "upstream"]).has(tlsMode)) {
     throw new Error(
       'SELFHOST_POMERIUM_TLS_MODE must be "direct" or "upstream"',
@@ -71,16 +74,6 @@ export async function writePomeriumConfig(env, { strict = true } = {}) {
       requiredHttpsUrl(
         env.POMERIUM_IDP_PROVIDER_URL,
         "POMERIUM_IDP_PROVIDER_URL",
-      );
-    }
-    if (tlsMode === "direct") {
-      await requireFile(
-        path.join(repoRoot, ".selfhost", "pomerium", "tls.crt"),
-        ".selfhost/pomerium/tls.crt",
-      );
-      await requireFile(
-        path.join(repoRoot, ".selfhost", "pomerium", "tls.key"),
-        ".selfhost/pomerium/tls.key",
       );
     }
   }
@@ -225,13 +218,6 @@ function validPort(value) {
 
 function requireValue(value, name) {
   if (!String(value || "").trim()) throw new Error(`Missing ${name}`);
-}
-
-async function requireFile(filePath, displayPath) {
-  const stat = await fs.stat(filePath).catch(() => null);
-  if (!stat?.isFile() || stat.size === 0) {
-    throw new Error(`Missing ${displayPath}`);
-  }
 }
 
 if (path.resolve(process.argv[1] || "") === path.resolve(import.meta.filename)) {

--- a/scripts/selfhost-tls-mode.mjs
+++ b/scripts/selfhost-tls-mode.mjs
@@ -1,0 +1,34 @@
+import process from "node:process";
+
+export function selfhostTlsMode(env = {}) {
+  const configured = (
+    env.SELFHOST_TLS_MODE ||
+    process.env.SELFHOST_TLS_MODE ||
+    ""
+  ).trim();
+  if (configured) return configured;
+
+  // Migrate installations created before SELFHOST_TLS_MODE existed. Their
+  // operator-provided PEM files can move from direct Pomerium TLS to Caddy
+  // without requiring a new certificate.
+  if (
+    (env.SELFHOST_AUTH_MODE || process.env.SELFHOST_AUTH_MODE) ===
+      "bundled-pomerium" &&
+    (env.SELFHOST_POMERIUM_TLS_MODE ||
+      process.env.SELFHOST_POMERIUM_TLS_MODE ||
+      "direct") === "direct"
+  ) {
+    return "provided";
+  }
+  return "external";
+}
+
+export function usesCaddy(env = {}) {
+  return new Set(["automatic", "external", "provided"]).has(
+    selfhostTlsMode(env),
+  );
+}
+
+export function tlsTerminatesOnVm(env = {}) {
+  return new Set(["automatic", "provided"]).has(selfhostTlsMode(env));
+}

--- a/scripts/selfhost-up.mjs
+++ b/scripts/selfhost-up.mjs
@@ -5,10 +5,12 @@ import {
   run,
   scriptEnv,
 } from "./selfhost-common.mjs";
+import { writeCaddyConfig } from "./selfhost-caddy-config.mjs";
 import { writePomeriumConfig } from "./selfhost-pomerium-config.mjs";
 
 const env = await readSelfhostEnv(true);
 await writePomeriumConfig(env);
+await writeCaddyConfig(env);
 const sourceMode =
   (env.SELFHOST_DEPLOYMENT_MODE || process.env.SELFHOST_DEPLOYMENT_MODE) ===
   "source";

--- a/scripts/selfhost-upgrade.mjs
+++ b/scripts/selfhost-upgrade.mjs
@@ -12,6 +12,7 @@ import {
   scriptEnv,
   writeEnvValue,
 } from "./selfhost-common.mjs";
+import { writeCaddyConfig } from "./selfhost-caddy-config.mjs";
 import { writePomeriumConfig } from "./selfhost-pomerium-config.mjs";
 
 const IMAGE_ENV_BY_MANIFEST_KEY = {
@@ -21,6 +22,7 @@ const IMAGE_ENV_BY_MANIFEST_KEY = {
   analysis: "SELFHOST_ANALYSIS_IMAGE",
   "db-query": "SELFHOST_DB_QUERY_IMAGE",
   "container-egress": "SELFHOST_CONTAINER_EGRESS_IMAGE",
+  caddy: "SELFHOST_CADDY_IMAGE",
   pomerium: "SELFHOST_POMERIUM_IMAGE",
 };
 
@@ -191,6 +193,7 @@ async function applyCurrentConfig(env, { onRuntimeStart } = {}) {
     "source";
   const effectiveEnv = scriptEnv(env);
   await writePomeriumConfig(env);
+  await writeCaddyConfig(env);
 
   await run(
     "docker",
@@ -302,29 +305,14 @@ async function restoreReleaseState(snapshotDir) {
   await run("bun", ["install", "--frozen-lockfile"]);
 
   const restoredEnv = await readSelfhostEnv(true);
-  await writePomeriumConfig(restoredEnv);
-  const pull = await capture("docker", composeArgs(restoredEnv, ["pull"]), {
+  // The restored checkout owns its Compose topology and config schema. This
+  // matters when rolling back across a release that adds or removes overlays.
+  await run("bun", ["run", "selfhost:configure"], {
     env: scriptEnv(restoredEnv),
   });
-  if (pull.code !== 0) {
-    console.warn(
-      `[selfhost:upgrade] Could not refresh rollback images; trying the images already present locally: ${
-        pull.stderr.trim() || `docker compose pull exited ${pull.code}`
-      }`,
-    );
-  }
-  await run(
-    "docker",
-    composeArgs(restoredEnv, [
-      "up",
-      "-d",
-      "--remove-orphans",
-      "--wait",
-      "--wait-timeout",
-      "900",
-    ]),
-    { env: scriptEnv(restoredEnv) },
-  );
+  await run("bun", ["run", "selfhost:up"], {
+    env: scriptEnv(restoredEnv),
+  });
   await run(process.execPath, ["scripts/selfhost-doctor.mjs"], {
     env: scriptEnv(restoredEnv),
   });

--- a/scripts/test-selfhost-release.mjs
+++ b/scripts/test-selfhost-release.mjs
@@ -2,12 +2,15 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
+  caddyComposeFile,
+  caddySourceComposeFile,
   composeArgs,
   pomeriumComposeFile,
   pomeriumLoopbackComposeFile,
   sourceComposeFile,
   volumeNamesForEnv,
 } from "./selfhost-common.mjs";
+import { selfhostTlsMode } from "./selfhost-tls-mode.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -29,6 +32,11 @@ const [
   pomeriumOverride,
   pomeriumLoopbackOverride,
   pomeriumConfig,
+  caddyOverride,
+  caddySourceOverride,
+  caddyConfig,
+  caddyDockerfile,
+  tlsModeScript,
   commonScript,
   bundledDockerfile,
   imageWorkflow,
@@ -46,6 +54,11 @@ const [
   read("docker-compose.selfhost.pomerium.yml"),
   read("docker-compose.selfhost.pomerium-loopback.yml"),
   read("scripts/selfhost-pomerium-config.mjs"),
+  read("docker-compose.selfhost.caddy.yml"),
+  read("docker-compose.selfhost.caddy-source.yml"),
+  read("scripts/selfhost-caddy-config.mjs"),
+  read("infra/selfhost/caddy.Dockerfile"),
+  read("scripts/selfhost-tls-mode.mjs"),
   read("scripts/selfhost-common.mjs"),
   read("infra/selfhost/app-bundled.Dockerfile"),
   read(".github/workflows/selfhost-images.yml"),
@@ -130,6 +143,10 @@ assert(
   !pomeriumOverride.includes("IDP_CLIENT_SECRET:"),
   "bundled Pomerium secrets must not be exposed through container environment values",
 );
+assert(
+  !pomeriumOverride.includes("NET_BIND_SERVICE"),
+  "bundled Pomerium must not retain the capability to bind public TLS ports",
+);
 includesAll(
   pomeriumConfig,
   [
@@ -150,40 +167,126 @@ assert(
   ".env.selfhost must be the single source of truth for generated Pomerium configuration",
 );
 includesAll(
+  caddyOverride,
+  [
+    "SELFHOST_CADDY_IMAGE",
+    "network_mode: host",
+    "./.selfhost/caddy:/etc/caddy:ro",
+    "./.selfhost/caddy/secrets:/run/camelai-secrets:ro",
+    "caddy-data",
+    "caddy-config",
+    "NET_BIND_SERVICE",
+    "no-new-privileges:true",
+  ],
+  "Caddy TLS front-door Compose override",
+);
+includesAll(
+  caddySourceOverride,
+  ["infra/selfhost/caddy.Dockerfile", "camelai-selfhost-caddy:source"],
+  "source-build Caddy override",
+);
+includesAll(
+  caddyDockerfile,
+  [
+    "ARG CADDY_VERSION=2.11.4",
+    "caddy:${CADDY_VERSION}-builder-alpine",
+    "caddy-dns/cloudflare@v0.2.4",
+    "caddy-dns/route53@v1.6.2",
+    "caddy:${CADDY_VERSION}-alpine",
+  ],
+  "Caddy release image",
+);
+includesAll(
+  caddyConfig,
+  [
+    "SELFHOST_TLS_MODE",
+    "SELFHOST_TLS_DNS_PROVIDER",
+    "dns cloudflare",
+    "dns route53",
+    "hosted_zone_id",
+    "/run/camelai-secrets/tls.crt",
+    "SELFHOST_TLS_EXTERNAL_BIND_ADDRESS",
+    "http://127.0.0.1:5444",
+  ],
+  "Caddy configuration generator",
+);
+includesAll(
+  tlsModeScript,
+  [
+    '"automatic"',
+    '"external"',
+    '"provided"',
+    "SELFHOST_POMERIUM_TLS_MODE",
+  ],
+  "legacy TLS-mode migration",
+);
+assert(
+  selfhostTlsMode({
+    SELFHOST_AUTH_MODE: "bundled-pomerium",
+    SELFHOST_POMERIUM_TLS_MODE: "direct",
+  }) === "provided",
+  "legacy direct-Pomerium installs must migrate to provided Caddy TLS",
+);
+assert(
+  selfhostTlsMode({
+    SELFHOST_AUTH_MODE: "bundled-pomerium",
+    SELFHOST_POMERIUM_TLS_MODE: "upstream",
+  }) === "external",
+  "legacy upstream-Pomerium installs must preserve external TLS termination",
+);
+includesAll(
   commonScript,
   [
     "docker-compose.selfhost.pomerium.yml",
     "docker-compose.selfhost.pomerium-loopback.yml",
-    "SELFHOST_POMERIUM_LOOPBACK_HTTPS",
+    "docker-compose.selfhost.caddy.yml",
+    "docker-compose.selfhost.caddy-source.yml",
+    "tlsTerminatesOnVm",
     '"bundled-pomerium"',
     '"pomerium-data"',
+    '"caddy-data"',
+    '"caddy-config"',
   ],
   "self-host Compose selection",
 );
 for (const [name, env, expectedFiles] of [
-  ["release/external", { SELFHOST_DEPLOYMENT_MODE: "release" }, []],
   [
-    "release/bundled",
+    "release/external-proxy",
+    {
+      SELFHOST_DEPLOYMENT_MODE: "release",
+      SELFHOST_TLS_MODE: "external",
+    },
+    [caddyComposeFile],
+  ],
+  [
+    "release/bundled/automatic",
     {
       SELFHOST_DEPLOYMENT_MODE: "release",
       SELFHOST_AUTH_MODE: "bundled-pomerium",
+      SELFHOST_TLS_MODE: "automatic",
     },
-    [pomeriumComposeFile, pomeriumLoopbackComposeFile],
+    [pomeriumComposeFile, caddyComposeFile, pomeriumLoopbackComposeFile],
   ],
   [
-    "source/external",
-    { SELFHOST_DEPLOYMENT_MODE: "source" },
-    [sourceComposeFile],
+    "source/external-proxy",
+    {
+      SELFHOST_DEPLOYMENT_MODE: "source",
+      SELFHOST_TLS_MODE: "external",
+    },
+    [sourceComposeFile, caddyComposeFile, caddySourceComposeFile],
   ],
   [
-    "source/bundled",
+    "source/bundled/provided",
     {
       SELFHOST_DEPLOYMENT_MODE: "source",
       SELFHOST_AUTH_MODE: "bundled-pomerium",
+      SELFHOST_TLS_MODE: "provided",
     },
     [
       sourceComposeFile,
       pomeriumComposeFile,
+      caddyComposeFile,
+      caddySourceComposeFile,
       pomeriumLoopbackComposeFile,
     ],
   ],
@@ -192,9 +295,18 @@ for (const [name, env, expectedFiles] of [
     {
       SELFHOST_DEPLOYMENT_MODE: "release",
       SELFHOST_AUTH_MODE: "bundled-pomerium",
-      SELFHOST_POMERIUM_LOOPBACK_HTTPS: "0",
+      SELFHOST_TLS_MODE: "external",
     },
-    [pomeriumComposeFile],
+    [pomeriumComposeFile, caddyComposeFile],
+  ],
+  [
+    "release/legacy-direct-pomerium-migration",
+    {
+      SELFHOST_DEPLOYMENT_MODE: "release",
+      SELFHOST_AUTH_MODE: "bundled-pomerium",
+      SELFHOST_POMERIUM_TLS_MODE: "direct",
+    },
+    [pomeriumComposeFile, caddyComposeFile, pomeriumLoopbackComposeFile],
   ],
 ]) {
   const args = composeArgs(env, ["config"]);
@@ -202,6 +314,8 @@ for (const [name, env, expectedFiles] of [
     sourceComposeFile,
     pomeriumComposeFile,
     pomeriumLoopbackComposeFile,
+    caddyComposeFile,
+    caddySourceComposeFile,
   ]) {
     assert(
       args.includes(file) === expectedFiles.includes(file),
@@ -210,10 +324,13 @@ for (const [name, env, expectedFiles] of [
   }
 }
 assert(
-  volumeNamesForEnv({ SELFHOST_AUTH_MODE: "bundled-pomerium" }).includes(
-    "pomerium-data",
+  ["pomerium-data", "caddy-data", "caddy-config"].every((name) =>
+    volumeNamesForEnv({
+      SELFHOST_AUTH_MODE: "bundled-pomerium",
+      SELFHOST_TLS_MODE: "automatic",
+    }).includes(name),
   ),
-  "bundled Pomerium backups must include pomerium-data",
+  "bundled automatic-TLS backups must include Pomerium and Caddy state",
 );
 
 assert(
@@ -245,6 +362,7 @@ includesAll(
     "image: analysis",
     "image: db-query",
     "image: container-egress",
+    "image: caddy",
     "platforms: linux/amd64",
     "provenance: mode=max",
     "sbom: true",
@@ -259,6 +377,9 @@ includesAll(
     "Smoke analysis notebook runtime",
     "Smoke DB query drivers",
     "Smoke release app nested-Docker topology",
+    "Validate Caddy DNS providers",
+    "dns.providers.cloudflare",
+    "dns.providers.route53",
     "--network host",
     "- validate-contract",
     "- validate-bundled-images",
@@ -279,6 +400,7 @@ includesAll(
     "SELFHOST_ANALYSIS_IMAGE",
     "SELFHOST_DB_QUERY_IMAGE",
     "SELFHOST_CONTAINER_EGRESS_IMAGE",
+    "SELFHOST_CADDY_IMAGE",
     "SELFHOST_POMERIUM_IMAGE",
     "@sha256:",
     "snapshotReleaseState",
@@ -330,8 +452,14 @@ includesAll(
   [
     'await check("network binding"',
     "SELFHOST_BIND_ADDRESS must remain loopback",
+    'await check("TLS front door"',
+    "SELFHOST_CADDY_IMAGE",
+    "SELFHOST_TLS_DNS_PROVIDER",
+    '"caddy",',
+    '"validate",',
+    "Caddy configuration validated with the configured image",
   ],
-  "self-host loopback binding validation",
+  "self-host network and TLS validation",
 );
 
 for (const [name, template] of [
@@ -351,7 +479,12 @@ includesAll(
     "bundled-pomerium",
     "PomeriumIdpClientSecretArn",
     "PomeriumAuthenticateDnsRecord",
-    "127.0.0.1:5444",
+    "Default: automatic",
+    "route53:ChangeResourceRecordSets",
+    "SELFHOST_CADDY_IMAGE",
+    "SELFHOST_TLS_MODE",
+    "SELFHOST_TLS_DNS_PROVIDER",
+    "docker-compose.selfhost.caddy.yml",
     "docker-compose.selfhost.pomerium.yml",
     "docker-compose.selfhost.pomerium-loopback.yml",
   ],
@@ -363,6 +496,10 @@ includesAll(
     'var.auth_provider == "bundled-pomerium"',
     "pomerium_idp_client_secret_arn",
     "aws_route53_record\" \"pomerium_authenticate",
+    'var.tls_mode == "automatic"',
+    "ManageCamelAITlsDnsChallenge",
+    "caddy_image_b64",
+    "route53_zone_id_b64",
     "user_data_base64",
     "base64gzip(local.cloud_init)",
   ],
@@ -373,7 +510,9 @@ includesAll(
   [
     "POMERIUM_IDP_CLIENT_SECRET_ARN",
     'CFG_SELFHOST_AUTH_MODE="external-pomerium"',
-    "127.0.0.1:5444",
+    'CFG_SELFHOST_TLS_DNS_PROVIDER="route53"',
+    "CFG_SELFHOST_CADDY_IMAGE",
+    "docker-compose.selfhost.caddy.yml",
     "docker-compose.selfhost.pomerium.yml",
     "docker-compose.selfhost.pomerium-loopback.yml",
   ],

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -268,6 +268,16 @@ type ChatBillingAccessMode =
   | "selfhost"
   | "camel_free";
 
+export function isModelVisibleForChatRuntime(
+  model: LlmModel,
+  billingAccessMode: ChatBillingAccessMode | null,
+): boolean {
+  return (
+    billingAccessMode !== "selfhost" ||
+    model !== CAMEL_CODE_LLM_MODEL
+  );
+}
+
 function sameJson(left: unknown, right: unknown): boolean {
   return left === right || JSON.stringify(left) === JSON.stringify(right);
 }
@@ -687,10 +697,10 @@ export default function Chat({
   initialUiMessages,
   olderUiMessagesCursor = null,
   initialTodos = [],
-  threadModel,
+  threadModel: providedThreadModel,
   llmProvider,
-  allowedThreadModels,
-  modelOptions,
+  allowedThreadModels: providedAllowedThreadModels,
+  modelOptions: providedModelOptions,
   effectivePickerDefaultModel = null,
   hasEffectivePickerDefault = false,
   billingAccessMode = null,
@@ -717,6 +727,25 @@ export default function Chat({
   bridgedStreamingMessageId,
   welcomeData,
 }: ChatProps) {
+  const threadModel =
+    providedThreadModel &&
+    !isModelVisibleForChatRuntime(providedThreadModel, billingAccessMode)
+      ? getDefaultLlmModel(llmProvider)
+      : providedThreadModel;
+  const allowedThreadModels = useMemo(
+    () =>
+      providedAllowedThreadModels?.filter((model) =>
+        isModelVisibleForChatRuntime(model, billingAccessMode),
+      ),
+    [billingAccessMode, providedAllowedThreadModels],
+  );
+  const modelOptions = useMemo(
+    () =>
+      providedModelOptions?.filter((entry) =>
+        isModelVisibleForChatRuntime(entry.id, billingAccessMode),
+      ),
+    [billingAccessMode, providedModelOptions],
+  );
   const navigate = useNavigate();
   const location = useLocation();
   const locationPathname = location.pathname;
@@ -1373,12 +1402,14 @@ export default function Chat({
       {
         orgProvider: llmProvider,
         allowOpenAiSubscription,
+        allowCamelCode: billingAccessMode !== "selfhost",
       },
     );
     return modelCatalogEntriesForIds(options.map((option) => option.value));
   }, [
     allowedThreadModels,
     allowOpenAiSubscription,
+    billingAccessMode,
     llmProvider,
     modelOptions,
     threadModel,
@@ -3123,7 +3154,12 @@ export default function Chat({
       const optimisticFallbackModel = resolveAgentFallbackOptimisticModel({
         threadId,
         model: state.model,
-        notice: fallbackNotice,
+        notice:
+          fallbackNotice &&
+          isLlmModel(state.model) &&
+          isModelVisibleForChatRuntime(state.model, billingAccessMode)
+            ? fallbackNotice
+            : null,
       });
       if (optimisticFallbackModel) {
         // Agent state is newer than the route's loader snapshot. Hold this as
@@ -3141,7 +3177,9 @@ export default function Chat({
       }
       if ("modelFallbackNotice" in state) {
         setModelFallbackNotice((current) =>
-          current?.id === fallbackNotice?.id
+          billingAccessMode === "selfhost"
+            ? null
+            : current?.id === fallbackNotice?.id
             ? current
             : (fallbackNotice ?? null),
         );
@@ -3190,7 +3228,10 @@ export default function Chat({
               : Date.now(),
         });
       }
-      if (isLlmModel(state.model)) {
+      if (
+        isLlmModel(state.model) &&
+        isModelVisibleForChatRuntime(state.model, billingAccessMode)
+      ) {
         const updatedAt =
           typeof state.modelUpdatedAt === "number" &&
           Number.isFinite(state.modelUpdatedAt)
@@ -3228,6 +3269,7 @@ export default function Chat({
     },
     [
       applyAgentPreviewState,
+      billingAccessMode,
       setConnectionSetupPrompt,
       handleTerminalError,
       threadId,
@@ -3794,6 +3836,9 @@ export default function Chat({
     }
     if (updateThreadModelFetcher.data.thread?.model) {
       const nextModel = updateThreadModelFetcher.data.thread.model;
+      if (!isModelVisibleForChatRuntime(nextModel, billingAccessMode)) {
+        return;
+      }
       const updatedAt = updateThreadModelFetcher.data.thread.updated_at;
       if (
         shouldIgnoreStaleThreadModelResult({
@@ -3836,6 +3881,7 @@ export default function Chat({
     }
   }, [
     llmProvider,
+    billingAccessMode,
     threadId,
     ready,
     threadModel,
@@ -3884,7 +3930,12 @@ export default function Chat({
       selectedThreadModel,
       refreshedThreadModel,
     );
-    if (!canonicalModel) return;
+    if (
+      !canonicalModel ||
+      !isModelVisibleForChatRuntime(canonicalModel, billingAccessMode)
+    ) {
+      return;
+    }
     optimisticThreadModelRef.current = {
       threadId,
       model: canonicalModel,
@@ -3900,7 +3951,13 @@ export default function Chat({
       model: canonicalModel,
       updatedAt: refreshedThreadModel?.updatedAt ?? Date.now(),
     });
-  }, [readOnly, refreshedThreadModel, selectedThreadModel, threadId]);
+  }, [
+    billingAccessMode,
+    readOnly,
+    refreshedThreadModel,
+    selectedThreadModel,
+    threadId,
+  ]);
 
   // The Durable Object persists hosted-credit fallback and normally broadcasts
   // the new model through Agent state. Reconcile from the independent

--- a/src/lib/chat-do.server.ts
+++ b/src/lib/chat-do.server.ts
@@ -35,6 +35,7 @@ import {
   normalizeLlmModel,
 } from "./llm-provider-config";
 import { getEffectiveLlmProviderConfig } from "./selfhost-ai-provider";
+import { isSelfhostRuntime } from "./selfhost-runtime";
 import {
   MODEL_CATALOG,
   resolveModelPickerCatalog,
@@ -115,10 +116,26 @@ export function normalizeStoredThreadModel(
   return { model: normalizeLlmModel(rawModel) };
 }
 
+function normalizeRuntimeThreadModel(
+  env: CloudflareEnv,
+  rawModel: unknown,
+): LlmModel {
+  if (!isSelfhostRuntime(env)) {
+    return normalizeStoredThreadModel(rawModel).model;
+  }
+  const providerConfig = getEffectiveLlmProviderConfig(env, null);
+  return normalizeLlmModel(rawModel, providerConfig?.provider, {
+    customApi: getStoredCustomLlmProviderApi(providerConfig),
+    customModelId: getStoredCustomLlmProviderModelId(providerConfig),
+    awsRegion: getStoredBedrockAwsRegion(providerConfig),
+    allowCamelCode: false,
+  });
+}
+
 // Full thread records are used by single-thread loaders and new-thread
 // transcript hydration, so canonical message metadata must remain unbounded.
-function toThread(orgThread: OrgThread): Thread {
-  const { model } = normalizeStoredThreadModel(orgThread.model);
+function toThread(env: CloudflareEnv, orgThread: OrgThread): Thread {
+  const model = normalizeRuntimeThreadModel(env, orgThread.model);
   return {
     id: orgThread.id,
     workspace_id: orgThread.workspace_id,
@@ -146,8 +163,11 @@ function toThread(orgThread: OrgThread): Thread {
 
 // List and history surfaces should not serialize full prompt text. Keep this
 // mapper separate from toThread so transcript hydration keeps full metadata.
-function toThreadListPreview(orgThread: OrgThread): Thread {
-  const thread = toThread(orgThread);
+function toThreadListPreview(
+  env: CloudflareEnv,
+  orgThread: OrgThread,
+): Thread {
+  const thread = toThread(env, orgThread);
   return {
     ...thread,
     first_user_message: truncateThreadPreviewText(thread.first_user_message, 500),
@@ -490,7 +510,7 @@ export async function getThreads(
   if (!wsInfo) return [];
   const orgStub = env.ORG.get(env.ORG.idFromName(wsInfo.org_id));
   const threads = await orgStub.getThreadsByWorkspace(workspaceId);
-  return threads.map((t) => toThreadListPreview(t));
+  return threads.map((t) => toThreadListPreview(env, t));
 }
 
 export async function getThreadsPaginated(
@@ -521,7 +541,7 @@ export async function getThreadsPaginated(
   const searchTerms = parseThreadSearchTerms(params.searchQuery);
   return {
     items: result.items.map((thread) => {
-      const preview = toThreadListPreview(thread);
+      const preview = toThreadListPreview(env, thread);
       return searchTerms.length > 0
         ? {
             ...preview,
@@ -566,7 +586,7 @@ export async function getThreadsPaginatedAllWorkspaces(
   const searchTerms = parseThreadSearchTerms(params.searchQuery);
   return {
     items: result.items.map((thread) => {
-      const preview = toThreadListPreview(thread);
+      const preview = toThreadListPreview(env, thread);
       return searchTerms.length > 0
         ? {
             ...preview,
@@ -641,7 +661,7 @@ export async function createThread(
     firstUserMessage,
     selectedModel,
   );
-  return toThread(thread);
+  return toThread(env, thread);
 }
 
 export async function createThreadWithValidatedAccess(
@@ -668,7 +688,7 @@ export async function createThreadWithValidatedAccess(
     firstUserMessage,
     selectedModel,
   );
-  return toThread(thread);
+  return toThread(env, thread);
 }
 
 export async function getRecentThreads(
@@ -692,7 +712,7 @@ export async function getRecentThreads(
     workspaceId,
     createdBy,
   );
-  return result.items.map((t) => toThreadListPreview(t));
+  return result.items.map((t) => toThreadListPreview(env, t));
 }
 
 export async function getThread(
@@ -715,7 +735,7 @@ export async function getThread(
   if (!thread) return null;
   // Verify the thread belongs to this workspace
   if (thread.workspace_id !== workspaceId) return null;
-  return toThread(thread);
+  return toThread(env, thread);
 }
 
 export async function getThreadsByIds(
@@ -735,7 +755,7 @@ export async function getThreadsByIds(
     "OrgDO.getThreadsByIds",
     () => orgStub.getThreadsByIds(workspaceId, uniqueThreadIds),
   );
-  return threads.map((thread) => toThreadListPreview(thread));
+  return threads.map((thread) => toThreadListPreview(env, thread));
 }
 
 export async function updateThread(
@@ -758,7 +778,7 @@ export async function updateThread(
   if (!existing || existing.workspace_id !== workspaceId) return null;
   const thread = await orgStub.updateThread(id, title);
   if (!thread) return null;
-  return toThread(thread);
+  return toThread(env, thread);
 }
 
 export async function updateThreadModel(
@@ -800,7 +820,7 @@ export async function updateThreadModel(
     throw new Error("Invalid thread model");
   }
   const updated = await orgStub.updateThreadModel(id, model);
-  return updated ? toThread(updated) : null;
+  return updated ? toThread(env, updated) : null;
 }
 
 export async function setThreadFirstUserMessage(
@@ -818,7 +838,7 @@ export async function setThreadFirstUserMessage(
   if (!existing || existing.workspace_id !== workspaceId) return null;
   const thread = await orgStub.setThreadFirstUserMessage(id, firstUserMessage);
   if (!thread) return null;
-  return toThread(thread);
+  return toThread(env, thread);
 }
 
 export async function deleteThread(

--- a/src/lib/llm-provider-config.ts
+++ b/src/lib/llm-provider-config.ts
@@ -303,6 +303,22 @@ export function getVisibleLlmModelOptions(
     return visibleOptions;
   }
 
+  // Retained thread models may bypass the provider catalog so an existing
+  // hosted thread can remain usable after an admin changes picker settings.
+  // Runtime exclusions are different: self-host must never re-add camelCode
+  // merely because a legacy thread still has it stored.
+  if (
+    !isLlmModelAllowedForOrgProvider(includeModel, options?.orgProvider, {
+      customApi: options?.customApi,
+      customModelId: options?.customModelId,
+      awsRegion: options?.awsRegion,
+      allowOpenAiSubscription: options?.allowOpenAiSubscription,
+      allowCamelCode: options?.allowCamelCode,
+    })
+  ) {
+    return visibleOptions;
+  }
+
   const fallbackOption = [
     ...OPENAI_COMPATIBLE_LLM_MODEL_OPTIONS,
     ...ANTHROPIC_LLM_MODEL_OPTIONS,

--- a/src/routes/_app.chat.$id.tsx
+++ b/src/routes/_app.chat.$id.tsx
@@ -31,12 +31,14 @@ import {
   getDevChatInitialError,
 } from "@/lib/chat-credit-status";
 import {
+  CAMEL_CODE_LLM_MODEL,
   getDefaultLlmModel,
   getStoredCustomLlmProviderApi,
   getStoredCustomLlmProviderModelId,
   getStoredBedrockAwsRegion,
   getVisibleLlmModelOptions,
   isLlmModel,
+  normalizeLlmModel,
 } from "@/lib/llm-provider-config";
 import { getEffectiveLlmProviderConfig } from "@/lib/selfhost-ai-provider";
 import { isSelfhostRuntime } from "@/lib/selfhost-runtime";
@@ -809,12 +811,25 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
   const customApi = getStoredCustomLlmProviderApi(effectiveLlmProviderConfig);
   const customModelId = getStoredCustomLlmProviderModelId(effectiveLlmProviderConfig);
   const awsRegion = getStoredBedrockAwsRegion(effectiveLlmProviderConfig);
-  const fallbackThreadModel =
-    thread?.model ??
-    getDefaultLlmModel(effectiveLlmProviderConfig?.provider, {
+  const providerDefaultModel = getDefaultLlmModel(
+    effectiveLlmProviderConfig?.provider,
+    {
       customApi,
       customModelId,
-    });
+    },
+  );
+  const fallbackThreadModel = selfhostRuntime
+    ? normalizeLlmModel(
+        thread.model,
+        effectiveLlmProviderConfig?.provider,
+        {
+          customApi,
+          customModelId,
+          awsRegion,
+          allowCamelCode: false,
+        },
+      )
+    : thread.model ?? providerDefaultModel;
   const fallbackAllowedThreadModels = getVisibleLlmModelOptions(
     fallbackThreadModel,
     {
@@ -902,7 +917,7 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
     : Promise.resolve([null, []] as const);
   const [activeChatGroup, moveChatGroups] = await activeChatGroupPromise;
   const resolvedThreadModel =
-    thread?.model ??
+    (selfhostRuntime ? fallbackThreadModel : thread?.model) ??
     pausedPickerState?.defaultModel ??
     fallbackThreadModel;
   recordChatThreadRouteLoaderStage(
@@ -1022,6 +1037,14 @@ export default function ChatPage() {
   const markViewedEnabled = chatDebugFlags.markViewed;
   const markThreadIdleRef = useRef(markThreadIdle);
   const resolvedActiveGroupId = activeGroupId ?? activeChatGroup?.id ?? null;
+  const selfhostDisplayFallbackModel =
+    threadModel ??
+    allowedThreadModels?.[0] ??
+    getDefaultLlmModel(llmProvider);
+  const modelForDisplay = (model: LlmModel): LlmModel =>
+    billingAccessMode === "selfhost" && model === CAMEL_CODE_LLM_MODEL
+      ? selfhostDisplayFallbackModel
+      : model;
   const liveActiveChatGroup =
     resolvedActiveGroupId && !readOnly
       ? liveChatGroups.find((group) => group.id === resolvedActiveGroupId) ??
@@ -1073,7 +1096,9 @@ export default function ChatPage() {
   const isDisplayingLoaderThread = displayThreadId === threadId;
   const displayThreadModel = isDisplayingLoaderThread
     ? threadModel
-    : (activeThreadSummary?.model ?? threadModel);
+    : activeThreadSummary
+      ? modelForDisplay(activeThreadSummary.model)
+      : threadModel;
   const displayAllowedThreadModels = allowedThreadModels;
   const cachedSnapshot = displayThreadId ? getSnapshot(displayThreadId) : null;
   const shouldUseCachedSnapshot = Boolean(
@@ -1118,7 +1143,7 @@ export default function ChatPage() {
     liveActiveChatGroup?.open_threads.map((thread) => ({
       threadId: thread.id,
       title: thread.title,
-      model: thread.model,
+      model: modelForDisplay(thread.model),
       status: thread.status,
     })) ?? [];
 
@@ -1126,7 +1151,7 @@ export default function ChatPage() {
     liveActiveChatGroup?.closed_threads.map((thread) => ({
       threadId: thread.id,
       title: thread.title,
-      model: thread.model,
+      model: modelForDisplay(thread.model),
       status: thread.status,
     })) ?? [];
   const liveChatGroupById = new Map(

--- a/tests/chat-do-model-picker-state.test.ts
+++ b/tests/chat-do-model-picker-state.test.ts
@@ -230,6 +230,88 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     );
   });
 
+  it('never exposes or accepts camelCode in self-host mode', async () => {
+    const workspaceStub = {
+      getInfo: vi.fn().mockResolvedValue({ org_id: 'org_123' }),
+      getModelPickerConfig: vi.fn().mockResolvedValue({
+        use_org_defaults: true,
+        models: [],
+        default_model: null,
+      }),
+    };
+    const orgStub = {
+      getInfo: vi.fn().mockResolvedValue({
+        billing_status: 'inactive',
+        billing_credit_purchase_total_cents: 0,
+        billing_credit_grant_total_cents: 0,
+      }),
+      getLlmProviderConfig: vi.fn().mockResolvedValue(null),
+      getModelPickerConfig: vi.fn().mockResolvedValue({
+        use_platform_defaults: true,
+        models: [],
+        default_model: null,
+      }),
+      createThread: vi.fn().mockResolvedValue({
+        id: 'thread_selfhost',
+        workspace_id: 'ws_123',
+        title: 'New Chat',
+        created_by: 'user_123',
+        model: 'sonnet',
+        created_at: 1,
+        updated_at: 1,
+        user_message_count: 0,
+        first_user_message: null,
+      }),
+    };
+
+    getEnvMock.mockReturnValue({
+      CF_ACCOUNT_ID: 'selfhost',
+      SELFHOST_AI_PROVIDER: 'bedrock',
+      SELFHOST_AI_API_KEY: 'bedrock-api-key-test',
+      SELFHOST_AI_AWS_REGION: 'us-east-1',
+      WORKSPACE: {
+        idFromName: (id: string) => id,
+        get: () => workspaceStub,
+      },
+      ORG: {
+        idFromName: (id: string) => id,
+        get: () => orgStub,
+      },
+    });
+
+    const state = await getWorkspaceModelPickerState({}, 'ws_123');
+
+    expect(state).toMatchObject({
+      billingAccessMode: 'selfhost',
+      llmProvider: 'bedrock',
+      defaultModel: 'sonnet',
+    });
+    expect(state?.modelOptions.map((option) => option.id)).not.toContain(
+      CAMEL_CODE_LLM_MODEL,
+    );
+    expect(state?.allowedThreadModels).not.toContain(CAMEL_CODE_LLM_MODEL);
+
+    await expect(
+      createThread(
+        {},
+        'ws_123',
+        'New Chat',
+        'user_123',
+        undefined,
+        CAMEL_CODE_LLM_MODEL,
+      ),
+    ).rejects.toThrow('Invalid thread model');
+
+    await createThread({}, 'ws_123', 'New Chat', 'user_123');
+    expect(orgStub.createThread).toHaveBeenCalledWith(
+      'ws_123',
+      'New Chat',
+      'user_123',
+      undefined,
+      'sonnet',
+    );
+  });
+
   it('keeps the hosted premium default for a subscribed organization', async () => {
     const workspaceStub = {
       getInfo: vi.fn().mockResolvedValue({ org_id: 'org_123' }),
@@ -1111,6 +1193,44 @@ describe('getWorkspaceModelPickerState rollout compatibility', () => {
     const thread = await getThread({}, 'thread_123', 'ws_123');
 
     expect(thread?.model).toBe('gemini-3.5-flash');
+  });
+
+  it('replaces retained camelCode before returning self-host threads to React', async () => {
+    const workspaceStub = {
+      getInfo: vi.fn().mockResolvedValue({ org_id: 'org_123' }),
+    };
+    const orgStub = {
+      getThread: vi.fn().mockResolvedValue({
+        id: 'thread_123',
+        workspace_id: 'ws_123',
+        title: 'Migrated self-host thread',
+        created_by: 'user_123',
+        model: CAMEL_CODE_LLM_MODEL,
+        created_at: 1,
+        updated_at: 2,
+        user_message_count: 0,
+        first_user_message: null,
+      }),
+    };
+
+    getEnvMock.mockReturnValue({
+      CF_ACCOUNT_ID: 'selfhost',
+      SELFHOST_AI_PROVIDER: 'bedrock',
+      SELFHOST_AI_API_KEY: 'bedrock-api-key-test',
+      SELFHOST_AI_AWS_REGION: 'us-east-1',
+      WORKSPACE: {
+        idFromName: (id: string) => id,
+        get: () => workspaceStub,
+      },
+      ORG: {
+        idFromName: (id: string) => id,
+        get: () => orgStub,
+      },
+    });
+
+    const thread = await getThread({}, 'thread_123', 'ws_123');
+
+    expect(thread?.model).toBe('sonnet');
   });
 
   it('keeps full prompts for single thread reads but bounds recent-thread previews', async () => {

--- a/tests/chat-selected-model.test.ts
+++ b/tests/chat-selected-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isModelVisibleForChatRuntime,
   resolveAgentFallbackOptimisticModel,
   resolveSelectedThreadModel,
   shouldIgnoreOlderThreadModelUpdate,
@@ -13,6 +14,16 @@ const visibleCatalog = [
 ] as ModelCatalogEntry[];
 
 describe("new-chat selected model", () => {
+  it("never exposes camelCode in the self-host chat runtime", () => {
+    expect(
+      isModelVisibleForChatRuntime("deepseek-v4-auto", "selfhost"),
+    ).toBe(false);
+    expect(isModelVisibleForChatRuntime("sonnet", "selfhost")).toBe(true);
+    expect(
+      isModelVisibleForChatRuntime("deepseek-v4-auto", "camel_free"),
+    ).toBe(true);
+  });
+
   it("holds a recent Agent-state fallback over a stale loader model", () => {
     const now = Date.parse("2026-07-16T12:00:00.000Z");
     expect(

--- a/workers/main/tests/llm-provider-config.test.ts
+++ b/workers/main/tests/llm-provider-config.test.ts
@@ -248,6 +248,14 @@ describe("llm provider config helpers", () => {
         allowCamelCode: false,
       }).map((option) => option.value),
     ).toEqual([...ANTHROPIC_MODELS, ...BEDROCK_OPENAI_MODELS]);
+
+    expect(
+      getVisibleLlmModelOptions(CAMEL_CODE_MODEL, {
+        orgProvider: "bedrock",
+        awsRegion: "us-east-1",
+        allowCamelCode: false,
+      }).map((option) => option.value),
+    ).toEqual([...ANTHROPIC_MODELS, ...BEDROCK_OPENAI_MODELS]);
   });
 
   it("shows only policy-allowed model families for new chats", () => {


### PR DESCRIPTION
## Summary

- add a containerized Caddy ingress layer for self-hosted Docker Compose deployments
- support `SELFHOST_TLS_MODE=automatic|external|provided`
- automate DNS-01 certificates through Cloudflare API tokens or Route53 instance-role credentials
- keep bundled Pomerium on loopback-only plaintext behind Caddy
- migrate legacy direct/upstream Pomerium TLS settings safely
- make Terraform and CloudFormation default to automatic Route53 TLS with least-privilege TXT challenge permissions
- build and publish the custom Caddy image alongside the other self-host release images
- include Caddy state in backups and preserve rollback compatibility across Compose topology changes
- expand self-host setup, doctor checks, and repository documentation
- remove camelCode from self-hosting documentation and prevent it from appearing or being selected in self-host runtimes

## Compatibility

- existing direct Pomerium TLS installs migrate to `provided` mode and continue using their existing certificate files
- existing upstream TLS installs migrate to `external` mode
- retained camelCode threads are normalized to the configured self-host provider default before reaching UI/thread APIs
- outbound email remains explicitly disabled; internal SMTP support remains future work

## Validation

- `bun run test:selfhost`
- `bun run test:run -- tests/chat-selected-model.test.ts tests/chat-do-model-picker-state.test.ts`
- `bun run test:workers -- llm-provider-config.test.ts chat-thread-pi-turn.test.ts`
- `bun run typecheck`
- `bun run lint`
- `terraform init -backend=false && terraform validate`
- `terraform fmt -check`
- `aws cloudformation validate-template`
- `cfn-lint`
- built the custom Caddy image and verified both Cloudflare and Route53 DNS modules
- validated generated Caddy configs for Cloudflare automatic, Route53 automatic, provided PEM, and external origin modes
- started and health-checked the external-origin Caddy container
- `git diff --check`

Public documentation: https://github.com/qaml-ai/docs/pull/9