### PR TITLE
Fix bundled self-host app image install

### DIFF
--- a/infra/selfhost/app-bundled.Dockerfile
+++ b/infra/selfhost/app-bundled.Dockerfile
@@ -7,6 +7,7 @@ RUN npm install --global "bun@${BUN_VERSION}"
 WORKDIR /workspace
 
 COPY package.json bun.lock ./
+COPY patches ./patches
 RUN bun install --frozen-lockfile
 
 COPY . .
@@ -66,6 +67,7 @@ WORKDIR /workspace
 # and Miniflare/workerd support modules. Install only production dependencies,
 # copy the source tree, then overlay the immutable build artifacts.
 COPY package.json bun.lock ./
+COPY patches ./patches
 RUN bun install --frozen-lockfile --production
 COPY . .
 COPY --from=build /workspace/build /workspace/build

--- a/scripts/test-selfhost-release.mjs
+++ b/scripts/test-selfhost-release.mjs
@@ -337,6 +337,18 @@ assert(
   bundledDockerfile.includes("RUN bun run build:cf"),
   "bundled app image must build the application at image-build time",
 );
+assert(
+  bundledDockerfile.includes(
+    "COPY package.json bun.lock ./\nCOPY patches ./patches\nRUN bun install --frozen-lockfile",
+  ),
+  "bundled app build must copy patched dependencies before installing",
+);
+assert(
+  bundledDockerfile.includes(
+    "COPY package.json bun.lock ./\nCOPY patches ./patches\nRUN bun install --frozen-lockfile --production",
+  ),
+  "bundled app runtime must copy patched dependencies before installing",
+);
 const bundledCommand =
   bundledDockerfile.match(/^CMD\s+(.+)$/m)?.[1] ?? "";
 assert(


### PR DESCRIPTION
## Summary

- copy Bun patched-dependency files before dependency installation in both bundled app image stages
- add a release-contract regression assertion for both install layers

## Why

The first `selfhost-v0.1.0` release run failed because `bun install --frozen-lockfile` could not find `patches/@cloudflare%2Fai-chat@0.9.4.patch`.

## Validation

- `bun run test:selfhost:release`
- exact `linux/amd64` bundled app image build via Docker Buildx
- `git diff --check`