### PR TITLE
agentOS / Rivet VPS rewrite foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ worker-side). There is no in-repo Go sandbox-host or data-proxy tree.
 - `scripts/` - Deploy, eval, self-host, and maintenance scripts.
 - `docs/` - Supporting documentation; see `docs/README.md` for the canonical index (many `*-plan.md` / feedback files are historical).
 - `plans/` - Active cross-cutting architecture plans (e.g. OrgDO split, no-VM build/deploy).
+- `agentos-platform/` - Rivet Actors + agentOS VPS rewrite (experimental/next chat plane). See `agentos-platform/README.md` and `plans/agentos-full-rewrite.md`.
 - `infra/` - Terraform for the static-IP database egress relay VM (`infra/db-egress-relay/`); `infra/selfhost/` for self-host cloud templates. See `infra/README.md`.
 - `tests/` - Vitest UI / `src/lib` unit tests (`vitest.config.ts`).
 - `workers/main/tests/` - Worker / Durable Object / Miniflare tests + `evals/` (`vitest.workers.config.ts`).

--- a/agentos-platform/.env.example
+++ b/agentos-platform/.env.example
@@ -3,6 +3,20 @@ DATA_DIR=.data
 
 # HTTP port for the Rivetkit / agentOS server.
 PORT=6420
+# REST API for auth, billing, health, and metrics.
+AUTH_HTTP_PORT=6422
+
+# Session and external authentication. Set SESSION_COOKIE_SECURE=true on VPS
+# deployments served over HTTPS (NODE_ENV=production also enables it).
+SESSION_TTL_SECONDS=2592000
+SESSION_COOKIE_SECURE=false
+AUTH_PUBLIC_URL=http://localhost:6422
+AUTH_SUCCESS_REDIRECT=/
+PROXY_AUTH_MODE=off
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 
 # Rivet actor version tag for graceful deploy drain. Bump on each production image.
 # Baked into the Docker image via build-arg; also set at runtime for local dev.

--- a/agentos-platform/.env.example
+++ b/agentos-platform/.env.example
@@ -15,6 +15,15 @@ AGENT_RUNTIME=mock
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 
+# Stripe Checkout and webhook billing. Prefer a restricted key with only the
+# required Checkout permissions; never expose it to the web client.
+STRIPE_MODE=test
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_STARTER_PRICE_ID=
+STRIPE_PRO_PRICE_ID=
+STRIPE_TEAM_PRICE_ID=
+
 # Optional: second runner version when exercising canary drain (docker compose --profile canary).
 # RIVET_ENVOY_VERSION_NEXT=2
 

--- a/agentos-platform/.env.example
+++ b/agentos-platform/.env.example
@@ -1,0 +1,22 @@
+# Persistent platform data (JSON store, project trees). Mounted at /data in Docker.
+DATA_DIR=.data
+
+# HTTP port for the Rivetkit / agentOS server.
+PORT=6420
+
+# Rivet actor version tag for graceful deploy drain. Bump on each production image.
+# Baked into the Docker image via build-arg; also set at runtime for local dev.
+RIVET_ENVOY_VERSION=1
+
+# Agent harness backend: mock (default) | agentos (real Pi via @rivet-dev/agentos software).
+AGENT_RUNTIME=mock
+
+# Model provider keys (required when AGENT_RUNTIME=agentos and using hosted models).
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+
+# Optional: second runner version when exercising canary drain (docker compose --profile canary).
+# RIVET_ENVOY_VERSION_NEXT=2
+
+# Optional: static web port when using docker compose `web` service.
+# WEB_PORT=8080

--- a/agentos-platform/.env.example
+++ b/agentos-platform/.env.example
@@ -24,6 +24,11 @@ RIVET_ENVOY_VERSION=1
 
 # Agent harness backend: mock (default) | agentos (real Pi via @rivet-dev/agentos software).
 AGENT_RUNTIME=mock
+# Bypass hosted credit checks (or use a model id prefixed with "byok:").
+AGENT_BYOK=0
+
+# Signing secret for short-lived thread turn tickets.
+TOKEN_SIGNING_SECRET=dev-secret
 
 # Model provider keys (required when AGENT_RUNTIME=agentos and using hosted models).
 ANTHROPIC_API_KEY=

--- a/agentos-platform/.gitignore
+++ b/agentos-platform/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.data/
+dist/
+*.log
+.DS_Store

--- a/agentos-platform/Dockerfile
+++ b/agentos-platform/Dockerfile
@@ -1,0 +1,32 @@
+# camelAI agentOS platform — VPS app image (Bun + Rivetkit embedded engine).
+# agentOS native sidecar binaries ship as optional deps in node_modules
+# (@rivet-dev/agentos-sidecar-linux-x64-gnu, agentos-runtime-sidecar-linux-x64-gnu).
+
+FROM oven/bun:1.2 AS app
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+COPY src ./src
+COPY web ./web
+
+RUN bun install --frozen-lockfile
+
+ARG RIVET_ENVOY_VERSION=1
+ENV RIVET_ENVOY_VERSION=${RIVET_ENVOY_VERSION}
+
+EXPOSE 6420
+
+CMD ["bun", "run", "src/server/index.ts"]
+
+# ---------------------------------------------------------------------------
+# Web static assets (optional second stage for docker compose `web` service)
+# ---------------------------------------------------------------------------
+
+FROM app AS web-build
+RUN bun run build
+
+FROM nginx:1.27-alpine AS web
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=web-build /app/web/dist /usr/share/nginx/html
+EXPOSE 80

--- a/agentos-platform/README.md
+++ b/agentos-platform/README.md
@@ -1,0 +1,193 @@
+# camelAI agentOS platform (rewrite)
+
+Experimental next-generation chat plane for camelAI: **Rivet Actors** + **agentOS** on a single VPS, replacing the Cloudflare Workers + Durable Objects + Pi harness stack for the core agent runtime.
+
+Production camelAI still runs on Workers (`ChatThreadDO`, `WorkspaceFilesystemDO`, sandbox containers). This tree is the self-hosted rewrite path.
+
+## What this is
+
+| Today (production) | This rewrite |
+| --- | --- |
+| `ChatThreadDO` per thread | `chatThread` Rivet actor per thread |
+| `@cloudflare/ai-chat` UIMessage stream | `ChatEvent` websocket bus (`src/shared/events.ts`) |
+| `WorkspaceFilesystemDO` + R2 | Local `ProjectFilesystem` under `DATA_DIR/projects/` |
+| `UserDO` / `OrgDO` identity | `IdentityService` (JSON store; future Rivet actors) |
+| Cloudflare sandbox containers | agentOS runtime sidecars (from `node_modules`) |
+| Workers deploy | Docker image on a VPS |
+
+Rivetkit runs in **embedded mode**: the Rivet engine is in-process inside the Bun server — no separate `rivet-engine` container is required.
+
+## Architecture
+
+```text
+Browser (Vite SPA, web/)
+        |
+        |  HTTP /api/*  +  WS /ws
+        v
+Bun server (src/server/index.ts)
+        |
+        +-- Rivetkit registry (embedded engine)
+        |       |
+        |       +-- chatThread actor  (per thread: turns, state, WS)
+        |       +-- (future) org / workspace actors
+        |
+        +-- Platform services (src/server/platform/)
+        |       Store, IdentityService, BillingService, ProjectFilesystem
+        |
+        +-- agentOS harness (AGENT_RUNTIME=agentos)
+                native sidecars from node_modules
+                (@rivet-dev/agentos-sidecar-*, agentos-runtime-sidecar-*)
+
+Shared volume: DATA_DIR  (.data/ locally, /data in Docker)
+  store.json          — org / workspace / thread metadata
+  projects/{ws}/{id}/ — project source trees
+```
+
+## Development
+
+Prerequisites: [Bun](https://bun.sh) 1.2+, Node 22-compatible host.
+
+```bash
+cd agentos-platform
+cp .env.example .env
+bun install
+
+bun run test          # vitest unit tests
+bun run typecheck     # tsc --noEmit
+bun run dev           # Bun watch: src/server/index.ts
+bun run dev:web       # Vite dev server (web/)
+```
+
+From the monorepo root:
+
+```bash
+bun run dev:agentos
+bun run test:agentos
+bun run typecheck:agentos
+```
+
+Smoke script (CI-friendly, no server boot):
+
+```bash
+./scripts/smoke.sh
+```
+
+## VPS deploy
+
+### 1. Prepare the host
+
+- Linux x86_64 (agentOS sidecar optional deps target `linux-x64-gnu`).
+- Docker Engine + Compose v2.
+- Persistent disk for `DATA_DIR` (bind mount or named volume `agentos-data`).
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+# Edit .env: set RIVET_ENVOY_VERSION, API keys, AGENT_RUNTIME
+```
+
+`RIVET_ENVOY_VERSION` must be a monotonically increasing integer per production deploy. Rivet uses it to tag actors so old runners can drain in-flight work during rolling updates.
+
+### 3. Build and start
+
+```bash
+export RIVET_ENVOY_VERSION=1   # bump each release
+docker compose up --build -d
+```
+
+- API + Rivet: `http://<host>:6420`
+- Static web (nginx): `http://<host>:8080` (proxies `/api` and `/ws` to `app`)
+
+### 4. Rolling / graceful deploy
+
+Rivetkit embedded mode supports **versioned actor drain** when `RIVET_ENVOY_VERSION` is set (see [Rivet actor versions](https://rivet.dev/docs/actors/versions)).
+
+Recommended two-runner flow:
+
+1. **Bump version** — set `RIVET_ENVOY_VERSION` (and Docker build-arg) to `N+1`.
+2. **Start canary** — `docker compose --profile canary up -d --build app-canary` (listens on `:6421` for drain testing).
+3. **Shift traffic** — place new actors on the canary runner; existing actors on the old version continue until idle.
+4. **Drain in-flight turns** — chat actors call `c.keepAwake(promise)` around active Pi/agentOS turns so shutdown waits for completion.
+5. **Retire old runner** — `docker compose stop app` (or swap primary/canary roles) once the old version has no live actors.
+
+`docker-compose.yml` documents this inline. For production, put a reverse proxy (Caddy, nginx, Traefik) in front and route by runner health.
+
+### 5. Data backup
+
+Back up the `agentos-data` volume (or host path bound to `/data`):
+
+- `store.json` — identity and billing metadata
+- `projects/` — user project trees
+
+## Graceful deploy notes
+
+- **`RIVET_ENVOY_VERSION`** — required in production; without it Rivet logs a warning and actors are not version-tagged for drain.
+- **`keepAwake`** — use `c.keepAwake(promise)` (not deprecated `setPreventSleep`) to hold a `chatThread` actor awake for an active turn.
+- **Two runners** — `app` (primary, `:6420`) and `app-canary` (`--profile canary`, `:6421`) share `agentos-data` so project files and store are consistent across replicas during drain practice.
+- **Sidecar binaries** — ship inside the image via `bun install`; no separate download step.
+
+## Ported vs TODO
+
+### Ported (initial scaffold)
+
+- Shared chat contracts: messages, events, thread state, slash commands (`src/shared/`)
+- Platform services: JSON `Store`, `IdentityService`, `BillingService` (credits stub), `ProjectFilesystem`
+- Vitest coverage for platform layer
+- Docker / Compose VPS layout with healthchecks and canary profile
+
+### Still TODO
+
+| Area | Notes |
+| --- | --- |
+| `chatThread` Rivet actor | Replace `ChatThreadDO` turn loop, Pi session, recovery |
+| Real Pi via agentOS | `AGENT_RUNTIME=agentos`, `@rivet-dev/agentos` Pi software package |
+| Web SPA | `web/` Vite client, Rivet React hooks |
+| Auth / SSO | Session cookies, OAuth, Cloudflare Access / Pomerium parity |
+| Stripe billing | Hosted credits, subscriptions, webhooks |
+| Dispatcher / user apps | Workers for Platforms deploy path not in this stack |
+| Builds / notebooks / SQL | CF sandbox containers → agentOS or separate runners |
+| R2 / uploads | Local disk or S3-compatible object store |
+| Admin / MCP | Superuser APIs and moderation |
+| Migrations | Import from production OrgDO / thread / project data |
+
+## Migration map: `ChatThreadDO` → `chatThread` actor
+
+| Cloudflare (today) | agentOS rewrite |
+| --- | --- |
+| `ChatThreadDO` | `chatThread` Rivet actor (`src/server/actors/chat-thread.ts`) |
+| `pi_core_*` SQLite (model transcript) | Actor embedded SQLite (`c.db` / `c.sql`) |
+| ai-chat UIMessage render table | `ChatEvent` stream + client-side merge |
+| `uiMetadata.renderMessageId` invariant | Stable `messageId` on `messageUpsert` / `messageDelta` events |
+| `getUiMessages` cold load | Actor state + historical `ChatEvent` replay or snapshot RPC |
+| `onChatMessage` / Pi prompt | Actor action: `sendMessage` → agentOS/Pi harness |
+| `chatRecovery` / stall timeout | Actor `keepAwake` + recovery journal in actor storage |
+| `ThreadState` / agent state payload | `StateEvent` patches (`src/shared/thread-state.ts`) |
+| Slash commands (`SLASH_COMMANDS`) | Same allowlist (`src/shared/slash-commands.ts`) |
+| `AskUserQuestion` tool | `pendingQuestion` on thread state + `answerQuestion` action |
+| Tool permission gates | `permissionRequest` / `permissionResolved` events |
+| `WorkspaceFilesystemDO` + R2 | `ProjectFilesystem` at `DATA_DIR/projects/{ws}/{projectId}` |
+| `deploy_project` / build sandbox | TBD — agentOS exec or external build runner |
+| `run_notebook` / analysis sandbox | TBD |
+| `DATA_PROXY` / `DbQuerySandbox` | TBD — db egress relay or embedded query runner |
+| WebSocket `/ws/{workspace}` | Rivet actor websocket on `chatThread` |
+| `UserDO` / `OrgDO` | `IdentityService` → future `org` / `workspace` actors |
+| Stripe / hosted credits | `BillingService` stub → Stripe integration |
+| Observability (Analytics Engine) | Structured logs + future metrics backend |
+
+Cross-cutting plan: [`plans/agentos-full-rewrite.md`](../plans/agentos-full-rewrite.md).
+
+## Docker reference
+
+```bash
+# App only
+docker build --build-arg RIVET_ENVOY_VERSION=1 -t agentos-app .
+
+# Full stack (app + web)
+docker compose up --build -d
+
+# Canary drain practice
+RIVET_ENVOY_VERSION_NEXT=2 docker compose --profile canary up -d --build
+```
+
+The `Dockerfile` copies `package.json`, `bun.lock`, `src/`, and `web/`, runs `bun install --frozen-lockfile`, and starts `bun run src/server/index.ts`. agentOS native sidecars are resolved from `node_modules` at runtime (linux x64 GNU optional dependencies).

--- a/agentos-platform/README.md
+++ b/agentos-platform/README.md
@@ -72,6 +72,26 @@ Smoke script (CI-friendly, no server boot):
 ./scripts/smoke.sh
 ```
 
+### Agent runtime selection
+
+`AGENT_RUNTIME` defaults to `mock`. The deterministic `chatThread` actor stays
+available in every mode so unit tests and local UI work do not require model
+credentials.
+
+Set `AGENT_RUNTIME=agentos` before starting the server to enable the AgentOS
+registry setup (including the actor SQLite runtime socket), then connect to the
+separate `chatThreadAgentOs` actor. It opens a durable Pi session on the first
+`sendMessage`, streams ACP events through the same `ChatEvent` contract, and
+exposes the camel workspace bindings:
+
+```bash
+AGENT_RUNTIME=agentos bun run dev
+```
+
+Configure the model provider credentials required by Pi in the server
+environment. Merely importing the registry or running the default test suite
+does not boot the AgentOS sidecar or require API keys.
+
 ## VPS deploy
 
 ### 1. Prepare the host
@@ -133,6 +153,7 @@ Back up the `agentos-data` volume (or host path bound to `/data`):
 
 - Shared chat contracts: messages, events, thread state, slash commands (`src/shared/`)
 - Platform services: JSON `Store`, `IdentityService`, `BillingService` (credits stub), `ProjectFilesystem`
+- Real `chatThreadAgentOs` actor with Pi sessions, camel bindings, and ACP event mapping
 - Vitest coverage for platform layer
 - Docker / Compose VPS layout with healthchecks and canary profile
 
@@ -141,7 +162,6 @@ Back up the `agentos-data` volume (or host path bound to `/data`):
 | Area | Notes |
 | --- | --- |
 | `chatThread` Rivet actor | Replace `ChatThreadDO` turn loop, Pi session, recovery |
-| Real Pi via agentOS | `AGENT_RUNTIME=agentos`, `@rivet-dev/agentos` Pi software package |
 | Web SPA | `web/` Vite client, Rivet React hooks |
 | Auth / SSO | Session cookies, OAuth, Cloudflare Access / Pomerium parity |
 | Stripe billing | Hosted credits, subscriptions, webhooks |

--- a/agentos-platform/README.md
+++ b/agentos-platform/README.md
@@ -43,7 +43,10 @@ Shared volume: DATA_DIR  (.data/ locally, /data in Docker)
   projects/{ws}/{id}/ — project source trees
 ```
 
-## Development
+## Dev
+
+The server boots Rivetkit with `registry.start()` (embedded engine on `:6420`).
+elopment
 
 Prerequisites: [Bun](https://bun.sh) 1.2+, Node 22-compatible host.
 

--- a/agentos-platform/README.md
+++ b/agentos-platform/README.md
@@ -152,27 +152,29 @@ Back up the `agentos-data` volume (or host path bound to `/data`):
 
 ## Ported vs TODO
 
-### Ported (initial scaffold)
+### Ported (through Phase 3)
 
 - Shared chat contracts: messages, events, thread state, slash commands (`src/shared/`)
-- Platform services: JSON `Store`, `IdentityService`, `BillingService` (credits stub), `ProjectFilesystem`
-- Real `chatThreadAgentOs` actor with Pi sessions, camel bindings, and ACP event mapping
-- Vitest coverage for platform layer
+- Platform services: JSON `Store`, `IdentityService`, ledger `BillingService`, `ProjectFilesystem`, `UsageService`
+- `chatThread` (mock) + `chatThreadAgentOs` (Pi) actors, camel bindings, ACP mapper
+- React SPA + `useRivetChat` (replaces Cloudflare Agents SDK)
+- Session auth: password, GitHub/Google OAuth, CF Access / Pomerium proxy headers (`AUTH_HTTP_PORT`, default `:6422`)
+- Stripe Checkout (subscription + credits) + signed webhooks + plan limits parity
+- Credit gate on hosted turns + usage metering (`AGENT_BYOK=1` or `byok:` model bypass)
+- Structured JSON logs, counters, `/health`, `/api/metrics`
 - Docker / Compose VPS layout with healthchecks and canary profile
 
-### Still TODO
+### Still TODO (Phase 4+)
 
 | Area | Notes |
 | --- | --- |
-| `chatThread` Rivet actor | Replace `ChatThreadDO` turn loop, Pi session, recovery |
-| Web SPA | `web/` Vite client, Rivet React hooks |
-| Auth / SSO | Session cookies, OAuth, Cloudflare Access / Pomerium parity |
-| Stripe billing | Hosted credits, subscriptions, webhooks |
 | Dispatcher / user apps | Workers for Platforms deploy path not in this stack |
 | Builds / notebooks / SQL | CF sandbox containers → agentOS or separate runners |
 | R2 / uploads | Local disk or S3-compatible object store |
 | Admin / MCP | Superuser APIs and moderation |
 | Migrations | Import from production OrgDO / thread / project data |
+| Live Pi e2e | API-key smoke on a real VPS (`AGENT_RUNTIME=agentos`) |
+| Turn resume across migrate | Durable ACP history + client reconnect polish |
 
 ## Migration map: `ChatThreadDO` → `chatThread` actor
 

--- a/agentos-platform/bun.lock
+++ b/agentos-platform/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@camelai/agentos-platform",
       "dependencies": {
+        "@agentos-software/pi": "0.2.7",
         "@rivet-dev/agentos": "0.2.15",
         "@rivet-dev/agentos-core": "^0.2.15",
         "@rivetkit/react": "2.3.10",
@@ -57,7 +58,7 @@
 
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.87", "", { "dependencies": { "@anthropic-ai/sdk": "^0.74.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.74.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
 
     "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
 
@@ -765,7 +766,7 @@
 
     "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
 
-    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "googleapis": ["googleapis@144.0.0", "", { "dependencies": { "google-auth-library": "^9.0.0", "googleapis-common": "^7.0.0" } }, "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw=="],
 
@@ -1289,13 +1290,13 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.74.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw=="],
+
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1098.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/nested-clients": "^3.997.38", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-6cFAviffeqYGjrXn4FqGbWcTxB3nbpBpQXUm6MvnrWZThJaVBTHHnespHgSUh4yVLfzhipSh9H/XjzkHQd9P4g=="],
 
     "@google/genai/google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
 
     "@google/genai/p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
-
-    "@mariozechner/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
 
     "@rivet-dev/agentos/@rivetkit/react": ["@rivetkit/react@2.3.9", "", { "dependencies": { "@rivetkit/framework-base": "2.3.9", "@tanstack/react-store": "^0.7.1", "rivetkit": "2.3.9" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-j9t82h/yIqqSt17coQZeRu3F9Q5w2FgWPDUC9fCyQUJp9PTjO7ea494PR0lSWvuEiwMRqE5JpgbHdYUQ1woE9w=="],
 
@@ -1322,6 +1323,8 @@
     "fetch-blob/web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "gcp-metadata/google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
 
     "googleapis-common/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
@@ -1356,8 +1359,6 @@
     "@google/genai/google-auth-library/gaxios": ["gaxios@7.3.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA=="],
 
     "@google/genai/google-auth-library/gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
-
-    "@google/genai/google-auth-library/google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "@google/genai/p-retry/@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 

--- a/agentos-platform/bun.lock
+++ b/agentos-platform/bun.lock
@@ -4,68 +4,352 @@
   "workspaces": {
     "": {
       "name": "@camelai/agentos-platform",
+      "dependencies": {
+        "@rivet-dev/agentos": "0.2.15",
+        "@rivet-dev/agentos-core": "^0.2.15",
+        "@rivetkit/react": "2.3.10",
+        "rivetkit": "2.3.10",
+        "zod": "^4.1.11",
+      },
       "devDependencies": {
         "@types/node": "^22.13.10",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
         "bun-types": "^1.2.15",
+        "react": "^19",
+        "react-dom": "^19",
         "typescript": "^5.8.2",
+        "vite": "^6",
         "vitest": "^3.0.9",
       },
     },
   },
   "packages": {
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+    "@agentos-software/claude-code": ["@agentos-software/claude-code@0.2.7", "", { "dependencies": { "@agentclientprotocol/sdk": "^0.16.1", "@anthropic-ai/claude-agent-sdk": "0.2.87", "zod": "^4.1.11" }, "bin": { "claude": "dist/claude-cli.mjs", "claude-sdk-acp": "dist/adapter.js" } }, "sha512-gXmqqOUWT98QvLkQXHn1UU8OOvqMO8BRSj+0PT99mOL6XNpBlPW6L065FJ9dC4IwJC5xeGzB1XFevjOdP7LwQg=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+    "@agentos-software/codex-cli": ["@agentos-software/codex-cli@0.3.4", "", {}, "sha512-SAw3EOTa90dJLgEVVoE7JJIxHwticzdD9cEM9v00gpxhxC9vdLkeBva6rgWIUB9+qD1JEYBvUCyNkIpD2kT5YQ=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+    "@agentos-software/common": ["@agentos-software/common@0.2.15", "", { "dependencies": { "@agentos-software/coreutils": "0.3.4", "@agentos-software/diffutils": "0.3.4", "@agentos-software/findutils": "0.3.4", "@agentos-software/gawk": "0.3.4", "@agentos-software/grep": "0.3.4", "@agentos-software/gzip": "0.3.4", "@agentos-software/sed": "0.3.4", "@agentos-software/tar": "0.3.5" } }, "sha512-33roACt3EfAp+C6mciKfthVU7I21XeulM+/yLJRo9tSuXfbMLF18EnkodKhvYAJWjzlLGhbmsxfuSuBF7afrhw=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+    "@agentos-software/coreutils": ["@agentos-software/coreutils@0.3.4", "", {}, "sha512-tGd0gQjUjHnm+5KgOBwidwUtlkKnl9biQuD7X2sZl15VOhYqUJpnyLF33h/nF3r9WtOTclSiLj/dc2xCxmAXnw=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+    "@agentos-software/diffutils": ["@agentos-software/diffutils@0.3.4", "", {}, "sha512-a5Do+ERMdHPwT0Vrp35fxSgrsJNK8wCsYX8dOAomH9N+xJyV2Hb7/LLyp7XxqGk9BEjMeA6UhbH5ZY/HAlx5sQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+    "@agentos-software/findutils": ["@agentos-software/findutils@0.3.4", "", {}, "sha512-wjBWE3lkXe70fRj6da1+2MM/7KlPcBRhr2BycvgvAtglOT/0PtabFU9CrDuX3Vm/8acU/8tw35+WeitPOLi9mg=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+    "@agentos-software/gawk": ["@agentos-software/gawk@0.3.4", "", {}, "sha512-NlU6nGxoqIUc1I2zdBHFwH04gE0tBygP2FcBO12VBptty7lbgq1CNLk909jIcSNFEwlm3VRPHeZNkbdVKZ2Ujg=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+    "@agentos-software/grep": ["@agentos-software/grep@0.3.4", "", {}, "sha512-Bta2Ljl+kCX/3Bjg06Q9N9LPRcf13S92lHRaYG+CeGVDXabIIgkHLUGIQlI1OKuIr7IRAktjgelUAuJnxGFvvw=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+    "@agentos-software/gzip": ["@agentos-software/gzip@0.3.4", "", {}, "sha512-l7Y/Vwiwsqgna68yYwdNCnUBPGBg5zdmtjEFeG3hnDDFLe/02h17q0gUIqJmDBIAy1q9GoizqcFi7zXO2xygKg=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+    "@agentos-software/manifest": ["@agentos-software/manifest@0.2.15", "", {}, "sha512-3aftCfhOjVWy1I2m7CFO8y7If8/SLpE5T7DeIId6UR+88lVcD5I9GpmooYVOAQ8CBs33TWgqJI2Esvt/eb/nsQ=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+    "@agentos-software/opencode": ["@agentos-software/opencode@0.2.7", "", { "bin": { "agentos-opencode-acp": "dist/adapter.js" } }, "sha512-lZspCiMgM0+kPAA08CEvyNy8lfBx463wObKpAwbYyaVvc0KfGvbAPS6VmnuZQWmaBmJJuRMtSo14nmb8XCD16g=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+    "@agentos-software/pi": ["@agentos-software/pi@0.2.7", "", { "dependencies": { "@agentclientprotocol/sdk": "^0.16.1", "@mariozechner/pi-ai": "0.60.0", "@mariozechner/pi-coding-agent": "0.60.0" }, "bin": { "pi": "node_modules/@mariozechner/pi-coding-agent/dist/cli.js", "pi-sdk-acp": "dist/adapter.js" } }, "sha512-nOdwksByJgTqt92Ya84CzTGxpVFwGI6gkGWaCD/mmvP11JRA++1nshNdbig2mtiaxT7VG3ovWJmK7ZLTTzkhPA=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+    "@agentos-software/sed": ["@agentos-software/sed@0.3.4", "", {}, "sha512-J10nZnZmme2SvXK5WMK2unQlOVncMQVUCS20GZB579a2gNoayLJYHGvfJ9a4+42wOHgDKL1u74byWlydCkEyOQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+    "@agentos-software/tar": ["@agentos-software/tar@0.3.5", "", {}, "sha512-hSf6PY4q1luIomFSDgVHxVDDIPdAVZxdgwrQFEYH4aIE6TXX9qatVmzR36uYLWpnFGAZTR6srREGoTnmOGV4Lg=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.87", "", { "dependencies": { "@anthropic-ai/sdk": "^0.74.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.74.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.23", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Hv4VX5+IdDYmAbOdiwZguz8fLh3WnE4VtyJwVNEHLulA+OYy7Z5L0ETGUlX2T4g8DLO8XxCV8CyWrtVL4uwqkg=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1099.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/credential-provider-node": "^3.972.75", "@aws-sdk/eventstream-handler-node": "^3.972.31", "@aws-sdk/middleware-eventstream": "^3.972.26", "@aws-sdk/middleware-websocket": "^3.972.46", "@aws-sdk/token-providers": "3.1099.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-J0+NsFrckBmgg/HObV+88tfyCDp/+ej3ceGIya8vFEDUDtSML0Y8jON34Cc98A7L6Xeywa1GI4wGFADt1arq4w=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1099.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.23", "@aws-sdk/core": "^3.977.3", "@aws-sdk/credential-provider-node": "^3.972.75", "@aws-sdk/middleware-sdk-s3": "^3.972.69", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-d6R4bTZQTlMKxXFj8kIf/KZj2xXAozL9ai94yCXQILrvm4jja2yaiqi/ktTD835G3z3FuFoYK+wNWANADilU7A=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.3", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-6YZTpF5Zzl0KdSrztM0l6ErKdnXrnnodIDYfayHE9SFfZU8Ubxls7H2XnfWT121jgwiG+WP1z5kyfVDsH5V4qA=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.64", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-14kkR5aj1c7D+cYCrEcG2W3xw87wMYAEUeB/tMiQ2j0RVKzzdewd4mJw1+Q0JVLr4IFU1JHGDCyj0WqLrtIixg=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.66", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BrZxoXScBZ+nTOYy388zHkz1n5cS8C+uGFMozD4w9OKEWMq39Cu/9l/k385Hb54dtv0VIeh12f8h67o3xDNH9g=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.9", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/credential-provider-env": "^3.972.64", "@aws-sdk/credential-provider-http": "^3.972.66", "@aws-sdk/credential-provider-login": "^3.972.71", "@aws-sdk/credential-provider-process": "^3.972.64", "@aws-sdk/credential-provider-sso": "^3.973.8", "@aws-sdk/credential-provider-web-identity": "^3.972.70", "@aws-sdk/nested-clients": "^3.997.38", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-d/mMvS+sQjSWNA6+JCldK1YB/jQmtoWM8Izj10mrOZdRCeWNVb8IYQuuyHHKKKXcpGo5Pd0LIK6onHbLvlhuVQ=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.71", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/nested-clients": "^3.997.38", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-l93922lXnTs5RjM3QrMCXSmXiEgLFLaQ0Lco9F3tJ08o0mzGdAj6m2nAXDuTMHoUuL0u7RKmrhm+Z8/7GCilyg=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.75", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.64", "@aws-sdk/credential-provider-http": "^3.972.66", "@aws-sdk/credential-provider-ini": "^3.973.9", "@aws-sdk/credential-provider-process": "^3.972.64", "@aws-sdk/credential-provider-sso": "^3.973.8", "@aws-sdk/credential-provider-web-identity": "^3.972.70", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-sdFhR4E3HWZefGL6OsBhxqXdqtFvxGOh8VLfiu9yttPgVNcpEozEDPmrTYmXA3CIf6npUETVLveQPGQ7GBzVhg=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.64", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Q5noG5vfFo++bUaLGcjj8OHX5tmwa1O/5nDVMeaSSZgjzgvWbW6tgu/gSa+aENwcJXjoXDQh+8TRZR2zHds/aw=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.8", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/nested-clients": "^3.997.38", "@aws-sdk/token-providers": "3.1098.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-37okeZyRdVkGrU6nyKBPGqQvyl/7CEiMpUVOb0+BCNCIR0VAuBxNgjMb0mnsR1EXm8dqQFfQZOJ5YW/0sBfa1w=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.70", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/nested-clients": "^3.997.38", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Ps/f9USafScb6CSQTRPNMzdKL5x5XRwDIRgFvnuFWfClGZe7/fI7iCFqXdxKjc9LBxP28E7iUgNloGgfgw406w=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.31", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.26", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.69", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ziSQA8AkB+u4K/5t/SStFbeoiNTG04reUeddCLNCAgmdRJGQ3+MJcpZOXXLdD6uyfCqSK1/R6004gRdXvHbYQA=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.46", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4ZWFqfiqSTda+SsMUihhype6L0sHWKnLouWj2WYRrF5oC+3G+yUatBILLiesELF+7AP+kHMhEpD2UGnk2vOPMw=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.38", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-jQDs+nxnmgo4+WPOmY373HIC8jx4KyYYMYDI74FWrzX3Ba9fYsV0dSA+7PNYNkhRbbRCRLre83tQ31F1ACCHkA=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.43", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1099.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/nested-clients": "^3.997.38", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-PJGSxDCxvls4kL9sRyJ12K+EIuEtC001EpeusLL4ZP41MMz2IikqiEKguX7W/27A3uyz3oOu6C/T+Pwfj2kmKg=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.37", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@cbor-extract/cbor-extract-darwin-arm64": ["@cbor-extract/cbor-extract-darwin-arm64@2.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA=="],
+
+    "@cbor-extract/cbor-extract-darwin-x64": ["@cbor-extract/cbor-extract-darwin-x64@2.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q=="],
+
+    "@cbor-extract/cbor-extract-linux-arm": ["@cbor-extract/cbor-extract-linux-arm@2.2.2", "", { "os": "linux", "cpu": "arm" }, "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ=="],
+
+    "@cbor-extract/cbor-extract-linux-arm64": ["@cbor-extract/cbor-extract-linux-arm64@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg=="],
+
+    "@cbor-extract/cbor-extract-linux-x64": ["@cbor-extract/cbor-extract-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA=="],
+
+    "@cbor-extract/cbor-extract-win32-x64": ["@cbor-extract/cbor-extract-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
+
+    "@hono/zod-openapi": ["@hono/zod-openapi@1.5.1", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.9.0", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.10.0", "zod": "^4.0.0" } }, "sha512-ZaDdEIkn6PEGjIYHXJeyByg6yhvLzI+UXn968pWtahpwcQ6HMjQYXI3zNffTl0Wl9QZ79nUnGqiN1erEIu23fA=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.9.0", "", { "peerDependencies": { "hono": ">=4.11.2", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-n0ZSXmCiHVIp4Y5wlOOyZCeTd/rsawA/qW1cipB8QOYKZ9N8Tk0nZUZCXho9cu374AN4JpDNKioNKBJ/W+LBug=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
+    "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
+
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.60.0", "", { "dependencies": { "@mariozechner/pi-ai": "^0.60.0" } }, "sha512-1zQcfFp8r0iwZCxCBQ9/ccFJoagns68cndLPTJJXl1ZqkYirzSld1zBOPxLAgeAKWIz3OX8dB2WQwTJFhmEojQ=="],
+
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.60.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-OiMuXQturnEDPmA+ho7eLe4G8plO2z21yjNMs9niQREauoblWOz7Glv58I66KPzczLED4aZTlQLTRdU6t1rz8A=="],
+
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.60.0", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.60.0", "@mariozechner/pi-ai": "^0.60.0", "@mariozechner/pi-tui": "^0.60.0", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-IOv7cTU4nbznFNUE5ofi13k2dmSG39coBoGWIBQTVw3iVyl0HxuHbg0NiTx3ktrPIDNtkii+y7tWXzWqwoo4lw=="],
+
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.60.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-ZAK5gxYhGmfJqMjfWcRBjB8glITltDbTrYJXvcDtfengbKTZN0p39p5uO5pvUB8/PiAWKTRS06yaNMhf/LG26g=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
+    "@napi-rs/cli": ["@napi-rs/cli@2.18.4", "", { "bin": { "napi": "scripts/index.js" } }, "sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@rivet-dev/agent-os-core": ["@rivet-dev/agent-os-core@0.1.1", "", { "dependencies": { "@rivet-dev/agent-os-posix": "0.1.0", "@rivet-dev/agent-os-python": "0.1.0", "@secure-exec/core": "^0.2.1", "@secure-exec/nodejs": "^0.2.1", "@secure-exec/v8": "^0.2.1", "croner": "^10.0.1", "long-timeout": "^0.1.1", "secure-exec": "^0.2.1" } }, "sha512-Uw5jr+gUXDY7TDUFqlypjGe1BD2KL9kTHPNo/f1iNS1R+l9IWuvT+FF/MXsLOEkc3fB06OPVu2ZvUuNwp9MpLQ=="],
+
+    "@rivet-dev/agent-os-posix": ["@rivet-dev/agent-os-posix@0.1.0", "", { "dependencies": { "@secure-exec/core": "^0.2.1" } }, "sha512-NIrI7cCb9x6jdmzRPPx7dAeXoTF/YCqf93ydEzYFA2zshIelLW9Rp5KtgP/2hM6fP0ly4+vVnOeavxJW0wYtcA=="],
+
+    "@rivet-dev/agent-os-python": ["@rivet-dev/agent-os-python@0.1.0", "", { "dependencies": { "@secure-exec/core": "^0.2.1", "pyodide": "^0.28.3" } }, "sha512-1tH1beMf1ceSpicQKwN/a6h+NmJrmfuT4GStiRDZmvN/UWfZhkxuy7HR5VPTQpE/feUZJ01FdtBS3Em/Qoxb2Q=="],
+
+    "@rivet-dev/agentos": ["@rivet-dev/agentos@0.2.15", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@agentos-software/common": "0.2.15", "@rivet-dev/agentos-core": "0.2.15", "@rivetkit/react": "2.3.9", "rivetkit": "2.3.9", "zod": "^4.1.11" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["react", "react-dom"] }, "sha512-NLJjFNVD0uP/EzGfGOcDaZ+GMx595P9sps/A2aLn+xb/KPUqpc+mxmZi8VYhCj2cr20QBa6jhfA2Ohf+0r72Mg=="],
+
+    "@rivet-dev/agentos-core": ["@rivet-dev/agentos-core@0.2.15", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@agentos-software/claude-code": "0.2.7", "@agentos-software/codex-cli": "0.3.4", "@agentos-software/common": "0.2.15", "@agentos-software/manifest": "0.2.15", "@agentos-software/opencode": "0.2.7", "@agentos-software/pi": "0.2.7", "@aws-sdk/client-s3": "^3.1019.0", "@rivet-dev/agentos-runtime-core": "0.2.15", "@rivet-dev/agentos-sidecar": "0.2.15", "@rivetkit/bare-ts": "^0.6.2", "@xterm/headless": "^6.0.0", "better-sqlite3": "^12.8.0", "croner": "^10.0.1", "googleapis": "^144.0.0", "isolated-vm": "^6.0.0", "long-timeout": "^0.1.1", "minimatch": "^10.2.4", "zod": "^4.1.11", "zod-to-json-schema": "^3.25.2" } }, "sha512-uRg3BmbZzDUwWVmCTcd9Iuo1k8GJeuaXE3FnBbFGzAeI7I077KAhYlVejb9TBWHtjYcblVlMnl591vDm0DbpCQ=="],
+
+    "@rivet-dev/agentos-runtime-core": ["@rivet-dev/agentos-runtime-core@0.2.15", "", { "dependencies": { "@rivet-dev/agentos-runtime-sidecar": "0.2.15", "@rivetkit/bare-ts": "^0.6.2", "zod": "^4.1.11" } }, "sha512-u8J9psQbu7gixzasyS8b7MiVXrrNPAGzk46DAGM3g8TwUZdP1muR1aa4FS7XePRmD3YWM5QrgCxFETl4gmE8vQ=="],
+
+    "@rivet-dev/agentos-runtime-sidecar": ["@rivet-dev/agentos-runtime-sidecar@0.2.15", "", { "optionalDependencies": { "@rivet-dev/agentos-runtime-sidecar-darwin-arm64": "0.2.15", "@rivet-dev/agentos-runtime-sidecar-darwin-x64": "0.2.15", "@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu": "0.2.15", "@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu": "0.2.15" } }, "sha512-8eemRmcqp5X9UdpzUD0vJbtG29Ip34n6ulUIFI+ewGXRAxJ+aU5+iqdfRxjYaW71t6zc7r/tMbUSLaPkwMsZqA=="],
+
+    "@rivet-dev/agentos-runtime-sidecar-darwin-arm64": ["@rivet-dev/agentos-runtime-sidecar-darwin-arm64@0.2.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GN+OJjp8GLNyWSeRNp9Lh27ZWCW7O1RI95RXKCSQCn07d5Hj5QYLbIn7VYN1mpDzOfdbvhvSy5Re0kKU94FZFA=="],
+
+    "@rivet-dev/agentos-runtime-sidecar-darwin-x64": ["@rivet-dev/agentos-runtime-sidecar-darwin-x64@0.2.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-3/4WGmd0MGDIYWSCVBvsdElZUEZ0YMZZdOP57hyYV3ut9pQdhnJPciqe6s46RBE78G+2ZtHGf/PgWyHL0zS2gA=="],
+
+    "@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu": ["@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu@0.2.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-OiUoHPmgOfbUGyPapmT6VBxXTKQBRyOc0O6MWALCc3dNy50C/Tb2K1lH3JlF9upUzcdp7g6HcqaDeja88tQujQ=="],
+
+    "@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu": ["@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu@0.2.15", "", { "os": "linux", "cpu": "x64" }, "sha512-5QIF7C5rQqWf77Fd5tKj4vP8FPPmwIPsdd454CblFQerH5PPDSua5o44w38PyNMgi2tlWu2OTuiYloiOwyHo6g=="],
+
+    "@rivet-dev/agentos-sidecar": ["@rivet-dev/agentos-sidecar@0.2.15", "", { "optionalDependencies": { "@rivet-dev/agentos-sidecar-darwin-arm64": "0.2.15", "@rivet-dev/agentos-sidecar-darwin-x64": "0.2.15", "@rivet-dev/agentos-sidecar-linux-arm64-gnu": "0.2.15", "@rivet-dev/agentos-sidecar-linux-x64-gnu": "0.2.15" } }, "sha512-XvABEkqiA/zLqcOM8AgYvRxxbg8dMviR1D/66GWgEWOAMjcqfn1kXFrsL1d0WbKEn7nwUfguKQVV4weeR3oF5g=="],
+
+    "@rivet-dev/agentos-sidecar-darwin-arm64": ["@rivet-dev/agentos-sidecar-darwin-arm64@0.2.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2csTR3/C3KmNTZln1/u3xU6pKVB/0RdG+MqW3AP2OmS/Q5Lucdd4Y6tnxZGg/ku6Q+Pw9KLOTEuFW1p8cQi1Ig=="],
+
+    "@rivet-dev/agentos-sidecar-darwin-x64": ["@rivet-dev/agentos-sidecar-darwin-x64@0.2.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-xUDxTXARNbQY1Jq0JjxN7D9sfv8iEff4nYnBQR2efo/L5HBObT/fRO2gT+zwUZSRGHnEJCb8gvDxFYc/Th/sqg=="],
+
+    "@rivet-dev/agentos-sidecar-linux-arm64-gnu": ["@rivet-dev/agentos-sidecar-linux-arm64-gnu@0.2.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-5pzCqLcHYluESd9c6aIohi2x6A7K8vli0DnmkMJwHXJilQyqmjZz8Y0m6Ggi+0jGi2Idad46SzzC1Z7uRrO5Ow=="],
+
+    "@rivet-dev/agentos-sidecar-linux-x64-gnu": ["@rivet-dev/agentos-sidecar-linux-x64-gnu@0.2.15", "", { "os": "linux", "cpu": "x64" }, "sha512-2byoXX4ol1PKOvvtPxUk0BgPTv+mlOCX6nXKOsb4Z6OY7OwhMn+z+um1VpWxwMyU8gBS3oG12ungDmVmH8aIYw=="],
+
+    "@rivetkit/bare-ts": ["@rivetkit/bare-ts@0.6.2", "", {}, "sha512-3qndQUQXLdwafMEqfhz24hUtDPcsf1Bu3q52Kb8MqeH8JUh3h6R4HYW3ZJXiQsLcyYyFM68PuIwlLRlg1xDEpg=="],
+
+    "@rivetkit/engine-cli": ["@rivetkit/engine-cli@2.3.10", "", { "optionalDependencies": { "@rivetkit/engine-cli-darwin-arm64": "2.3.10", "@rivetkit/engine-cli-darwin-x64": "2.3.10", "@rivetkit/engine-cli-linux-arm64-musl": "2.3.10", "@rivetkit/engine-cli-linux-x64-musl": "2.3.10", "@rivetkit/engine-cli-win32-x64": "2.3.10" } }, "sha512-7NoyfdT8Qk5bBOqnFgsDF2baL0BISNvWNB0mWsjA/AHRqrwg+RCQbTvkWy1iPCUr8/EdndMsNIwjxA1s8vGYwQ=="],
+
+    "@rivetkit/engine-cli-darwin-arm64": ["@rivetkit/engine-cli-darwin-arm64@2.3.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hu9rfesS9RnmIoGo0z+6YEroeZavaohYmwsc5K5//SPDfUl83mZirU4sWNjo5N2CQz+Y1fEyXcZTcnulF72rvA=="],
+
+    "@rivetkit/engine-cli-darwin-x64": ["@rivetkit/engine-cli-darwin-x64@2.3.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-l5pgExB9lBt5UeNj9NOZHQv/oQCEMLuirCDAKidOU0bMD9LI2TV0S/JHWG7IWyBf34SEv+/Zo+LC4JoB8iu82Q=="],
+
+    "@rivetkit/engine-cli-linux-arm64-musl": ["@rivetkit/engine-cli-linux-arm64-musl@2.3.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-opLAOm1Up5BrYk+T3p5yHQ9e5ZtWSjVfA0LyNllYKHNyYJ+L6cxosVBf1uakyENS8ytYu92R6fhQZOUQyjgevA=="],
+
+    "@rivetkit/engine-cli-linux-x64-musl": ["@rivetkit/engine-cli-linux-x64-musl@2.3.10", "", { "os": "linux", "cpu": "x64" }, "sha512-q0WDESrssRNzVSqmnNgaLt2D8wjYhVPiiJi96kDIaatWAXvPHd7SPN4gNHdvRVUD0hImOEQDw1u3NGRyi7TBkg=="],
+
+    "@rivetkit/engine-cli-win32-x64": ["@rivetkit/engine-cli-win32-x64@2.3.10", "", { "os": "win32", "cpu": "x64" }, "sha512-VnNn3R6YpMzrDauCVZRmt1L2/oUax+KQmOFSiXQwo7JPt2MdZaa5Z5ISWVD51c1/xCPiMiLDsL6V9mjpJculzw=="],
+
+    "@rivetkit/engine-envoy-protocol": ["@rivetkit/engine-envoy-protocol@2.3.10", "", { "dependencies": { "@rivetkit/bare-ts": "^0.6.2" } }, "sha512-AqYekBbHrxuUOrup2oo+iSBP80ZbI1Jp8euk0rRaaxkwlnWQO3p2ymMOLHW+jaQ6zK6g4f41aSq0l1ji8SoWZA=="],
+
+    "@rivetkit/framework-base": ["@rivetkit/framework-base@2.3.10", "", { "dependencies": { "@tanstack/store": "^0.7.1", "fast-deep-equal": "^3.1.3", "rivetkit": "2.3.10" } }, "sha512-lMFHdyCNf0pFdK6LlSGhiGmQoMwZevC0ayF6qYS6uDveM9fiY0SrccRr7xeosxj+/aUIDTkg0Q0w2th78dFG+g=="],
+
+    "@rivetkit/on-change": ["@rivetkit/on-change@6.0.1", "", {}, "sha512-QBN/KRBXLJdCgN4gBTL3XAc/zKm58atSnieXWMOyFSPmo6F1/yIVV/LTRdvAktfCttrGx7W6c32i/lwqCHWnsQ=="],
+
+    "@rivetkit/react": ["@rivetkit/react@2.3.10", "", { "dependencies": { "@rivetkit/framework-base": "2.3.10", "@tanstack/react-store": "^0.7.1", "rivetkit": "2.3.10" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-CGmWf2GjznsH3NsT5sLHTtwxEJZN5QKGrZ2l7pscHS6wJ5cSzmTr4luTS2fo5+6GwFzufB4FVPqqt9O1dRnQWQ=="],
+
+    "@rivetkit/rivetkit-napi": ["@rivetkit/rivetkit-napi@2.3.10", "", { "dependencies": { "@napi-rs/cli": "^2.18.4", "@rivetkit/engine-envoy-protocol": "2.3.10" }, "optionalDependencies": { "@rivetkit/rivetkit-napi-darwin-arm64": "2.3.10", "@rivetkit/rivetkit-napi-darwin-x64": "2.3.10", "@rivetkit/rivetkit-napi-linux-arm64-gnu": "2.3.10", "@rivetkit/rivetkit-napi-linux-arm64-musl": "2.3.10", "@rivetkit/rivetkit-napi-linux-x64-gnu": "2.3.10", "@rivetkit/rivetkit-napi-linux-x64-musl": "2.3.10", "@rivetkit/rivetkit-napi-win32-x64-msvc": "2.3.10" } }, "sha512-nkaimgCcSPVZn+dGhlHMrrxVJrUwujhPlSznxehUWCaG6lR1gIysvlZucdiBTYF1iEKzzmvGqao1z25l1NVWAg=="],
+
+    "@rivetkit/rivetkit-napi-darwin-arm64": ["@rivetkit/rivetkit-napi-darwin-arm64@2.3.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/E//AAI/jSMjuSMjWs05sQR6XFrplN8Ni0kuvmpDM9ds+AlcIgScDdRgBgleus9QLMU8aGEz3MrBNO9q4FGwVQ=="],
+
+    "@rivetkit/rivetkit-napi-darwin-x64": ["@rivetkit/rivetkit-napi-darwin-x64@2.3.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+nzDsGgrslECZ7NxoUm1vvWlO+XxXNoFuBu2eefHkm9J06vXCrSPkiY/kAFa7rhcD9UA1MsNheUxC68BmKeXg=="],
+
+    "@rivetkit/rivetkit-napi-linux-arm64-gnu": ["@rivetkit/rivetkit-napi-linux-arm64-gnu@2.3.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-2uiQOJ5CsRvB6lqhYwezRWBZxuKVs6n0aPsRCdEggLPTEUcsx43ODcVVbkbg0aDM3qE+1itWjzOu086xhqGTQg=="],
+
+    "@rivetkit/rivetkit-napi-linux-arm64-musl": ["@rivetkit/rivetkit-napi-linux-arm64-musl@2.3.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-jad0eDH9MIn2VG3Dsu+UOtQyz3X3V4sBgp7VfiqHtjtV2wqVbGnDEQbdcQK6xCDQrPNFsUbGNznzDa1C/4l3Pg=="],
+
+    "@rivetkit/rivetkit-napi-linux-x64-gnu": ["@rivetkit/rivetkit-napi-linux-x64-gnu@2.3.10", "", { "os": "linux", "cpu": "x64" }, "sha512-l2wphS5wSl8xpje743/NYd9gl02FVh4qtqDQPk/LNA/WBT5WkdkkWhhTLiKiTMMA1L309XMQLH3iZbNq1yXFFg=="],
+
+    "@rivetkit/rivetkit-napi-linux-x64-musl": ["@rivetkit/rivetkit-napi-linux-x64-musl@2.3.10", "", { "os": "linux", "cpu": "x64" }, "sha512-kdhVxFm8z7HWG7LWqt1TBi1ye7VDNhgqq3acsh2NlpCHPJ19aElu2yiHR2F4jh1zFZU5SpAKHJGKNbfIqGO4/Q=="],
+
+    "@rivetkit/rivetkit-napi-win32-x64-msvc": ["@rivetkit/rivetkit-napi-win32-x64-msvc@2.3.10", "", { "os": "win32", "cpu": "x64" }, "sha512-KQdLH8sXyAKF0fEzpFeXl8AZwTObl/G4nT21BQy8B+pba2os9DUjOVy8k/bTiZzcvy8FvaL9KerfVH4Pr8yg4w=="],
+
+    "@rivetkit/rivetkit-wasm": ["@rivetkit/rivetkit-wasm@2.3.10", "", {}, "sha512-90czUWCMQa8mAMkHg/jSUGud0jemNJeU6XHeBw5izzE3kdELo8bWBlF06rprMJV6VOwwdPfluID0FrBmZpuNgQ=="],
+
+    "@rivetkit/traces": ["@rivetkit/traces@2.3.10", "", { "dependencies": { "@rivetkit/bare-ts": "^0.6.2", "cbor-x": "^1.6.0", "fdb-tuple": "^1.0.0", "vbare": "^0.0.4" } }, "sha512-CNYz8hJOR0o77wiUQbbWh24Qj6lQk/eH0lJXfHHUisYBsjyZKnN0TlSVfhAIf7UnSMh9ASMuTwPx8s2Yz53xVA=="],
+
+    "@rivetkit/virtual-websocket": ["@rivetkit/virtual-websocket@2.3.10", "", {}, "sha512-CQhhys540fASByQzbu7YqRlKlIziL9FwI/mzAS0NGg+AZMiHc6YhB/cJw/LJ1VYrEQjbm83XFkUr6i6pRnZVNw=="],
+
+    "@rivetkit/workflow-engine": ["@rivetkit/workflow-engine@2.3.10", "", { "dependencies": { "@rivetkit/bare-ts": "^0.6.2", "cbor-x": "^1.6.0", "fdb-tuple": "^1.0.0", "pino": "^9.6.0", "vbare": "^0.0.4" } }, "sha512-+1VcVsWbmCd608tgqrVndMF8jWGCNflXSXmP8NYJnq7uEBcBcQy1bkCdcD1rckAkRkfefXqfW0ReNgLv202elg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.3", "", { "os": "android", "cpu": "arm" }, "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw=="],
 
@@ -117,13 +401,63 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.3", "", { "os": "win32", "cpu": "x64" }, "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g=="],
 
+    "@secure-exec/core": ["@secure-exec/core@0.2.1", "", { "dependencies": { "better-sqlite3": "^12.8.0" } }, "sha512-HsnUv6gClpMA1BBRmX86j30TKTZtgJC/fO1tVavr7IpM2zNKbHU8LgSlBd7mv2SNy02ImTmU/GnQ3aYB4NSbEg=="],
+
+    "@secure-exec/nodejs": ["@secure-exec/nodejs@0.2.1", "", { "dependencies": { "@secure-exec/core": "0.2.1", "@secure-exec/v8": "0.2.1", "cbor-x": "^1.6.4", "cjs-module-lexer": "^2.1.0", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.1", "node-stdlib-browser": "^1.3.1", "web-streams-polyfill": "^4.2.0" } }, "sha512-UJMJqVFxexlHJV0Q9nWURvrz6GElj8673DDOOFln6FHR6JS+9SaSU3eISrN158DuNC3SFi4rgjb/scKnK4YOYQ=="],
+
+    "@secure-exec/v8": ["@secure-exec/v8@0.2.1", "", { "dependencies": { "cbor-x": "^1.6.4" }, "optionalDependencies": { "@secure-exec/v8-darwin-arm64": "0.2.1", "@secure-exec/v8-darwin-x64": "0.2.1", "@secure-exec/v8-linux-arm64-gnu": "0.2.1", "@secure-exec/v8-linux-x64-gnu": "0.2.1" } }, "sha512-ye/seCqzvyMGnvyP+AO7RkVMR/lE3x9m0D2PfmiAXA457R78ZmOFmZ6v+JlJG2vv3LM30KsSXTUhwpG+Teh0hw=="],
+
+    "@secure-exec/v8-darwin-arm64": ["@secure-exec/v8-darwin-arm64@0.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gEWhMHzUpLwzuBNAD0lVkZXE8wFlWMLp4IOZ+56FYwOW/C+m07cYxuW4TjHyPqZ+vPm3IkoaMqqH5yT9VhjX/Q=="],
+
+    "@secure-exec/v8-darwin-x64": ["@secure-exec/v8-darwin-x64@0.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-H2Z5K+Cq+fn/kxjGvhJzepnNFWG6qNdyhZybVWGr5bAAZoSz/Qkad4WnXcurWU+880tKDtnf19LHBXrg7zewNQ=="],
+
+    "@secure-exec/v8-linux-arm64-gnu": ["@secure-exec/v8-linux-arm64-gnu@0.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-14subGhVV/gW35mYYm7Gv1Keeex7PxIgQfoKji/JH7wYyDuarP6kgaES0nJw+JXVkxEVud52c+kbcIjIggqCEw=="],
+
+    "@secure-exec/v8-linux-x64-gnu": ["@secure-exec/v8-linux-x64-gnu@0.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Az4s+vUf+78vWtsC7rTn/jQc6WKJafAdt2YpEjB4Gnu+sX+FFTIst1hRV4gJonbRyJdy6SW+OQ6DZatmwczorQ=="],
+
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
+
+    "@smithy/core": ["@smithy/core@3.31.1", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.16", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.12", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@tanstack/react-store": ["@tanstack/react-store@0.7.7", "", { "dependencies": { "@tanstack/store": "0.7.7", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg=="],
+
+    "@tanstack/store": ["@tanstack/store@0.7.7", "", {}, "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
+    "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
+
     "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
+    "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
+
+    "@types/retry": ["@types/retry@0.12.2", "", {}, "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w=="],
 
@@ -139,63 +473,717 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw=="],
 
+    "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "asn1.js": ["asn1.js@4.10.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw=="],
+
+    "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
+    "better-sqlite3": ["better-sqlite3@12.11.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "bn.js": ["bn.js@5.2.5", "", {}, "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
+
+    "browser-resolve": ["browser-resolve@2.0.0", "", { "dependencies": { "resolve": "^1.17.0" } }, "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ=="],
+
+    "browserify-aes": ["browserify-aes@1.2.0", "", { "dependencies": { "buffer-xor": "^1.0.3", "cipher-base": "^1.0.0", "create-hash": "^1.1.0", "evp_bytestokey": "^1.0.3", "inherits": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA=="],
+
+    "browserify-cipher": ["browserify-cipher@1.0.1", "", { "dependencies": { "browserify-aes": "^1.0.4", "browserify-des": "^1.0.0", "evp_bytestokey": "^1.0.0" } }, "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w=="],
+
+    "browserify-des": ["browserify-des@1.0.2", "", { "dependencies": { "cipher-base": "^1.0.1", "des.js": "^1.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A=="],
+
+    "browserify-rsa": ["browserify-rsa@4.1.1", "", { "dependencies": { "bn.js": "^5.2.1", "randombytes": "^2.1.0", "safe-buffer": "^5.2.1" } }, "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ=="],
+
+    "browserify-sign": ["browserify-sign@4.2.6", "", { "dependencies": { "bn.js": "^5.2.3", "browserify-rsa": "^4.1.1", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "elliptic": "^6.6.1", "inherits": "^2.0.4", "parse-asn1": "^5.1.9", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1" } }, "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg=="],
+
+    "browserify-zlib": ["browserify-zlib@0.2.0", "", { "dependencies": { "pako": "~1.0.5" } }, "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "buffer-xor": ["buffer-xor@1.0.3", "", {}, "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="],
+
+    "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "cbor-extract": ["cbor-extract@2.2.2", "", { "dependencies": { "node-gyp-build-optional-packages": "5.1.1" }, "optionalDependencies": { "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2", "@cbor-extract/cbor-extract-darwin-x64": "2.2.2", "@cbor-extract/cbor-extract-linux-arm": "2.2.2", "@cbor-extract/cbor-extract-linux-arm64": "2.2.2", "@cbor-extract/cbor-extract-linux-x64": "2.2.2", "@cbor-extract/cbor-extract-win32-x64": "2.2.2" }, "bin": { "download-cbor-prebuilds": "bin/download-prebuilds.js" } }, "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng=="],
+
+    "cbor-x": ["cbor-x@1.6.5", "", { "optionalDependencies": { "cbor-extract": "^2.2.2" } }, "sha512-yO64CxnSh6kp+pHNRK9IfwnMvCB+c8HvmUjQY/9l9YRF0/cAPka/tUHLwS64QqUpFCq3/OtbKziVJYXH2EaRig=="],
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "cipher-base": ["cipher-base@1.0.7", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.2" } }, "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
+
+    "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
+
+    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "console-browserify": ["console-browserify@1.2.0", "", {}, "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="],
+
+    "constants-browserify": ["constants-browserify@1.0.0", "", {}, "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "create-ecdh": ["create-ecdh@4.0.4", "", { "dependencies": { "bn.js": "^4.1.0", "elliptic": "^6.5.3" } }, "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A=="],
+
+    "create-hash": ["create-hash@1.2.0", "", { "dependencies": { "cipher-base": "^1.0.1", "inherits": "^2.0.1", "md5.js": "^1.3.4", "ripemd160": "^2.0.1", "sha.js": "^2.4.0" } }, "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg=="],
+
+    "create-hmac": ["create-hmac@1.1.7", "", { "dependencies": { "cipher-base": "^1.0.3", "create-hash": "^1.1.0", "inherits": "^2.0.1", "ripemd160": "^2.0.0", "safe-buffer": "^5.0.1", "sha.js": "^2.4.8" } }, "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg=="],
+
+    "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
+
+    "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crypto-browserify": ["crypto-browserify@3.12.1", "", { "dependencies": { "browserify-cipher": "^1.0.1", "browserify-sign": "^4.2.3", "create-ecdh": "^4.0.4", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "diffie-hellman": "^5.0.3", "hash-base": "~3.0.4", "inherits": "^2.0.4", "pbkdf2": "^3.1.2", "public-encrypt": "^4.0.3", "randombytes": "^2.1.0", "randomfill": "^1.0.4" } }, "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "des.js": ["des.js@1.1.0", "", { "dependencies": { "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "diffie-hellman": ["diffie-hellman@5.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "miller-rabin": "^4.0.0", "randombytes": "^2.0.0" } }, "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg=="],
+
+    "domain-browser": ["domain-browser@4.22.0", "", {}, "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.44.7", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
-    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "evp_bytestokey": ["evp_bytestokey@1.0.3", "", { "dependencies": { "md5.js": "^1.3.4", "safe-buffer": "^5.1.1" } }, "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.1", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "fdb-tuple": ["fdb-tuple@1.0.0", "", {}, "sha512-8jSvKPCYCgTpi9Pt87qlfTk6griyMx4Gk3Xv31Dp72Qp8b6XgIyFsMm8KzPmFJ9iJ8K4pGvRxvOS8D0XGnrkjw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
+
+    "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
+
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+
+    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+
+    "googleapis": ["googleapis@144.0.0", "", { "dependencies": { "google-auth-library": "^9.0.0", "googleapis-common": "^7.0.0" } }, "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw=="],
+
+    "googleapis-common": ["googleapis-common@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "gaxios": "^6.0.3", "google-auth-library": "^9.7.0", "qs": "^6.7.0", "url-template": "^2.0.8", "uuid": "^9.0.0" } }, "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hash-base": ["hash-base@3.0.5", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1" } }, "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg=="],
+
+    "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
+
+    "hono": ["hono@4.12.32", "", {}, "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-browserify": ["https-browserify@1.0.0", "", {}, "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
+
+    "ip-address": ["ip-address@10.3.1", "", {}, "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
+
+    "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
+
+    "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
+
+    "is-nan": ["is-nan@1.3.2", "", { "dependencies": { "call-bind": "^1.0.0", "define-properties": "^1.1.3" } }, "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w=="],
+
+    "is-network-error": ["is-network-error@1.3.2", "", {}, "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "isolated-vm": ["isolated-vm@6.1.2", "", { "dependencies": { "node-gyp-build": "^4.8.4" } }, "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A=="],
+
+    "isomorphic-timers-promises": ["isomorphic-timers-promises@1.0.1", "", {}, "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ=="],
+
+    "jose": ["jose@6.2.5", "", {}, "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "koffi": ["koffi@2.16.3", "", {}, "sha512-E9y1AsgYGlaxMhcZzHr8y96QF2U5XzA12GGVAfbWqIubTwPNMXQarfBzePNXHe0xtIEtNd6ifAv3GAKYGUeBAQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "long-timeout": ["long-timeout@0.1.1", "", {}, "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "md5.js": ["md5.js@1.3.5", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "miller-rabin": ["miller-rabin@4.0.1", "", { "dependencies": { "bn.js": "^4.0.0", "brorand": "^1.0.1" }, "bin": { "miller-rabin": "bin/miller-rabin" } }, "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
+
+    "minimalistic-crypto-utils": ["minimalistic-crypto-utils@1.0.1", "", {}, "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="],
+
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.1.1", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw=="],
+
+    "node-stdlib-browser": ["node-stdlib-browser@1.3.1", "", { "dependencies": { "assert": "^2.0.0", "browser-resolve": "^2.0.0", "browserify-zlib": "^0.2.0", "buffer": "^5.7.1", "console-browserify": "^1.1.0", "constants-browserify": "^1.0.0", "create-require": "^1.1.1", "crypto-browserify": "^3.12.1", "domain-browser": "4.22.0", "events": "^3.0.0", "https-browserify": "^1.0.0", "isomorphic-timers-promises": "^1.0.1", "os-browserify": "^0.3.0", "path-browserify": "^1.0.1", "pkg-dir": "^5.0.0", "process": "^0.11.10", "punycode": "^1.4.1", "querystring-es3": "^0.2.1", "readable-stream": "^3.6.0", "stream-browserify": "^3.0.0", "stream-http": "^3.2.0", "string_decoder": "^1.0.0", "timers-browserify": "^2.0.4", "tty-browserify": "0.0.1", "url": "^0.11.4", "util": "^0.12.4", "vm-browserify": "^1.0.1" } }, "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
+    "openapi3-ts": ["openapi3-ts@4.6.1", "", { "dependencies": { "yaml": "^2.9.0" } }, "sha512-XW9MOldkhoICNeXVzzmXzmOW5G73ppOEGmh7fLCqHjgfdEYCGGN+00MlVCeUZgovjjfC56j9tvtDt1zGabNjjA=="],
+
+    "os-browserify": ["os-browserify@0.3.0", "", {}, "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-retry": ["p-retry@6.2.1", "", { "dependencies": { "@types/retry": "0.12.2", "is-network-error": "^1.0.0", "retry": "^0.13.1" } }, "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parse-asn1": ["parse-asn1@5.1.9", "", { "dependencies": { "asn1.js": "^4.10.1", "browserify-aes": "^1.2.0", "evp_bytestokey": "^1.0.3", "pbkdf2": "^3.1.5", "safe-buffer": "^5.2.1" } }, "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg=="],
+
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
+    "pbkdf2": ["pbkdf2@3.1.6", "", { "dependencies": { "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "ripemd160": "^2.0.3", "safe-buffer": "^5.2.1", "sha.js": "^2.4.12", "to-buffer": "^1.2.2" } }, "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "^5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
+
+    "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
+
     "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
+
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "process-warning": ["process-warning@5.1.0", "", {}, "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "public-encrypt": ["public-encrypt@4.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "browserify-rsa": "^4.0.0", "create-hash": "^1.1.0", "parse-asn1": "^5.0.0", "randombytes": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
+
+    "pyodide": ["pyodide@0.28.3", "", { "dependencies": { "ws": "^8.5.0" } }, "sha512-rtCsyTU55oNGpLzSVuAd55ZvruJDEX8o6keSdWKN9jPeBVSNlynaKFG7eRqkiIgU7i2M6HEgYtm0atCEQX3u4A=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "querystring-es3": ["querystring-es3@0.2.1", "", {}, "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "randomfill": ["randomfill@1.0.4", "", { "dependencies": { "randombytes": "^2.0.5", "safe-buffer": "^5.1.0" } }, "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "ripemd160": ["ripemd160@2.0.3", "", { "dependencies": { "hash-base": "^3.1.2", "inherits": "^2.0.4" } }, "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA=="],
+
+    "rivetkit": ["rivetkit@2.3.10", "", { "dependencies": { "@hono/zod-openapi": "^1.1.5", "@rivet-dev/agent-os-core": "^0.1.1", "@rivetkit/bare-ts": "^0.6.2", "@rivetkit/engine-cli": "2.3.10", "@rivetkit/engine-envoy-protocol": "2.3.10", "@rivetkit/on-change": "6.0.1", "@rivetkit/rivetkit-napi": "2.3.10", "@rivetkit/rivetkit-wasm": "2.3.10", "@rivetkit/traces": "2.3.10", "@rivetkit/virtual-websocket": "2.3.10", "@rivetkit/workflow-engine": "2.3.10", "cbor-x": "^1.6.0", "drizzle-orm": "^0.44.2", "hono": "^4.7.0", "invariant": "^2.2.4", "p-retry": "^6.2.1", "pino": "^9.5.0", "uuid": "^12.0.0", "vbare": "^0.0.4", "zod": "^4.1.0" }, "peerDependencies": { "drizzle-kit": "^0.31.2", "eventsource": "^4.0.0", "ws": "^8.0.0" }, "optionalPeers": ["drizzle-kit", "eventsource", "ws"] }, "sha512-E+H0lBc3O8dK9Pj7W2XW3VwrCnfpwYYm5LlsZyHrmk5bCrJIBdnEFdZXn5nsYMz0waCfP1ieyP6d1tdvBG76Dg=="],
 
     "rollup": ["rollup@4.62.3", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.3", "@rollup/rollup-android-arm64": "4.62.3", "@rollup/rollup-darwin-arm64": "4.62.3", "@rollup/rollup-darwin-x64": "4.62.3", "@rollup/rollup-freebsd-arm64": "4.62.3", "@rollup/rollup-freebsd-x64": "4.62.3", "@rollup/rollup-linux-arm-gnueabihf": "4.62.3", "@rollup/rollup-linux-arm-musleabihf": "4.62.3", "@rollup/rollup-linux-arm64-gnu": "4.62.3", "@rollup/rollup-linux-arm64-musl": "4.62.3", "@rollup/rollup-linux-loong64-gnu": "4.62.3", "@rollup/rollup-linux-loong64-musl": "4.62.3", "@rollup/rollup-linux-ppc64-gnu": "4.62.3", "@rollup/rollup-linux-ppc64-musl": "4.62.3", "@rollup/rollup-linux-riscv64-gnu": "4.62.3", "@rollup/rollup-linux-riscv64-musl": "4.62.3", "@rollup/rollup-linux-s390x-gnu": "4.62.3", "@rollup/rollup-linux-x64-gnu": "4.62.3", "@rollup/rollup-linux-x64-musl": "4.62.3", "@rollup/rollup-openbsd-x64": "4.62.3", "@rollup/rollup-openharmony-arm64": "4.62.3", "@rollup/rollup-win32-arm64-msvc": "4.62.3", "@rollup/rollup-win32-ia32-msvc": "4.62.3", "@rollup/rollup-win32-x64-gnu": "4.62.3", "@rollup/rollup-win32-x64-msvc": "4.62.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "secure-exec": ["secure-exec@0.2.1", "", { "dependencies": { "@secure-exec/core": "0.2.1", "@secure-exec/nodejs": "0.2.1" } }, "sha512-oaQDzTPDSCOckYC8G0PimIqzEVxY6sYEvcx0fMGsRR/Wl4wkFVHaZgQ3kc2DHWysV6WHWt5g1AXc/6seafO2XQ=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sha.js": ["sha.js@2.4.12", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": { "sha.js": "bin.js" } }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
+
+    "stream-http": ["stream-http@3.2.0", "", { "dependencies": { "builtin-status-codes": "^3.0.0", "inherits": "^2.0.4", "readable-stream": "^3.6.0", "xtend": "^4.0.2" } }, "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "thread-stream": ["thread-stream@3.2.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw=="],
+
+    "timers-browserify": ["timers-browserify@2.0.12", "", { "dependencies": { "setimmediate": "^1.0.4" } }, "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -209,16 +1197,388 @@
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
+    "to-buffer": ["to-buffer@1.2.2", "", { "dependencies": { "isarray": "^2.0.5", "safe-buffer": "^5.2.1", "typed-array-buffer": "^1.0.3" } }, "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tty-browserify": ["tty-browserify@0.0.1", "", {}, "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "url": ["url@0.11.4", "", { "dependencies": { "punycode": "^1.4.1", "qs": "^6.12.3" } }, "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg=="],
+
+    "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@12.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-9obBF8sMIHJWNQaO6IGOG8giGa/jUpKX34bz6o4whVs8M0WAvhID2tNxYp6A2XEBJPuZSX8wsS/6TEKfIDc+nw=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vbare": ["vbare@0.0.4", "", {}, "sha512-QsxSVw76NqYUWYPVcQmOnQPX8buIVjgn+yqldTHlWISulBTB9TJ9rnzZceDu+GZmycOtzsmuPbPN1YNxvK12fg=="],
+
+    "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
     "vitest": ["vitest@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.7", "@vitest/mocker": "3.2.7", "@vitest/pretty-format": "^3.2.7", "@vitest/runner": "3.2.7", "@vitest/snapshot": "3.2.7", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.7", "@vitest/ui": "3.2.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg=="],
 
+    "vm-browserify": ["vm-browserify@1.1.2", "", {}, "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@4.3.0", "", {}, "sha512-/Gnggvj9oSrEvJbDyyPtAnxBt5fGQM2iWOKQNu7ie1OxDgK40iZpyV3TKaRiEzVj1oA1UxKnEy9XPXh6PW3eVw=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-typed-array": ["which-typed-array@1.1.22", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.9", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yargs": ["yargs@16.2.2", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w=="],
+
+    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "yoctocolors": ["yoctocolors@2.2.0", "", {}, "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1098.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.3", "@aws-sdk/nested-clients": "^3.997.38", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-6cFAviffeqYGjrXn4FqGbWcTxB3nbpBpQXUm6MvnrWZThJaVBTHHnespHgSUh4yVLfzhipSh9H/XjzkHQd9P4g=="],
+
+    "@google/genai/google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
+
+    "@google/genai/p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "@mariozechner/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
+
+    "@rivet-dev/agentos/@rivetkit/react": ["@rivetkit/react@2.3.9", "", { "dependencies": { "@rivetkit/framework-base": "2.3.9", "@tanstack/react-store": "^0.7.1", "rivetkit": "2.3.9" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-j9t82h/yIqqSt17coQZeRu3F9Q5w2FgWPDUC9fCyQUJp9PTjO7ea494PR0lSWvuEiwMRqE5JpgbHdYUQ1woE9w=="],
+
+    "@rivet-dev/agentos/rivetkit": ["rivetkit@2.3.9", "", { "dependencies": { "@hono/zod-openapi": "^1.1.5", "@rivet-dev/agent-os-core": "^0.1.1", "@rivetkit/bare-ts": "^0.6.2", "@rivetkit/engine-cli": "2.3.9", "@rivetkit/engine-envoy-protocol": "2.3.9", "@rivetkit/on-change": "6.0.1", "@rivetkit/rivetkit-napi": "2.3.9", "@rivetkit/rivetkit-wasm": "2.3.9", "@rivetkit/traces": "2.3.9", "@rivetkit/virtual-websocket": "2.3.9", "@rivetkit/workflow-engine": "2.3.9", "cbor-x": "^1.6.0", "drizzle-orm": "^0.44.2", "hono": "^4.7.0", "invariant": "^2.2.4", "p-retry": "^6.2.1", "pino": "^9.5.0", "uuid": "^12.0.0", "vbare": "^0.0.4", "zod": "^4.1.0" }, "peerDependencies": { "drizzle-kit": "^0.31.2", "eventsource": "^4.0.0", "ws": "^8.0.0" }, "optionalPeers": ["drizzle-kit", "eventsource", "ws"] }, "sha512-m8pd3+nfI81T8uxKPflOKXTvvRf6X/u5zW0vRqq6v+d/Dwh964jKAHp0pVo5R6D9PotNZQIroqy57AZvX7nc4g=="],
+
+    "@secure-exec/nodejs/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "asn1.js/bn.js": ["bn.js@4.12.5", "", {}, "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "browserify-sign/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "create-ecdh/bn.js": ["bn.js@4.12.5", "", {}, "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="],
+
+    "diffie-hellman/bn.js": ["bn.js@4.12.5", "", {}, "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="],
+
+    "elliptic/bn.js": ["bn.js@4.12.5", "", {}, "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="],
+
+    "fetch-blob/web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "googleapis-common/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "hosted-git-info/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "miller-rabin/bn.js": ["bn.js@4.12.5", "", {}, "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="],
+
+    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "public-encrypt/bn.js": ["bn.js@4.12.5", "", {}, "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="],
+
+    "ripemd160/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
+
+    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "vite-node/vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "vitest/vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@google/genai/google-auth-library/gaxios": ["gaxios@7.3.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA=="],
+
+    "@google/genai/google-auth-library/gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "@google/genai/google-auth-library/google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "@google/genai/p-retry/@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@rivet-dev/agentos/@rivetkit/react/@rivetkit/framework-base": ["@rivetkit/framework-base@2.3.9", "", { "dependencies": { "@tanstack/store": "^0.7.1", "fast-deep-equal": "^3.1.3", "rivetkit": "2.3.9" } }, "sha512-ZSxrclYcpmdGsLMiVE2dfWNfUB6diSx+t8k4EQgL4cN02ThzJD3BM5mhU+zQVCCwfNw42eRZVIoxydYDLl/yHw=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/engine-cli": ["@rivetkit/engine-cli@2.3.9", "", { "optionalDependencies": { "@rivetkit/engine-cli-darwin-arm64": "2.3.9", "@rivetkit/engine-cli-darwin-x64": "2.3.9", "@rivetkit/engine-cli-linux-arm64-musl": "2.3.9", "@rivetkit/engine-cli-linux-x64-musl": "2.3.9", "@rivetkit/engine-cli-win32-x64": "2.3.9" } }, "sha512-6sFgD0h5Z6aTioerwCNw3WF0jRysEhJhOlQHHVdnL32KzXfZoAcJLvS3dW/M1IAKydND/MsVwSQjPSYPjTy4UQ=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/engine-envoy-protocol": ["@rivetkit/engine-envoy-protocol@2.3.9", "", { "dependencies": { "@rivetkit/bare-ts": "^0.6.2" } }, "sha512-2IK41V9U8sgMnEYd/P6u/68nCufCU2dvxuHVV3uAV0uIVCdtRV8lkjuR2fSr05bwHmzSmewdqsbiNMiC/GWt8w=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-napi": ["@rivetkit/rivetkit-napi@2.3.9", "", { "dependencies": { "@napi-rs/cli": "^2.18.4", "@rivetkit/engine-envoy-protocol": "2.3.9" }, "optionalDependencies": { "@rivetkit/rivetkit-napi-darwin-arm64": "2.3.9", "@rivetkit/rivetkit-napi-darwin-x64": "2.3.9", "@rivetkit/rivetkit-napi-linux-arm64-gnu": "2.3.9", "@rivetkit/rivetkit-napi-linux-arm64-musl": "2.3.9", "@rivetkit/rivetkit-napi-linux-x64-gnu": "2.3.9", "@rivetkit/rivetkit-napi-linux-x64-musl": "2.3.9", "@rivetkit/rivetkit-napi-win32-x64-msvc": "2.3.9" } }, "sha512-lUuOK1ja6ZMwnNRsdtqJeXChbBEqyvHuI/1h5XQWHfBUu7DgX5zuyA/FJ+BY6YFWtwnkHnOVCBJeNx/3gj8Xhg=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-wasm": ["@rivetkit/rivetkit-wasm@2.3.9", "", {}, "sha512-KRCKnk0h3dvzuLHHDTKdguSCaZdDpeza4XucYi2+XZaZUJUP1zNxCHfKvQRZ1FaGhPx9rhZJTGV19+lLOWKSwA=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/traces": ["@rivetkit/traces@2.3.9", "", { "dependencies": { "@rivetkit/bare-ts": "^0.6.2", "cbor-x": "^1.6.0", "fdb-tuple": "^1.0.0", "vbare": "^0.0.4" } }, "sha512-T0og48gPh6RjIdwEuG7mEKOuxVA3R/Zcptf67z8dHVF78yuzHooeW0W0rvH6wlu4XGINWvYhGHMGY0uh4uyPEw=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/virtual-websocket": ["@rivetkit/virtual-websocket@2.3.9", "", {}, "sha512-exWO75dBB81w3ipXRg7twXY0SYQyDsB9ELJVhi1LtmWnmCn4FnHlzfinZKZlFAf5C9L0m9XAbJGS3WfRGRGlUg=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/workflow-engine": ["@rivetkit/workflow-engine@2.3.9", "", { "dependencies": { "@rivetkit/bare-ts": "^0.6.2", "cbor-x": "^1.6.0", "fdb-tuple": "^1.0.0", "pino": "^9.6.0", "vbare": "^0.0.4" } }, "sha512-RqbXdQYc2z/PCLwOyi14iimE/+m0v7Oq7DKuzdAxs4Y1jqslUZurkn3B40pjhaNN2Kz212BJXnbmaK4YHE/q8g=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@secure-exec/nodejs/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "browserify-sign/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "browserify-sign/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ripemd160/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "vite-node/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "vitest/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@google/genai/google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/engine-cli/@rivetkit/engine-cli-darwin-arm64": ["@rivetkit/engine-cli-darwin-arm64@2.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4mXfCo48055pnNViS+2WjC8p57eLLzLw1ZNgL0b7AoaPpxJ4YKXJ9F8TezSHtTc5ScXtPdfZb5jH4n/e6ePSMA=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/engine-cli/@rivetkit/engine-cli-darwin-x64": ["@rivetkit/engine-cli-darwin-x64@2.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-BiNPd5KWKFp9H3xWZqeILJ9bmz7c04fYAAwXWtqmAWfGMBCd11QAGsJFwDnoHsMQhEGpDzbYg5L0KbKUD4HIMA=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/engine-cli/@rivetkit/engine-cli-linux-arm64-musl": ["@rivetkit/engine-cli-linux-arm64-musl@2.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-xbtUVXPK9aMcJgaA9XcLnZ52J9a9YXUWAP7pk9uHY7rRYODOwC8rRReiyeD++/+7+YsciwcIDcHb4daLHrN4tg=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/engine-cli/@rivetkit/engine-cli-linux-x64-musl": ["@rivetkit/engine-cli-linux-x64-musl@2.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-0OqFgoV4nvRJKtgXEELpwTLKuFJu6DaffG+l9xkDUdcTsf/tAgk5oNU1CLgGK0JsuT77JFucAqVd93pOEWSKhg=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/engine-cli/@rivetkit/engine-cli-win32-x64": ["@rivetkit/engine-cli-win32-x64@2.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-Pqr6YAM49vbDUhg6olE07wvIk0AhiEhoHFDoZWxfGLnnNAbZNKEa72j7rOZa0mXMe1JPCTRfG7zG85bIH6y4tQ=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-napi/@rivetkit/rivetkit-napi-darwin-arm64": ["@rivetkit/rivetkit-napi-darwin-arm64@2.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3Ls1gHUeYs1mByNDgt1H3s3b9gZaXyyFrrCagoK2HrBAr0celfMa2zh0fH1BrjZufyF5oC/Jvk3ALPCFCNf4EQ=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-napi/@rivetkit/rivetkit-napi-darwin-x64": ["@rivetkit/rivetkit-napi-darwin-x64@2.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-tsX60L7RXD9BnMU+0b8YnKfuAqYfH8sr6DnUAWk2z2Nnmc7E11RibVWSeny/+2LxD5Zib3f3G7Ea/Pt/NF+ypA=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-napi/@rivetkit/rivetkit-napi-linux-arm64-gnu": ["@rivetkit/rivetkit-napi-linux-arm64-gnu@2.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ov1c40CgIXMiOOo8sLLDO4cCcUw3+H/8OMOYoa7a5a5snmbJlDLSi0YYACWGRcBJvCGrjeDtQGIN3JISTL8Q9Q=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-napi/@rivetkit/rivetkit-napi-linux-arm64-musl": ["@rivetkit/rivetkit-napi-linux-arm64-musl@2.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-HgK83QYfT45HI+Ly+gWuoxWDSFzTgYJm0rFlmuOz8zweTirZ4ixHEE/lIQVU16lkHl4cO7PcRbQ1vUeQJMmVtA=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-napi/@rivetkit/rivetkit-napi-linux-x64-gnu": ["@rivetkit/rivetkit-napi-linux-x64-gnu@2.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-GvGfGUpCpFGWzQdA5Yey5Y5ih+J6Ay/chEwa10UlzF4MC4bX0GM//0m2FXLFUXtBjNRNdhKvAAaXWdWBuZQsSw=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-napi/@rivetkit/rivetkit-napi-linux-x64-musl": ["@rivetkit/rivetkit-napi-linux-x64-musl@2.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-J48W7iLoqE8i1n1TvhxkxFrwJTxOsdXrVf7HyXUsEyLrb+kal/aS+/ta+Bfq/veJ7wZyDw7YkOIdn0BgPinIuQ=="],
+
+    "@rivet-dev/agentos/rivetkit/@rivetkit/rivetkit-napi/@rivetkit/rivetkit-napi-win32-x64-msvc": ["@rivetkit/rivetkit-napi-win32-x64-msvc@2.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-3oZYh56m3wTVAbipHI5Rnqw1vSTI1fzoksdm1x4a45TgKi1ULxPyl2fT2E9A/Jyn1LzfTfztazN6mX0//kxmxg=="],
+
+    "ripemd160/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "ripemd160/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "vite-node/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@google/genai/google-auth-library/gaxios/node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
   }
 }

--- a/agentos-platform/bun.lock
+++ b/agentos-platform/bun.lock
@@ -1,0 +1,224 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@camelai/agentos-platform",
+      "devDependencies": {
+        "@types/node": "^22.13.10",
+        "bun-types": "^1.2.15",
+        "typescript": "^5.8.2",
+        "vitest": "^3.0.9",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.3", "", { "os": "android", "cpu": "arm" }, "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.3", "", { "os": "android", "cpu": "arm64" }, "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.3", "", { "os": "linux", "cpu": "arm" }, "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.3", "", { "os": "linux", "cpu": "arm" }, "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.3", "", { "os": "linux", "cpu": "x64" }, "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.3", "", { "os": "linux", "cpu": "x64" }, "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.3", "", { "os": "none", "cpu": "arm64" }, "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.3", "", { "os": "win32", "cpu": "x64" }, "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.3", "", { "os": "win32", "cpu": "x64" }, "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.7", "", { "dependencies": { "@vitest/spy": "3.2.7", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.7", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.7", "", { "dependencies": { "@vitest/utils": "3.2.7", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.7", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
+
+    "rollup": ["rollup@4.62.3", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.3", "@rollup/rollup-android-arm64": "4.62.3", "@rollup/rollup-darwin-arm64": "4.62.3", "@rollup/rollup-darwin-x64": "4.62.3", "@rollup/rollup-freebsd-arm64": "4.62.3", "@rollup/rollup-freebsd-x64": "4.62.3", "@rollup/rollup-linux-arm-gnueabihf": "4.62.3", "@rollup/rollup-linux-arm-musleabihf": "4.62.3", "@rollup/rollup-linux-arm64-gnu": "4.62.3", "@rollup/rollup-linux-arm64-musl": "4.62.3", "@rollup/rollup-linux-loong64-gnu": "4.62.3", "@rollup/rollup-linux-loong64-musl": "4.62.3", "@rollup/rollup-linux-ppc64-gnu": "4.62.3", "@rollup/rollup-linux-ppc64-musl": "4.62.3", "@rollup/rollup-linux-riscv64-gnu": "4.62.3", "@rollup/rollup-linux-riscv64-musl": "4.62.3", "@rollup/rollup-linux-s390x-gnu": "4.62.3", "@rollup/rollup-linux-x64-gnu": "4.62.3", "@rollup/rollup-linux-x64-musl": "4.62.3", "@rollup/rollup-openbsd-x64": "4.62.3", "@rollup/rollup-openharmony-arm64": "4.62.3", "@rollup/rollup-win32-arm64-msvc": "4.62.3", "@rollup/rollup-win32-ia32-msvc": "4.62.3", "@rollup/rollup-win32-x64-gnu": "4.62.3", "@rollup/rollup-win32-x64-msvc": "4.62.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.7", "@vitest/mocker": "3.2.7", "@vitest/pretty-format": "^3.2.7", "@vitest/runner": "3.2.7", "@vitest/snapshot": "3.2.7", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.7", "@vitest/ui": "3.2.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+  }
+}

--- a/agentos-platform/docker-compose.yml
+++ b/agentos-platform/docker-compose.yml
@@ -1,0 +1,94 @@
+# Rivetkit embedded mode: the Rivet engine runs in-process inside each app
+# container (no separate rivet-engine image). Use two app replicas to practice
+# versioned graceful drain during deploys.
+#
+# Rolling deploy (summary):
+#   1. Bump RIVET_ENVOY_VERSION (build arg + env) for the new image.
+#   2. Start app-canary (or scale a second runner) on the new version.
+#   3. Route new actor placements to the new version; old actors drain on the
+#      previous runner via Rivet version tags + keepAwake on in-flight turns.
+#   4. Stop the old runner once its actors have finalized.
+#
+# See README.md and plans/agentos-full-rewrite.md for the full procedure.
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: app
+      args:
+        RIVET_ENVOY_VERSION: ${RIVET_ENVOY_VERSION:-1}
+    container_name: agentos-app
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      PORT: "6420"
+      DATA_DIR: /data
+      RIVET_ENVOY_VERSION: ${RIVET_ENVOY_VERSION:-1}
+    volumes:
+      - agentos-data:/data
+    ports:
+      - "${PORT:-6420}:6420"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bun -e \"fetch('http://127.0.0.1:'+(process.env.PORT||6420)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # Second runner for drain testing. Enable with: docker compose --profile canary up -d
+  app-canary:
+    profiles: ["canary"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: app
+      args:
+        RIVET_ENVOY_VERSION: ${RIVET_ENVOY_VERSION_NEXT:-2}
+    container_name: agentos-app-canary
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      PORT: "6420"
+      DATA_DIR: /data
+      RIVET_ENVOY_VERSION: ${RIVET_ENVOY_VERSION_NEXT:-2}
+    volumes:
+      - agentos-data:/data
+    ports:
+      - "6421:6420"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bun -e \"fetch('http://127.0.0.1:'+(process.env.PORT||6420)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: web
+    container_name: agentos-web
+    restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_healthy
+    ports:
+      - "${WEB_PORT:-8080}:80"
+
+volumes:
+  agentos-data:
+    name: agentos-data

--- a/agentos-platform/docker/nginx.conf
+++ b/agentos-platform/docker/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://app:6420;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /ws {
+        proxy_pass http://app:6420;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 86400;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/agentos-platform/package.json
+++ b/agentos-platform/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@camelai/agentos-platform",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "dev": "bun run --watch src/server/index.ts",
+    "dev:web": "vite --config web/vite.config.ts",
+    "build": "tsc -p tsconfig.json --noEmit && vite build --config web/vite.config.ts",
+    "start": "bun run src/server/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "docker:up": "docker compose up --build -d",
+    "docker:down": "docker compose down"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "bun-types": "^1.2.15",
+    "typescript": "^5.8.2",
+    "vitest": "^3.0.9"
+  }
+}

--- a/agentos-platform/package.json
+++ b/agentos-platform/package.json
@@ -11,7 +11,9 @@
     "start": "bun run src/server/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:live-smoke": "bun run scripts/live-smoke.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "smoke": "bash scripts/smoke.sh",
     "docker:up": "docker compose up --build -d",
     "docker:down": "docker compose down"
   },

--- a/agentos-platform/package.json
+++ b/agentos-platform/package.json
@@ -27,6 +27,7 @@
     "vitest": "^3.0.9"
   },
   "dependencies": {
+    "@agentos-software/pi": "0.2.7",
     "@rivet-dev/agentos": "0.2.15",
     "@rivet-dev/agentos-core": "^0.2.15",
     "@rivetkit/react": "2.3.10",

--- a/agentos-platform/package.json
+++ b/agentos-platform/package.json
@@ -17,8 +17,20 @@
   },
   "devDependencies": {
     "@types/node": "^22.13.10",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
     "bun-types": "^1.2.15",
+    "react": "^19",
+    "react-dom": "^19",
     "typescript": "^5.8.2",
+    "vite": "^6",
     "vitest": "^3.0.9"
+  },
+  "dependencies": {
+    "@rivet-dev/agentos": "0.2.15",
+    "@rivet-dev/agentos-core": "^0.2.15",
+    "@rivetkit/react": "2.3.10",
+    "rivetkit": "2.3.10",
+    "zod": "^4.1.11"
   }
 }

--- a/agentos-platform/scripts/live-smoke.mjs
+++ b/agentos-platform/scripts/live-smoke.mjs
@@ -1,0 +1,64 @@
+/**
+ * Boots the Rivet registry and exercises sendMessage over the real client.
+ * Usage: bun run scripts/live-smoke.mjs
+ */
+import { createPlatform } from "../src/server/platform/index.ts";
+import { registry } from "../src/server/registry.ts";
+
+process.env.AGENT_RUNTIME = "mock";
+createPlatform({ ensureDemoTenant: true });
+registry.start();
+
+const endpoint = "http://127.0.0.1:6420";
+for (let attempt = 0; attempt < 50; attempt++) {
+  try {
+    const res = await fetch(endpoint);
+    if (res.ok || res.status >= 400) break;
+  } catch {
+    // engine not ready
+  }
+  await new Promise((r) => setTimeout(r, 100));
+}
+
+const { createClient } = await import("rivetkit/client");
+const client = createClient(endpoint);
+const threadId = `live_smoke_${crypto.randomUUID().slice(0, 8)}`;
+const handle = client.chatThread.getOrCreate(threadId, {
+  createWithInput: {
+    threadId,
+    workspaceId: "ws_demo",
+    orgId: "org_demo",
+    projectId: "app",
+    title: "Live smoke",
+  },
+});
+
+const clientMessageId = crypto.randomUUID();
+const send = await Promise.race([
+  handle.sendMessage("hello live smoke", clientMessageId),
+  new Promise((_, reject) =>
+    setTimeout(() => reject(new Error("sendMessage timed out")), 20_000),
+  ),
+]);
+const messages = await handle.getMessages();
+
+const summary = {
+  endpoint,
+  threadId,
+  send,
+  messageCount: messages.length,
+  roles: messages.map((m) => m.role),
+};
+console.log(JSON.stringify(summary, null, 2));
+
+if (!send || typeof send !== "object" || send.status !== "completed") {
+  console.error("unexpected send status", send);
+  process.exit(1);
+}
+if (messages.length < 2) {
+  console.error("expected user+assistant messages");
+  process.exit(1);
+}
+
+console.log("LIVE_SMOKE_OK");
+process.exit(0);

--- a/agentos-platform/scripts/smoke.sh
+++ b/agentos-platform/scripts/smoke.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# CI-friendly smoke: unit tests + typecheck (no long-running server boot).
+set -euo pipefail
+
+export PATH="/home/ubuntu/.bun/bin:${PATH:-}"
+cd "$(dirname "$0")/.."
+
+echo "==> agentos-platform smoke: typecheck"
+bun run typecheck
+
+echo "==> agentos-platform smoke: unit tests"
+bun run test
+
+echo "OK — agentos-platform smoke passed"

--- a/agentos-platform/src/client/message-adapter.ts
+++ b/agentos-platform/src/client/message-adapter.ts
@@ -1,0 +1,244 @@
+import type {
+  ChatEvent,
+  ChatMessage,
+  ContentBlock,
+  UiMessage,
+  UiPart,
+} from "../shared/index.ts";
+
+function isUiMessage(message: ChatMessage | UiMessage): message is UiMessage {
+  return "parts" in message;
+}
+
+function chatMessageToUiMessage(message: ChatMessage): UiMessage {
+  const blocks: ContentBlock[] =
+    typeof message.content === "string"
+      ? [{ type: "text", text: message.content }]
+      : message.content;
+
+  return {
+    id: message.id,
+    role: message.role,
+    createdAt: message.createdAt,
+    parts: blocks.map((block): UiPart => {
+      switch (block.type) {
+        case "text":
+          return {
+            type: "text",
+            text: block.text,
+            state: message.isStreaming ? "streaming" : "done",
+          };
+        case "thinking":
+          return {
+            type: "reasoning",
+            text: block.thinking,
+            state: message.isStreaming ? "streaming" : "done",
+          };
+        case "tool_use":
+          return {
+            type: "tool-call",
+            toolCallId: block.id,
+            toolName: block.name,
+            input: block.input,
+            state: "input-available",
+          };
+        case "tool_result":
+          return {
+            type: "tool-result",
+            toolCallId: block.tool_use_id,
+            output: block.content,
+            isError: block.is_error,
+          };
+        case "error":
+          return {
+            type: "data-error",
+            data: {
+              error: block.error,
+              title: block.title,
+              status: block.status,
+              errorType: block.errorType,
+            },
+          };
+      }
+    }),
+  };
+}
+
+function toolOutputToString(output: unknown): string {
+  if (typeof output === "string") return output;
+  try {
+    return JSON.stringify(output, null, 2);
+  } catch {
+    return String(output);
+  }
+}
+
+/**
+ * Converts the live UI shape to the durable transcript shape.
+ * Transient todo and tool-stream parts are intentionally not persisted.
+ */
+export function uiMessageToChatMessage(
+  ui: UiMessage,
+  threadId: string,
+): ChatMessage {
+  const blocks: ContentBlock[] = [];
+
+  for (const part of ui.parts) {
+    switch (part.type) {
+      case "text":
+        blocks.push({ type: "text", text: part.text });
+        break;
+      case "reasoning":
+        blocks.push({ type: "thinking", thinking: part.text });
+        break;
+      case "tool-call":
+        blocks.push({
+          type: "tool_use",
+          id: part.toolCallId,
+          name: part.toolName,
+          input: part.input,
+        });
+        break;
+      case "tool-result":
+        blocks.push({
+          type: "tool_result",
+          tool_use_id: part.toolCallId,
+          content: toolOutputToString(part.output),
+          is_error: part.isError,
+        });
+        break;
+      case "data-error":
+        blocks.push({
+          type: "error",
+          error: part.data.error,
+          title: part.data.title,
+          status:
+            typeof part.data.status === "number" ? part.data.status : undefined,
+          errorType: part.data.errorType ?? undefined,
+        });
+        break;
+      case "data-todos":
+      case "data-tool-stream":
+        break;
+    }
+  }
+
+  return {
+    id: ui.id,
+    threadId,
+    role: ui.role,
+    content: blocks,
+    createdAt: ui.createdAt,
+    isStreaming: ui.parts.some(
+      (part) =>
+        ("state" in part && part.state === "streaming") ||
+        ("state" in part && part.state === "input-streaming"),
+    ),
+  };
+}
+
+function appendDeltaParts(existing: UiPart[], incoming: UiPart[]): UiPart[] {
+  const next = [...existing];
+
+  for (const part of incoming) {
+    const identity =
+      part.type === "tool-call" || part.type === "tool-result"
+        ? `${part.type}:${part.toolCallId}`
+        : part.type === "data-error" && part.id
+          ? `${part.type}:${part.id}`
+          : part.type === "data-todos" && part.id
+            ? `${part.type}:${part.id}`
+            : null;
+
+    const replaceIndex =
+      identity === null
+        ? -1
+        : next.findIndex((candidate) => {
+            if (
+              candidate.type === "tool-call" ||
+              candidate.type === "tool-result"
+            ) {
+              return `${candidate.type}:${candidate.toolCallId}` === identity;
+            }
+            if (
+              (candidate.type === "data-error" ||
+                candidate.type === "data-todos") &&
+              candidate.id
+            ) {
+              return `${candidate.type}:${candidate.id}` === identity;
+            }
+            return false;
+          });
+
+    if (replaceIndex >= 0) next[replaceIndex] = part;
+    else next.push(part);
+  }
+
+  return next;
+}
+
+/** Applies transcript events without mutating the previous message array. */
+export function applyChatEvent(
+  messages: UiMessage[],
+  event: ChatEvent,
+): UiMessage[] {
+  if (event.type === "messageUpsert") {
+    const incoming = isUiMessage(event.message)
+      ? event.message
+      : chatMessageToUiMessage(event.message);
+    const existingIndex = messages.findIndex(
+      (message) => message.id === incoming.id,
+    );
+
+    if (existingIndex < 0) {
+      return [...messages, incoming].sort(
+        (left, right) => left.createdAt - right.createdAt,
+      );
+    }
+
+    const next = [...messages];
+    next[existingIndex] = incoming;
+    return next;
+  }
+
+  if (event.type !== "messageDelta") return messages;
+
+  const existingIndex = messages.findIndex(
+    (message) => message.id === event.messageId,
+  );
+  const current: UiMessage =
+    existingIndex >= 0
+      ? messages[existingIndex]!
+      : {
+          id: event.messageId,
+          role: "assistant",
+          parts: [],
+          createdAt: Date.now(),
+        };
+  let parts = event.parts
+    ? appendDeltaParts(current.parts, event.parts)
+    : [...current.parts];
+
+  if (event.textDelta) {
+    const lastPart = parts.at(-1);
+    if (lastPart?.type === "text" && lastPart.state === "streaming") {
+      parts = [
+        ...parts.slice(0, -1),
+        { ...lastPart, text: lastPart.text + event.textDelta },
+      ];
+    } else {
+      parts.push({
+        type: "text",
+        text: event.textDelta,
+        state: "streaming",
+      });
+    }
+  }
+
+  const updated = { ...current, parts };
+  if (existingIndex < 0) return [...messages, updated];
+
+  const next = [...messages];
+  next[existingIndex] = updated;
+  return next;
+}

--- a/agentos-platform/src/client/use-rivet-chat.ts
+++ b/agentos-platform/src/client/use-rivet-chat.ts
@@ -71,7 +71,7 @@ type LooseRivetHandle = {
 type LooseRivetClient = {
   chatThread: {
     getOrCreate(
-      key: string[],
+      key: string | string[],
       options: {
         createWithInput: Omit<ChatThreadInput, "initialTitle"> & {
           title?: string;
@@ -97,7 +97,9 @@ export function createRivetChatTransport(
   return {
     async connect(input, observer) {
       observer.onStatus("connecting");
-      const handle = client.chatThread.getOrCreate([input.threadId], {
+      // Rivet actor keys are strings (or string arrays for compound keys).
+      // Prefer the bare threadId string to match server tests / live smoke.
+      const handle = client.chatThread.getOrCreate(input.threadId, {
         createWithInput: {
           threadId: input.threadId,
           workspaceId: input.workspaceId,

--- a/agentos-platform/src/client/use-rivet-chat.ts
+++ b/agentos-platform/src/client/use-rivet-chat.ts
@@ -1,0 +1,484 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createClient } from "rivetkit/client";
+import type {
+  AnswerQuestionInput,
+  ChatEvent,
+  SendMessageInput,
+  ThreadState,
+  TurnStatus,
+  UiMessage,
+} from "../shared/index.ts";
+import { EMPTY_THREAD_STATE } from "../shared/index.ts";
+import { applyChatEvent } from "./message-adapter.ts";
+
+export type ChatConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "disconnected";
+
+export type ChatThreadInput = {
+  threadId: string;
+  workspaceId: string;
+  orgId: string;
+  projectId?: string;
+  initialTitle?: string;
+};
+
+export type ChatSnapshot = {
+  messages: UiMessage[];
+  threadState: ThreadState;
+  turnStatus: TurnStatus;
+};
+
+export type ChatTransportObserver = {
+  onEvent(event: ChatEvent): void;
+  onStatus(status: ChatConnectionStatus): void;
+  onError(error: Error): void;
+};
+
+export interface ChatTransportSession {
+  sendMessage(input: SendMessageInput): Promise<void>;
+  answerQuestion(input: AnswerQuestionInput): Promise<void>;
+  requestStop(): Promise<void>;
+  refresh(): Promise<ChatSnapshot>;
+  dispose(): Promise<void>;
+}
+
+export interface ChatTransport {
+  connect(
+    input: ChatThreadInput,
+    observer: ChatTransportObserver,
+  ): Promise<ChatTransportSession>;
+}
+
+type LooseRivetConnection = {
+  ready: Promise<void>;
+  action<T>(options: { name: string; args: unknown[] }): Promise<T>;
+  on(
+    eventName: string,
+    callback: (...args: unknown[]) => void,
+  ): () => void;
+  onError(callback: (error: unknown) => void): () => void;
+  onStatusChange(callback: (status: ChatConnectionStatus) => void): () => void;
+  dispose(): Promise<void>;
+};
+
+type LooseRivetHandle = {
+  connect(): LooseRivetConnection;
+};
+
+type LooseRivetClient = {
+  chatThread: {
+    getOrCreate(
+      key: string[],
+      options: {
+        createWithInput: Omit<ChatThreadInput, "initialTitle"> & {
+          title?: string;
+        };
+      },
+    ): LooseRivetHandle;
+  };
+};
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+/**
+ * Browser transport for the chatThread Rivet actor. This intentionally keeps
+ * the registry loose so the web bundle does not import server actor code.
+ */
+export function createRivetChatTransport(
+  endpoint = "http://localhost:6420",
+): ChatTransport {
+  const client = createClient({ endpoint }) as unknown as LooseRivetClient;
+
+  return {
+    async connect(input, observer) {
+      observer.onStatus("connecting");
+      const handle = client.chatThread.getOrCreate([input.threadId], {
+        createWithInput: {
+          threadId: input.threadId,
+          workspaceId: input.workspaceId,
+          orgId: input.orgId,
+          projectId: input.projectId,
+          title: input.initialTitle,
+        },
+      });
+      const connection = handle.connect();
+      const cleanups = [
+        connection.on("chatEvent", (event) => {
+          observer.onEvent(event as ChatEvent);
+        }),
+        connection.onStatusChange(observer.onStatus),
+        connection.onError((error) => observer.onError(asError(error))),
+      ];
+
+      try {
+        await connection.ready;
+        observer.onStatus("connected");
+      } catch (error) {
+        for (const cleanup of cleanups) cleanup();
+        await connection.dispose();
+        observer.onError(asError(error));
+        throw error;
+      }
+
+      return {
+        sendMessage(payload) {
+          return connection.action<void>({
+            name: "sendMessage",
+            args: [payload.content, payload.clientMessageId],
+          });
+        },
+        answerQuestion(payload) {
+          return connection.action<void>({
+            name: "answerQuestion",
+            args: [payload.questionId, payload.answers],
+          });
+        },
+        requestStop() {
+          return connection.action<void>({
+            name: "requestStop",
+            args: [],
+          });
+        },
+        async refresh() {
+          const [messages, state] = await Promise.all([
+            connection.action<UiMessage[]>({
+              name: "getMessages",
+              args: [],
+            }),
+            connection.action<{
+              threadState: ThreadState;
+              turnStatus: TurnStatus;
+            }>({
+              name: "getThreadState",
+              args: [],
+            }),
+          ]);
+          return {
+            messages,
+            threadState: state.threadState,
+            turnStatus: state.turnStatus,
+          };
+        },
+        async dispose() {
+          for (const cleanup of cleanups) cleanup();
+          await connection.dispose();
+        },
+      };
+    },
+  };
+}
+
+type MemoryThread = ChatSnapshot & {
+  observers: Set<ChatTransportObserver>;
+};
+
+export interface MemoryChatTransport extends ChatTransport {
+  emit(threadId: string, event: ChatEvent): void;
+  getSnapshot(threadId: string): ChatSnapshot | undefined;
+}
+
+function cloneSnapshot(thread: MemoryThread): ChatSnapshot {
+  return {
+    messages: structuredClone(thread.messages),
+    threadState: structuredClone(thread.threadState),
+    turnStatus: thread.turnStatus,
+  };
+}
+
+/** Deterministic in-memory transport used by local demo mode and unit tests. */
+export function createMemoryChatTransport(): MemoryChatTransport {
+  const threads = new Map<string, MemoryThread>();
+
+  function notifyEvent(thread: MemoryThread, event: ChatEvent) {
+    thread.messages = applyChatEvent(thread.messages, event);
+    if (event.type === "state") {
+      thread.threadState = { ...thread.threadState, ...event.state };
+    } else if (event.type === "turnStatus") {
+      thread.turnStatus = event.status;
+    }
+    for (const observer of thread.observers) observer.onEvent(event);
+  }
+
+  function notifyStatus(thread: MemoryThread, status: ChatConnectionStatus) {
+    for (const observer of thread.observers) observer.onStatus(status);
+  }
+
+  return {
+    async connect(input, observer) {
+      observer.onStatus("connecting");
+      let thread = threads.get(input.threadId);
+      if (!thread) {
+        thread = {
+          messages: [],
+          threadState: {
+            ...EMPTY_THREAD_STATE,
+            title: input.initialTitle ?? "New agent session",
+            model: "memory/demo",
+          },
+          turnStatus: "idle",
+          observers: new Set(),
+        };
+        threads.set(input.threadId, thread);
+      }
+      thread.observers.add(observer);
+      observer.onStatus("connected");
+
+      const session: ChatTransportSession = {
+        async sendMessage(payload) {
+          const createdAt = Date.now();
+          notifyEvent(thread, {
+            type: "messageUpsert",
+            message: {
+              id: payload.clientMessageId,
+              role: "user",
+              createdAt,
+              parts: [{ type: "text", text: payload.content, state: "done" }],
+            },
+          });
+          notifyEvent(thread, { type: "turnStatus", status: "streaming" });
+
+          const assistantId = `memory-${payload.clientMessageId}`;
+          notifyEvent(thread, {
+            type: "messageUpsert",
+            message: {
+              id: assistantId,
+              role: "assistant",
+              createdAt: createdAt + 1,
+              parts: [],
+            },
+          });
+          notifyEvent(thread, {
+            type: "messageDelta",
+            messageId: assistantId,
+            textDelta: `Memory mode received: ${payload.content}`,
+          });
+          notifyEvent(thread, {
+            type: "messageUpsert",
+            message: {
+              id: assistantId,
+              role: "assistant",
+              createdAt: createdAt + 1,
+              parts: [
+                {
+                  type: "text",
+                  text: `Memory mode received: ${payload.content}`,
+                  state: "done",
+                },
+              ],
+            },
+          });
+          notifyEvent(thread, { type: "turnStatus", status: "idle" });
+        },
+        async answerQuestion(payload) {
+          const answer = Object.entries(payload.answers)
+            .map(([question, value]) => `${question}: ${value}`)
+            .join("\n");
+          notifyEvent(thread, {
+            type: "state",
+            state: { pendingQuestion: null },
+          });
+          await session.sendMessage({
+            content: answer,
+            clientMessageId: crypto.randomUUID(),
+          });
+        },
+        async requestStop() {
+          notifyEvent(thread, { type: "turnStatus", status: "idle" });
+        },
+        async refresh() {
+          return cloneSnapshot(thread);
+        },
+        async dispose() {
+          notifyStatus(thread, "disconnected");
+          thread.observers.delete(observer);
+        },
+      };
+      return session;
+    },
+    emit(threadId, event) {
+      const thread = threads.get(threadId);
+      if (!thread) throw new Error(`Memory thread not found: ${threadId}`);
+      notifyEvent(thread, event);
+    },
+    getSnapshot(threadId) {
+      const thread = threads.get(threadId);
+      return thread ? cloneSnapshot(thread) : undefined;
+    },
+  };
+}
+
+export type UseRivetChatOptions = ChatThreadInput & {
+  endpoint?: string;
+  transport?: ChatTransport;
+};
+
+export function useRivetChat(options: UseRivetChatOptions) {
+  const {
+    endpoint = "http://localhost:6420",
+    threadId,
+    workspaceId,
+    orgId,
+    projectId,
+    initialTitle,
+    transport: suppliedTransport,
+  } = options;
+  const transport = useMemo(
+    () => suppliedTransport ?? createRivetChatTransport(endpoint),
+    [endpoint, suppliedTransport],
+  );
+  const sessionRef = useRef<ChatTransportSession | null>(null);
+  const [messages, setMessages] = useState<UiMessage[]>([]);
+  const [threadState, setThreadState] = useState<ThreadState>({
+    ...EMPTY_THREAD_STATE,
+    title: initialTitle ?? null,
+  });
+  const [turnStatus, setTurnStatus] = useState<TurnStatus>("idle");
+  const [connStatus, setConnStatus] =
+    useState<ChatConnectionStatus>("idle");
+  const [error, setError] = useState<Error | null>(null);
+
+  const applySnapshot = useCallback((snapshot: ChatSnapshot) => {
+    setMessages(snapshot.messages);
+    setThreadState(snapshot.threadState);
+    setTurnStatus(snapshot.turnStatus);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    let session: ChatTransportSession | null = null;
+    setMessages([]);
+    setThreadState({ ...EMPTY_THREAD_STATE, title: initialTitle ?? null });
+    setTurnStatus("idle");
+    setError(null);
+
+    void transport
+      .connect(
+        { threadId, workspaceId, orgId, projectId, initialTitle },
+        {
+          onEvent(event) {
+            if (!active) return;
+            if (
+              event.type === "messageUpsert" ||
+              event.type === "messageDelta"
+            ) {
+              setMessages((current) => applyChatEvent(current, event));
+            } else if (event.type === "state") {
+              setThreadState((current) => ({ ...current, ...event.state }));
+            } else if (event.type === "turnStatus") {
+              setTurnStatus(event.status);
+              if (event.status === "error" && event.errorMessage) {
+                setError(new Error(event.errorMessage));
+              }
+            } else if (event.type === "error") {
+              setError(new Error(event.error));
+            }
+          },
+          onStatus(status) {
+            if (active) setConnStatus(status);
+          },
+          onError(nextError) {
+            if (active) setError(nextError);
+          },
+        },
+      )
+      .then(async (connectedSession) => {
+        if (!active) {
+          await connectedSession.dispose();
+          return;
+        }
+        session = connectedSession;
+        sessionRef.current = connectedSession;
+        applySnapshot(await connectedSession.refresh());
+      })
+      .catch((nextError) => {
+        if (active) {
+          setError(asError(nextError));
+          setConnStatus("disconnected");
+        }
+      });
+
+    return () => {
+      active = false;
+      sessionRef.current = null;
+      if (session) void session.dispose();
+    };
+  }, [
+    applySnapshot,
+    initialTitle,
+    orgId,
+    projectId,
+    threadId,
+    transport,
+    workspaceId,
+  ]);
+
+  const sendMessage = useCallback(async (content: string) => {
+    const session = sessionRef.current;
+    const trimmed = content.trim();
+    if (!session) throw new Error("Chat is not connected");
+    if (!trimmed) return;
+
+    const clientMessageId = crypto.randomUUID();
+    const optimistic: UiMessage = {
+      id: clientMessageId,
+      role: "user",
+      createdAt: Date.now(),
+      parts: [{ type: "text", text: trimmed, state: "done" }],
+    };
+    setMessages((current) =>
+      applyChatEvent(current, {
+        type: "messageUpsert",
+        message: optimistic,
+      }),
+    );
+    setError(null);
+
+    try {
+      await session.sendMessage({ content: trimmed, clientMessageId });
+    } catch (nextError) {
+      const sendError = asError(nextError);
+      setError(sendError);
+      setTurnStatus("error");
+      throw sendError;
+    }
+  }, []);
+
+  const answerQuestion = useCallback(
+    async (questionId: string, answers: Record<string, string>) => {
+      const session = sessionRef.current;
+      if (!session) throw new Error("Chat is not connected");
+      setError(null);
+      await session.answerQuestion({ questionId, answers });
+    },
+    [],
+  );
+
+  const requestStop = useCallback(async () => {
+    const session = sessionRef.current;
+    if (!session) return;
+    await session.requestStop();
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const session = sessionRef.current;
+    if (!session) return;
+    applySnapshot(await session.refresh());
+  }, [applySnapshot]);
+
+  return {
+    messages,
+    threadState,
+    turnStatus,
+    connStatus,
+    error,
+    sendMessage,
+    answerQuestion,
+    requestStop,
+    refresh,
+  };
+}

--- a/agentos-platform/src/server/actors/chat-thread-agentos.ts
+++ b/agentos-platform/src/server/actors/chat-thread-agentos.ts
@@ -109,6 +109,43 @@ function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+const PI_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_OAUTH_TOKEN",
+  "OPENAI_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "AZURE_OPENAI_BASE_URL",
+  "AZURE_OPENAI_RESOURCE_NAME",
+  "AZURE_OPENAI_API_VERSION",
+  "AZURE_OPENAI_DEPLOYMENT_NAME_MAP",
+  "GEMINI_API_KEY",
+  "GROQ_API_KEY",
+  "CEREBRAS_API_KEY",
+  "XAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "AI_GATEWAY_API_KEY",
+  "ZAI_API_KEY",
+  "MISTRAL_API_KEY",
+  "MINIMAX_API_KEY",
+  "OPENCODE_API_KEY",
+  "KIMI_API_KEY",
+  "AWS_PROFILE",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "AWS_REGION",
+] as const;
+
+function piSessionEnvironment(): Record<string, string> {
+  return Object.fromEntries(
+    PI_ENV_KEYS.flatMap((key) => {
+      const value = process.env[key];
+      return value ? [[key, value]] : [];
+    }),
+  );
+}
+
 function appendMappedParts(message: UiMessage, incoming: UiPart[]): void {
   for (const part of incoming) {
     if (part.type === "reasoning") {
@@ -360,6 +397,7 @@ export function createChatThreadAgentOsActor(
               agent: "pi",
               cwd: "/workspace",
               permissionPolicy: "ask",
+              env: piSessionEnvironment(),
             });
             c.state.sessionId = "main";
           }
@@ -370,12 +408,13 @@ export function createChatThreadAgentOsActor(
             content: [{ type: "text", text: content }],
           });
           const result = await c.keepAwake(promptPromise);
+          const promptResult = result as {
+            message?: { content?: unknown };
+            stopReason?: unknown;
+          };
 
           if (assistantMessage.parts.length === 0) {
-            const response = result as {
-              message?: { content?: unknown };
-            };
-            const responseContent = response.message?.content;
+            const responseContent = promptResult.message?.content;
             if (Array.isArray(responseContent)) {
               const text = responseContent
                 .flatMap((block) =>
@@ -408,7 +447,9 @@ export function createChatThreadAgentOsActor(
             message: cloneJson(assistantMessage),
           });
           c.broadcast("chatEvent", { type: "turnStatus", status: "idle" });
-          return { status: "completed", messageId: assistantMessage.id };
+          return promptResult.stopReason === "cancelled"
+            ? { status: "stopped", messageId: assistantMessage.id }
+            : { status: "completed", messageId: assistantMessage.id };
         } catch (error) {
           const message =
             error instanceof Error ? error.message : String(error);
@@ -475,7 +516,6 @@ export function createChatThreadAgentOsActor(
           sessionId: c.state.sessionId,
         });
         c.state.turnStatus = "idle";
-        c.state.activeAssistantMessageId = null;
         c.broadcast("chatEvent", { type: "turnStatus", status: "idle" });
         return { status: "stopped" };
       },

--- a/agentos-platform/src/server/actors/chat-thread-agentos.ts
+++ b/agentos-platform/src/server/actors/chat-thread-agentos.ts
@@ -1,0 +1,506 @@
+import piSoftware from "@agentos-software/pi";
+import { agentOS, type SessionStreamEntry } from "@rivet-dev/agentos";
+import { event } from "rivetkit";
+import {
+  EMPTY_THREAD_STATE,
+  type AnswerQuestionInput,
+  type ChatEvent,
+  type ThreadState,
+  type TurnStatus,
+  type UiMessage,
+  type UiPart,
+} from "../../shared/index.ts";
+import { createCamelBindings } from "../bindings/camel.ts";
+import {
+  mapAcpSessionEntry,
+  type SessionStreamEntryLike,
+} from "../chat/acp-mapper.ts";
+import type { SendResult } from "../chat/turn.ts";
+import type { Platform } from "../platform/index.ts";
+import type {
+  ChatThreadConnParams,
+  ChatThreadCreateInput,
+} from "./chat-thread.ts";
+
+export type ChatThreadAgentOsState = {
+  threadId: string;
+  workspaceId: string;
+  orgId: string;
+  projectId: string;
+  title: string;
+  model: string;
+  messages: UiMessage[];
+  threadState: ThreadState;
+  turnStatus: TurnStatus;
+  clientMessageIds: string[];
+  sessionId: string | null;
+  activeAssistantMessageId: string | null;
+};
+
+export type ChatThreadAgentOsFactoryOptions = {
+  getPlatform?: () => Platform;
+};
+
+type ChatThreadAgentOsContext = {
+  state: ChatThreadAgentOsState;
+  broadcast: (name: "chatEvent", chatEvent: ChatEvent) => unknown;
+  keepAwake: <T>(promise: Promise<T>) => Promise<T>;
+};
+
+let configuredPlatform: Platform | undefined;
+
+/** Configure host services before the first AgentOS VM boots. */
+export function setChatThreadAgentOsPlatform(platform: Platform): void {
+  configuredPlatform = platform;
+}
+
+function getConfiguredPlatform(): Platform {
+  if (!configuredPlatform) {
+    throw new Error(
+      "chatThreadAgentOs platform is not configured; call setChatThreadAgentOsPlatform before listening",
+    );
+  }
+  return configuredPlatform;
+}
+
+function requireCreateInput(
+  input: ChatThreadCreateInput,
+): ChatThreadCreateInput {
+  if (!input?.threadId?.trim()) {
+    throw new Error("chatThreadAgentOs create input requires threadId");
+  }
+  if (!input.workspaceId?.trim()) {
+    throw new Error("chatThreadAgentOs create input requires workspaceId");
+  }
+  if (!input.orgId?.trim()) {
+    throw new Error("chatThreadAgentOs create input requires orgId");
+  }
+  return input;
+}
+
+function initialState(
+  rawInput: ChatThreadCreateInput,
+): ChatThreadAgentOsState {
+  const input = requireCreateInput(rawInput);
+  const title = input.title?.trim() || "New chat";
+  const model = input.model?.trim() || "pi";
+  return {
+    threadId: input.threadId,
+    workspaceId: input.workspaceId,
+    orgId: input.orgId,
+    projectId: input.projectId?.trim() || input.workspaceId,
+    title,
+    model,
+    messages: [],
+    threadState: {
+      ...EMPTY_THREAD_STATE,
+      title,
+      model,
+      currentTodos: [],
+    },
+    turnStatus: "idle",
+    clientMessageIds: [],
+    sessionId: null,
+    activeAssistantMessageId: null,
+  };
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function appendMappedParts(message: UiMessage, incoming: UiPart[]): void {
+  for (const part of incoming) {
+    if (part.type === "reasoning") {
+      const previous = message.parts.at(-1);
+      if (previous?.type === "reasoning" && previous.state === "streaming") {
+        previous.text += part.text;
+      } else {
+        message.parts.push(part);
+      }
+      continue;
+    }
+
+    if (part.type === "tool-call") {
+      const index = message.parts.findIndex(
+        (candidate) =>
+          candidate.type === "tool-call" &&
+          candidate.toolCallId === part.toolCallId,
+      );
+      if (index === -1) {
+        message.parts.push(part);
+      } else {
+        const previous = message.parts[index];
+        message.parts[index] =
+          previous?.type === "tool-call"
+            ? {
+                ...previous,
+                ...part,
+                input:
+                  Object.keys(part.input).length > 0
+                    ? part.input
+                    : previous.input,
+              }
+            : part;
+      }
+      continue;
+    }
+
+    if (part.type === "tool-result") {
+      const index = message.parts.findIndex(
+        (candidate) =>
+          candidate.type === "tool-result" &&
+          candidate.toolCallId === part.toolCallId,
+      );
+      if (index === -1) {
+        message.parts.push(part);
+      } else {
+        message.parts[index] = part;
+      }
+      continue;
+    }
+
+    message.parts.push(part);
+  }
+}
+
+function applyChatEvent(
+  state: ChatThreadAgentOsState,
+  chatEvent: ChatEvent,
+): void {
+  if (chatEvent.type === "state") {
+    Object.assign(state.threadState, chatEvent.state);
+    if (chatEvent.state.title) {
+      state.title = chatEvent.state.title;
+    }
+    if (chatEvent.state.model) {
+      state.model = chatEvent.state.model;
+    }
+    return;
+  }
+  if (chatEvent.type === "turnStatus") {
+    state.turnStatus = chatEvent.status;
+    return;
+  }
+  if (chatEvent.type !== "messageDelta") {
+    return;
+  }
+
+  const message = state.messages.find(
+    (candidate) => candidate.id === chatEvent.messageId,
+  );
+  if (!message) {
+    return;
+  }
+  if (chatEvent.textDelta) {
+    const previous = message.parts.at(-1);
+    if (previous?.type === "text" && previous.state === "streaming") {
+      previous.text += chatEvent.textDelta;
+    } else {
+      message.parts.push({
+        type: "text",
+        text: chatEvent.textDelta,
+        state: "streaming",
+      });
+    }
+  }
+  if (chatEvent.parts) {
+    appendMappedParts(message, chatEvent.parts);
+  }
+}
+
+type ActorDefinitionReference = {
+  config: {
+    actions?: Record<string, unknown>;
+  };
+};
+
+type InternalAction = (...args: unknown[]) => unknown;
+
+async function invokeInternalAction(
+  definition: ActorDefinitionReference,
+  name: string,
+  context: unknown,
+  ...args: unknown[]
+): Promise<unknown> {
+  const action = definition.config.actions?.[name];
+  if (typeof action !== "function") {
+    throw new Error(`AgentOS internal action is unavailable: ${name}`);
+  }
+  return await (action as InternalAction)(context, ...args);
+}
+
+export function createChatThreadAgentOsActor(
+  options: ChatThreadAgentOsFactoryOptions = {},
+) {
+  const resolvePlatform = options.getPlatform ?? getConfiguredPlatform;
+  let definition: ActorDefinitionReference;
+
+  const actorDefinition = agentOS({
+    events: {
+      chatEvent: event<ChatEvent>(),
+    },
+    software: [piSoftware],
+    resolveOptions: (c) => ({
+      bindings: [
+        createCamelBindings({
+          platform: resolvePlatform(),
+          orgId: c.state.orgId,
+          workspaceId: c.state.workspaceId,
+          projectId: c.state.projectId,
+          broadcastAskUser: ({ question, options: questionOptions }) => {
+            const pendingQuestion = {
+              questionId: crypto.randomUUID(),
+              questions: [
+                {
+                  question,
+                  header: "Question",
+                  options: questionOptions.map((label) => ({ label })),
+                  allowOther: true,
+                },
+              ],
+            };
+            c.state.threadState.pendingQuestion = pendingQuestion;
+            c.broadcast("chatEvent", {
+              type: "state",
+              state: { pendingQuestion },
+            });
+          },
+        }),
+      ],
+    }),
+    createState: (
+      _c,
+      input: ChatThreadCreateInput,
+    ): ChatThreadAgentOsState => initialState(input),
+    createConnState: (_c, _params: ChatThreadConnParams): undefined =>
+      undefined,
+    onCreate: (c, input) => {
+      const validInput = requireCreateInput(input);
+      if (c.state.threadId !== validInput.threadId) {
+        throw new Error(
+          "chatThreadAgentOs state did not initialize from create input",
+        );
+      }
+    },
+    onSessionEvent: async (
+      c,
+      sessionId: string,
+      sessionEvent: SessionStreamEntry,
+    ) => {
+      const entry = sessionEvent as unknown as SessionStreamEntryLike;
+      const messageId =
+        c.state.activeAssistantMessageId ??
+        (typeof entry.messageId === "string"
+          ? entry.messageId
+          : `agentos:${sessionId}`);
+      const events = mapAcpSessionEntry(
+        entry,
+        { messageId },
+      );
+      for (const chatEvent of events) {
+        applyChatEvent(c.state, chatEvent);
+        c.broadcast("chatEvent", chatEvent);
+      }
+    },
+    actions: {
+      async sendMessage(
+        c: ChatThreadAgentOsContext,
+        content: string,
+        clientMessageId: string,
+      ): Promise<SendResult> {
+        if (!content?.trim()) {
+          throw new Error("sendMessage requires non-empty content");
+        }
+        if (!clientMessageId?.trim()) {
+          throw new Error("sendMessage requires clientMessageId");
+        }
+        if (c.state.clientMessageIds.includes(clientMessageId)) {
+          return { status: "duplicate", messageId: clientMessageId };
+        }
+        if (c.state.turnStatus === "streaming") {
+          return { status: "busy" };
+        }
+
+        const now = Date.now();
+        const userMessage: UiMessage = {
+          id: clientMessageId,
+          role: "user",
+          parts: [{ type: "text", text: content, state: "done" }],
+          createdAt: now,
+        };
+        const assistantMessage: UiMessage = {
+          id: `assistant:${clientMessageId}`,
+          role: "assistant",
+          parts: [],
+          createdAt: now,
+        };
+        c.state.clientMessageIds.push(clientMessageId);
+        c.state.messages.push(userMessage, assistantMessage);
+        c.state.activeAssistantMessageId = assistantMessage.id;
+        c.state.turnStatus = "streaming";
+        c.state.threadState.lastError = null;
+        c.broadcast("chatEvent", {
+          type: "messageUpsert",
+          message: cloneJson(userMessage),
+        });
+        c.broadcast("chatEvent", {
+          type: "messageUpsert",
+          message: cloneJson(assistantMessage),
+        });
+        c.broadcast("chatEvent", {
+          type: "turnStatus",
+          status: "streaming",
+        });
+
+        try {
+          if (!c.state.sessionId) {
+            await invokeInternalAction(definition, "openSession", c, {
+              sessionId: "main",
+              agent: "pi",
+              cwd: "/workspace",
+              permissionPolicy: "ask",
+            });
+            c.state.sessionId = "main";
+          }
+
+          const promptPromise = invokeInternalAction(definition, "prompt", c, {
+            sessionId: c.state.sessionId,
+            idempotencyKey: clientMessageId,
+            content: [{ type: "text", text: content }],
+          });
+          const result = await c.keepAwake(promptPromise);
+
+          if (assistantMessage.parts.length === 0) {
+            const response = result as {
+              message?: { content?: unknown };
+            };
+            const responseContent = response.message?.content;
+            if (Array.isArray(responseContent)) {
+              const text = responseContent
+                .flatMap((block) =>
+                  typeof block === "object" &&
+                  block !== null &&
+                  "text" in block &&
+                  typeof block.text === "string"
+                    ? [block.text]
+                    : [],
+                )
+                .join("");
+              if (text) {
+                assistantMessage.parts.push({
+                  type: "text",
+                  text,
+                  state: "done",
+                });
+              }
+            }
+          }
+
+          for (const part of assistantMessage.parts) {
+            if (part.type === "text" || part.type === "reasoning") {
+              part.state = "done";
+            }
+          }
+          c.state.turnStatus = "idle";
+          c.broadcast("chatEvent", {
+            type: "messageUpsert",
+            message: cloneJson(assistantMessage),
+          });
+          c.broadcast("chatEvent", { type: "turnStatus", status: "idle" });
+          return { status: "completed", messageId: assistantMessage.id };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          const errorPart: UiPart = {
+            type: "data-error",
+            id: `error:${clientMessageId}`,
+            data: { error: message },
+          };
+          assistantMessage.parts.push(errorPart);
+          const lastError = {
+            id: `error:${clientMessageId}`,
+            error: message,
+          };
+          c.state.threadState.lastError = lastError;
+          c.state.turnStatus = "error";
+          c.broadcast("chatEvent", {
+            type: "state",
+            state: { lastError },
+          });
+          c.broadcast("chatEvent", {
+            type: "messageUpsert",
+            message: cloneJson(assistantMessage),
+          });
+          c.broadcast("chatEvent", {
+            type: "turnStatus",
+            status: "error",
+            errorMessage: message,
+          });
+          return {
+            status: "error",
+            messageId: assistantMessage.id,
+            error: message,
+          };
+        } finally {
+          c.state.activeAssistantMessageId = null;
+        }
+      },
+
+      getMessages(c: ChatThreadAgentOsContext): UiMessage[] {
+        return cloneJson(c.state.messages);
+      },
+
+      getThreadState(c: ChatThreadAgentOsContext): {
+        threadState: ThreadState;
+        turnStatus: TurnStatus;
+        title: string;
+        model: string;
+      } {
+        return {
+          threadState: cloneJson(c.state.threadState),
+          turnStatus: c.state.turnStatus,
+          title: c.state.title,
+          model: c.state.model,
+        };
+      },
+
+      async requestStop(
+        c: ChatThreadAgentOsContext,
+      ): Promise<{ status: "stopped" | "idle" }> {
+        if (c.state.turnStatus !== "streaming" || !c.state.sessionId) {
+          return { status: "idle" };
+        }
+        await invokeInternalAction(definition, "cancelPrompt", c, {
+          sessionId: c.state.sessionId,
+        });
+        c.state.turnStatus = "idle";
+        c.state.activeAssistantMessageId = null;
+        c.broadcast("chatEvent", { type: "turnStatus", status: "idle" });
+        return { status: "stopped" };
+      },
+
+      answerQuestion(
+        c: ChatThreadAgentOsContext,
+        questionId: string,
+        answers: AnswerQuestionInput["answers"],
+      ): { status: "answered" | "not_found"; answers?: Record<string, string> } {
+        const pending = c.state.threadState.pendingQuestion;
+        if (!pending || pending.questionId !== questionId) {
+          return { status: "not_found" };
+        }
+        c.state.threadState.pendingQuestion = null;
+        c.broadcast("chatEvent", {
+          type: "state",
+          state: { pendingQuestion: null },
+        });
+        return { status: "answered", answers };
+      },
+    },
+  });
+
+  definition = actorDefinition;
+  return actorDefinition;
+}
+
+export const chatThreadAgentOs = createChatThreadAgentOsActor();

--- a/agentos-platform/src/server/actors/chat-thread.ts
+++ b/agentos-platform/src/server/actors/chat-thread.ts
@@ -1,0 +1,247 @@
+import { actor, event } from "rivetkit";
+import {
+  EMPTY_THREAD_STATE,
+  type AnswerQuestionInput,
+  type ChatEvent,
+  type ThreadState,
+  type TurnStatus,
+  type UiMessage,
+} from "../../shared/index.ts";
+import {
+  createAgentRuntime,
+  type AgentRuntime,
+} from "../chat/runtime.ts";
+import { runChatTurn, type SendResult } from "../chat/turn.ts";
+
+export type ChatThreadCreateInput = {
+  threadId: string;
+  workspaceId: string;
+  orgId: string;
+  projectId?: string;
+  title?: string;
+  model?: string;
+};
+
+export type ChatThreadConnParams = {
+  userId?: string;
+};
+
+export type ChatThreadState = {
+  threadId: string;
+  workspaceId: string;
+  orgId: string;
+  projectId: string;
+  title: string;
+  model: string;
+  messages: UiMessage[];
+  threadState: ThreadState;
+  turnStatus: TurnStatus;
+  clientMessageIds: string[];
+};
+
+type ChatThreadVars = {
+  activeRuntime: AgentRuntime | null;
+  abortController: AbortController | null;
+};
+
+function requireCreateInput(input: ChatThreadCreateInput): ChatThreadCreateInput {
+  if (!input?.threadId?.trim()) {
+    throw new Error("chatThread create input requires threadId");
+  }
+  if (!input.workspaceId?.trim()) {
+    throw new Error("chatThread create input requires workspaceId");
+  }
+  if (!input.orgId?.trim()) {
+    throw new Error("chatThread create input requires orgId");
+  }
+  return input;
+}
+
+function initialState(rawInput: ChatThreadCreateInput): ChatThreadState {
+  const input = requireCreateInput(rawInput);
+  const title = input.title?.trim() || "New chat";
+  const model = input.model?.trim() || "mock";
+  return {
+    threadId: input.threadId,
+    workspaceId: input.workspaceId,
+    orgId: input.orgId,
+    projectId: input.projectId?.trim() || input.workspaceId,
+    title,
+    model,
+    messages: [],
+    threadState: {
+      ...EMPTY_THREAD_STATE,
+      title,
+      model,
+      currentTodos: [],
+    },
+    turnStatus: "idle",
+    clientMessageIds: [],
+  };
+}
+
+function runtimeForEnvironment(): AgentRuntime {
+  // "echo" is retained as a convenient alias for the deterministic mock.
+  return process.env.AGENT_RUNTIME === "agentos"
+    ? createAgentRuntime({ mode: "agentos" })
+    : createAgentRuntime({ mode: "mock" });
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function createChatThreadActor() {
+  return actor({
+    events: {
+      chatEvent: event<ChatEvent>(),
+    },
+    createState: (_c, input: ChatThreadCreateInput): ChatThreadState =>
+      initialState(input),
+    createVars: (): ChatThreadVars => ({
+      activeRuntime: null,
+      abortController: null,
+    }),
+    createConnState: (_c, _params: ChatThreadConnParams): undefined =>
+      undefined,
+    onCreate: (c, input) => {
+      // createState owns initialization; this validates the persisted identity
+      // against the create request before the actor becomes available.
+      const validInput = requireCreateInput(input);
+      if (c.state.threadId !== validInput.threadId) {
+        throw new Error("chatThread state did not initialize from create input");
+      }
+    },
+    actions: {
+      async sendMessage(
+        c,
+        content: string,
+        clientMessageId: string,
+      ): Promise<SendResult> {
+        if (!content?.trim()) {
+          throw new Error("sendMessage requires non-empty content");
+        }
+        if (!clientMessageId?.trim()) {
+          throw new Error("sendMessage requires clientMessageId");
+        }
+        if (c.state.clientMessageIds.includes(clientMessageId)) {
+          return { status: "duplicate", messageId: clientMessageId };
+        }
+        if (c.state.turnStatus === "streaming") {
+          return { status: "busy" };
+        }
+
+        c.state.clientMessageIds.push(clientMessageId);
+        const runtime = runtimeForEnvironment();
+        const abortController = new AbortController();
+        c.vars.activeRuntime = runtime;
+        c.vars.abortController = abortController;
+
+        const turnPromise = runChatTurn({
+          messages: c.state.messages,
+          broadcast: (chatEvent) => c.broadcast("chatEvent", chatEvent),
+          updateState: (patch) => {
+            Object.assign(c.state.threadState, patch);
+          },
+          runtime,
+          content,
+          clientMessageId,
+          turnStatus: () => c.state.turnStatus,
+          updateTurnStatus: (status) => {
+            c.state.turnStatus = status;
+          },
+          signal: abortController.signal,
+        });
+
+        try {
+          return await c.keepAwake(turnPromise);
+        } finally {
+          if (c.vars.activeRuntime === runtime) {
+            c.vars.activeRuntime = null;
+            c.vars.abortController = null;
+          }
+        }
+      },
+
+      getMessages(c): UiMessage[] {
+        return cloneJson(c.state.messages);
+      },
+
+      getThreadState(c): {
+        threadState: ThreadState;
+        turnStatus: TurnStatus;
+        title: string;
+        model: string;
+      } {
+        return {
+          threadState: cloneJson(c.state.threadState),
+          turnStatus: c.state.turnStatus,
+          title: c.state.title,
+          model: c.state.model,
+        };
+      },
+
+      answerQuestion(
+        c,
+        questionId: string,
+        answers: AnswerQuestionInput["answers"],
+      ): { status: "answered" | "not_found"; answers?: Record<string, string> } {
+        const pending = c.state.threadState.pendingQuestion;
+        if (!pending || pending.questionId !== questionId) {
+          return { status: "not_found" };
+        }
+        c.state.threadState.pendingQuestion = null;
+        c.broadcast("chatEvent", {
+          type: "state",
+          state: { pendingQuestion: null },
+        } satisfies ChatEvent);
+        return { status: "answered", answers };
+      },
+
+      async requestStop(c): Promise<{ status: "stopped" | "idle" }> {
+        const runtime = c.vars.activeRuntime;
+        if (!runtime) {
+          return { status: "idle" };
+        }
+        c.vars.abortController?.abort();
+        await runtime.cancel();
+        c.state.turnStatus = "idle";
+        c.broadcast("chatEvent", {
+          type: "turnStatus",
+          status: "idle",
+        } satisfies ChatEvent);
+        return { status: "stopped" };
+      },
+
+      setTitle(c, title: string): string {
+        const normalized = title?.trim();
+        if (!normalized) {
+          throw new Error("setTitle requires non-empty title");
+        }
+        c.state.title = normalized;
+        c.state.threadState.title = normalized;
+        c.broadcast("chatEvent", {
+          type: "state",
+          state: { title: normalized },
+        } satisfies ChatEvent);
+        return normalized;
+      },
+
+      setModel(c, model: string): string {
+        const normalized = model?.trim();
+        if (!normalized) {
+          throw new Error("setModel requires non-empty model");
+        }
+        c.state.model = normalized;
+        c.state.threadState.model = normalized;
+        c.broadcast("chatEvent", {
+          type: "state",
+          state: { model: normalized },
+        } satisfies ChatEvent);
+        return normalized;
+      },
+    },
+  });
+}
+
+export const chatThread = createChatThreadActor();

--- a/agentos-platform/src/server/actors/chat-thread.ts
+++ b/agentos-platform/src/server/actors/chat-thread.ts
@@ -13,7 +13,14 @@ import {
   createAgentRuntime,
   type AgentRuntime,
 } from "../chat/runtime.ts";
+import {
+  assertCanStartHostedTurn,
+  chargeTurn,
+  CreditDeniedError,
+} from "../chat/credits-gate.ts";
 import { runChatTurn, type SendResult } from "../chat/turn.ts";
+import { recordError, recordEvent } from "../observability.ts";
+import { getPlatform, type Platform } from "../platform/index.ts";
 
 export type ChatThreadCreateInput = {
   threadId: string;
@@ -44,6 +51,7 @@ export type ChatThreadState = {
 type ChatThreadVars = {
   activeRuntime: AgentRuntime | null;
   abortController: AbortController | null;
+  platform: Platform;
 };
 
 function requireCreateInput(input: ChatThreadCreateInput): ChatThreadCreateInput {
@@ -126,6 +134,7 @@ export function createChatThreadActor() {
     createVars: (): ChatThreadVars => ({
       activeRuntime: null,
       abortController: null,
+      platform: getPlatform(),
     }),
     createConnState: (_c, _params: ChatThreadConnParams): undefined =>
       undefined,
@@ -235,6 +244,62 @@ export function createChatThreadActor() {
           return { status: "error", messageId: assistantMessageId, error };
         }
 
+        const platform = c.vars.platform;
+        const bypassCredits =
+          process.env.AGENT_BYOK === "1" || c.state.model.startsWith("byok:");
+        try {
+          assertCanStartHostedTurn({
+            billing: platform.billing,
+            orgId: c.state.orgId,
+            bypass: bypassCredits,
+          });
+        } catch (error) {
+          if (!(error instanceof CreditDeniedError)) {
+            throw error;
+          }
+          const messageId = `assistant:${clientMessageId}`;
+          const lastError = {
+            id: `error:${clientMessageId}`,
+            error: error.message,
+            title: "Credits required",
+            status: error.status,
+            errorType: error.code,
+          };
+          c.state.threadState.lastError = lastError;
+          c.state.turnStatus = "error";
+          await c.broadcast("chatEvent", {
+            type: "state",
+            state: { lastError },
+          } satisfies ChatEvent);
+          await c.broadcast("chatEvent", {
+            type: "turnStatus",
+            status: "error",
+            errorMessage: error.message,
+          } satisfies ChatEvent);
+          recordEvent({
+            event: "turns_denied_credits",
+            severity: "warn",
+            component: "chat-thread",
+            operation: "sendMessage",
+            status: "denied",
+            threadId: c.state.threadId,
+            workspaceId: c.state.workspaceId,
+            orgId: c.state.orgId,
+          });
+          return { status: "error", messageId, error: error.message };
+        }
+
+        const startedAt = Date.now();
+        recordEvent({
+          event: "turns_started",
+          component: "chat-thread",
+          operation: "sendMessage",
+          status: "started",
+          threadId: c.state.threadId,
+          workspaceId: c.state.workspaceId,
+          orgId: c.state.orgId,
+          meta: { model: c.state.model, creditChargeable: !bypassCredits },
+        });
         const runtime = runtimeForEnvironment();
         const abortController = new AbortController();
         c.vars.activeRuntime = runtime;
@@ -257,7 +322,57 @@ export function createChatThreadActor() {
         });
 
         try {
-          return await c.keepAwake(turnPromise);
+          const result = await c.keepAwake(turnPromise);
+          const durationMs = Date.now() - startedAt;
+          if (result.status === "completed") {
+            try {
+              chargeTurn(
+                platform.billing,
+                platform.usage,
+                {
+                  orgId: c.state.orgId,
+                  workspaceId: c.state.workspaceId,
+                  threadId: c.state.threadId,
+                  bypass: bypassCredits,
+                },
+                { cents: 1, durationMs, model: c.state.model },
+              );
+            } catch (error) {
+              recordError({
+                event: "turn_charge_failed",
+                component: "chat-thread",
+                operation: "chargeTurn",
+                threadId: c.state.threadId,
+                workspaceId: c.state.workspaceId,
+                orgId: c.state.orgId,
+                durationMs,
+                error,
+              });
+              throw error;
+            }
+            recordEvent({
+              event: "turns_completed",
+              component: "chat-thread",
+              operation: "sendMessage",
+              status: "completed",
+              threadId: c.state.threadId,
+              workspaceId: c.state.workspaceId,
+              orgId: c.state.orgId,
+              durationMs,
+            });
+          } else if (result.status === "error") {
+            recordError({
+              event: "turn_failed",
+              component: "chat-thread",
+              operation: "sendMessage",
+              threadId: c.state.threadId,
+              workspaceId: c.state.workspaceId,
+              orgId: c.state.orgId,
+              durationMs,
+              error: result.error,
+            });
+          }
+          return result;
         } finally {
           if (c.vars.activeRuntime === runtime) {
             c.vars.activeRuntime = null;

--- a/agentos-platform/src/server/actors/chat-thread.ts
+++ b/agentos-platform/src/server/actors/chat-thread.ts
@@ -3,6 +3,8 @@ import {
   EMPTY_THREAD_STATE,
   type AnswerQuestionInput,
   type ChatEvent,
+  isSlashCommand,
+  type SlashCommand,
   type ThreadState,
   type TurnStatus,
   type UiMessage,
@@ -81,14 +83,37 @@ function initialState(rawInput: ChatThreadCreateInput): ChatThreadState {
 }
 
 function runtimeForEnvironment(): AgentRuntime {
-  // "echo" is retained as a convenient alias for the deterministic mock.
-  return process.env.AGENT_RUNTIME === "agentos"
-    ? createAgentRuntime({ mode: "agentos" })
-    : createAgentRuntime({ mode: "mock" });
+  // This actor intentionally remains deterministic. Live AgentOS sessions are
+  // exposed by the separate chatThreadAgentOs actor.
+  return createAgentRuntime({ mode: "mock" });
 }
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function slashCommandReply(
+  command: SlashCommand,
+  state: ChatThreadState,
+  messageCount: number,
+): string {
+  switch (command) {
+    case "/compact":
+      return "Context compacted (stub).";
+    case "/context":
+      return `Context contains ${messageCount} messages.`;
+    case "/debug":
+      return JSON.stringify({
+        orgId: state.orgId,
+        workspaceId: state.workspaceId,
+        threadId: state.threadId,
+        projectId: state.projectId,
+      });
+    case "/insights":
+      return "Insights generated (stub).";
+    case "/security-review":
+      return "Security review requested (stub).";
+  }
 }
 
 export function createChatThreadActor() {
@@ -132,6 +157,84 @@ export function createChatThreadActor() {
         }
 
         c.state.clientMessageIds.push(clientMessageId);
+        const normalizedContent = content.trim();
+        if (normalizedContent.startsWith("/")) {
+          const now = Date.now();
+          const assistantMessageId = `assistant:${clientMessageId}`;
+          const userMessage: UiMessage = {
+            id: clientMessageId,
+            role: "user",
+            parts: [{ type: "text", text: content, state: "done" }],
+            createdAt: now,
+          };
+
+          if (isSlashCommand(normalizedContent)) {
+            const assistantMessage: UiMessage = {
+              id: assistantMessageId,
+              role: "assistant",
+              parts: [
+                {
+                  type: "text",
+                  text: slashCommandReply(
+                    normalizedContent,
+                    c.state,
+                    c.state.messages.length,
+                  ),
+                  state: "done",
+                },
+              ],
+              createdAt: now,
+            };
+            c.state.messages.push(userMessage, assistantMessage);
+            await c.broadcast("chatEvent", {
+              type: "messageUpsert",
+              message: cloneJson(userMessage),
+            } satisfies ChatEvent);
+            await c.broadcast("chatEvent", {
+              type: "messageUpsert",
+              message: cloneJson(assistantMessage),
+            } satisfies ChatEvent);
+            return { status: "completed", messageId: assistantMessageId };
+          }
+
+          const error = `Unknown slash command: ${normalizedContent}`;
+          const errorId = `error:${clientMessageId}`;
+          const assistantMessage: UiMessage = {
+            id: assistantMessageId,
+            role: "assistant",
+            parts: [
+              {
+                type: "data-error",
+                id: errorId,
+                data: { error },
+              },
+            ],
+            createdAt: now,
+          };
+          const lastError = { id: errorId, error };
+          c.state.messages.push(userMessage, assistantMessage);
+          c.state.threadState.lastError = lastError;
+          c.state.turnStatus = "error";
+          await c.broadcast("chatEvent", {
+            type: "messageUpsert",
+            message: cloneJson(userMessage),
+          } satisfies ChatEvent);
+          await c.broadcast("chatEvent", {
+            type: "messageUpsert",
+            message: cloneJson(assistantMessage),
+          } satisfies ChatEvent);
+          await c.broadcast("chatEvent", {
+            type: "state",
+            state: { lastError },
+          } satisfies ChatEvent);
+          await c.broadcast("chatEvent", {
+            type: "turnStatus",
+            status: "error",
+            errorMessage: error,
+          } satisfies ChatEvent);
+          return { status: "error", messageId: assistantMessageId, error };
+        }
+
         const runtime = runtimeForEnvironment();
         const abortController = new AbortController();
         c.vars.activeRuntime = runtime;

--- a/agentos-platform/src/server/actors/org.ts
+++ b/agentos-platform/src/server/actors/org.ts
@@ -1,0 +1,45 @@
+import { actor } from "rivetkit";
+
+export type OrgActorState = {
+  orgId: string;
+  name: string;
+  creditCents: number;
+};
+
+export type OrgActorCreateInput = {
+  orgId: string;
+  name?: string;
+  creditCents?: number;
+};
+
+export const org = actor({
+  createState: (_c, input: OrgActorCreateInput): OrgActorState => {
+    if (!input?.orgId?.trim()) {
+      throw new Error("org create input requires orgId");
+    }
+    const creditCents = input.creditCents ?? 0;
+    if (!Number.isInteger(creditCents) || creditCents < 0) {
+      throw new Error("org creditCents must be a non-negative integer");
+    }
+    return {
+      orgId: input.orgId,
+      name: input.name?.trim() || "Untitled organization",
+      creditCents,
+    };
+  },
+  actions: {
+    getInfo(c): OrgActorState {
+      return { ...c.state };
+    },
+    grantCredits(c, cents: number): number {
+      if (!Number.isInteger(cents) || cents <= 0) {
+        throw new Error("grantCredits cents must be a positive integer");
+      }
+      c.state.creditCents += cents;
+      return c.state.creditCents;
+    },
+    getCredits(c): number {
+      return c.state.creditCents;
+    },
+  },
+});

--- a/agentos-platform/src/server/actors/workspace.ts
+++ b/agentos-platform/src/server/actors/workspace.ts
@@ -1,0 +1,55 @@
+import { actor } from "rivetkit";
+
+export type WorkspaceActorState = {
+  workspaceId: string;
+  orgId: string;
+  name: string;
+  threadIds: string[];
+};
+
+export type WorkspaceActorCreateInput = {
+  workspaceId: string;
+  orgId: string;
+  name?: string;
+};
+
+export const workspace = actor({
+  createState: (
+    _c,
+    input: WorkspaceActorCreateInput,
+  ): WorkspaceActorState => {
+    if (!input?.workspaceId?.trim()) {
+      throw new Error("workspace create input requires workspaceId");
+    }
+    if (!input.orgId?.trim()) {
+      throw new Error("workspace create input requires orgId");
+    }
+    return {
+      workspaceId: input.workspaceId,
+      orgId: input.orgId,
+      name: input.name?.trim() || "Untitled workspace",
+      threadIds: [],
+    };
+  },
+  actions: {
+    listThreads(c): string[] {
+      return [...c.state.threadIds];
+    },
+    registerThread(c, threadId: string): string[] {
+      const normalized = threadId?.trim();
+      if (!normalized) {
+        throw new Error("registerThread requires threadId");
+      }
+      if (!c.state.threadIds.includes(normalized)) {
+        c.state.threadIds.push(normalized);
+      }
+      return [...c.state.threadIds];
+    },
+    getInfo(c): WorkspaceActorState {
+      return {
+        ...c.state,
+        threadIds: [...c.state.threadIds],
+      };
+    },
+  },
+});

--- a/agentos-platform/src/server/auth/oauth.ts
+++ b/agentos-platform/src/server/auth/oauth.ts
@@ -1,0 +1,252 @@
+export type OAuthProviderName = "github" | "google";
+
+export type OAuthProviderConfig = {
+  provider: OAuthProviderName;
+  clientId: string;
+  secret: string;
+  authorizeUrl: string;
+  tokenUrl: string;
+  userInfoUrl: string;
+  scopes: string[];
+};
+
+export type OAuthProfile = {
+  providerUserId: string;
+  email: string;
+  name: string;
+};
+
+type OAuthEnvironment = Record<string, string | undefined>;
+export type OAuthFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+const PROVIDER_DEFAULTS: Record<
+  OAuthProviderName,
+  Pick<
+    OAuthProviderConfig,
+    "authorizeUrl" | "tokenUrl" | "userInfoUrl" | "scopes"
+  >
+> = {
+  github: {
+    authorizeUrl: "https://github.com/login/oauth/authorize",
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    userInfoUrl: "https://api.github.com/user",
+    scopes: ["read:user", "user:email"],
+  },
+  google: {
+    authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenUrl: "https://oauth2.googleapis.com/token",
+    userInfoUrl: "https://openidconnect.googleapis.com/v1/userinfo",
+    scopes: ["openid", "email", "profile"],
+  },
+};
+
+function providerPrefix(provider: OAuthProviderName): string {
+  return provider.toUpperCase();
+}
+
+function configuredValue(
+  env: OAuthEnvironment,
+  provider: OAuthProviderName,
+  name: string,
+): string {
+  const prefix = providerPrefix(provider);
+  return (
+    env[`${prefix}_OAUTH_${name}`]?.trim() ||
+    env[`${prefix}_${name}`]?.trim() ||
+    ""
+  );
+}
+
+export function getOAuthProviderConfig(
+  provider: OAuthProviderName,
+  env: OAuthEnvironment = process.env,
+): OAuthProviderConfig {
+  const defaults = PROVIDER_DEFAULTS[provider];
+  if (!defaults) {
+    throw new Error(`Unsupported OAuth provider: ${provider}`);
+  }
+  const prefix = providerPrefix(provider);
+  return {
+    provider,
+    clientId: configuredValue(env, provider, "CLIENT_ID"),
+    secret:
+      configuredValue(env, provider, "CLIENT_SECRET") ||
+      configuredValue(env, provider, "SECRET"),
+    authorizeUrl:
+      env[`${prefix}_OAUTH_AUTHORIZE_URL`]?.trim() ||
+      env[`${prefix}_AUTHORIZE_URL`]?.trim() ||
+      defaults.authorizeUrl,
+    tokenUrl:
+      env[`${prefix}_OAUTH_TOKEN_URL`]?.trim() ||
+      env[`${prefix}_TOKEN_URL`]?.trim() ||
+      defaults.tokenUrl,
+    userInfoUrl:
+      env[`${prefix}_OAUTH_USER_INFO_URL`]?.trim() ||
+      env[`${prefix}_USER_INFO_URL`]?.trim() ||
+      defaults.userInfoUrl,
+    scopes: defaults.scopes,
+  };
+}
+
+export const oauthProviderConfig = getOAuthProviderConfig;
+
+function requireConfigured(config: OAuthProviderConfig): void {
+  const missing: string[] = [];
+  if (!config.clientId) {
+    missing.push("client ID");
+  }
+  if (!config.secret) {
+    missing.push("client secret");
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `OAuth not configured for ${config.provider}: missing ${missing.join(" and ")}`,
+    );
+  }
+}
+
+export function buildAuthorizeUrl(
+  config: OAuthProviderConfig,
+  state: string,
+  redirectUri: string,
+): string {
+  requireConfigured(config);
+  if (!state) {
+    throw new Error("OAuth state is required");
+  }
+  if (!redirectUri) {
+    throw new Error("OAuth redirect URI is required");
+  }
+
+  const url = new URL(config.authorizeUrl);
+  url.searchParams.set("client_id", config.clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", config.scopes.join(" "));
+  url.searchParams.set("state", state);
+  if (config.provider === "google") {
+    url.searchParams.set("access_type", "online");
+  }
+  return url.toString();
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  ...keys: string[]
+): string {
+  for (const key of keys) {
+    const field = value[key];
+    if (typeof field === "string" && field.trim()) {
+      return field.trim();
+    }
+    if (typeof field === "number" && Number.isFinite(field)) {
+      return String(field);
+    }
+  }
+  return "";
+}
+
+async function responseJson(
+  response: Response,
+  operation: string,
+): Promise<Record<string, unknown>> {
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error(`${operation} returned an invalid JSON response`);
+  }
+  if (!response.ok) {
+    const detail =
+      payload && typeof payload === "object"
+        ? stringField(payload as Record<string, unknown>, "error_description", "error")
+        : "";
+    throw new Error(
+      `${operation} failed (${response.status})${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error(`${operation} returned an invalid response`);
+  }
+  return payload as Record<string, unknown>;
+}
+
+export async function exchangeCodeForProfile(
+  config: OAuthProviderConfig,
+  code: string,
+  redirectUri: string,
+  fetchImpl: OAuthFetch = globalThis.fetch,
+): Promise<OAuthProfile> {
+  requireConfigured(config);
+  if (!code) {
+    throw new Error("OAuth authorization code is required");
+  }
+  if (!redirectUri) {
+    throw new Error("OAuth redirect URI is required");
+  }
+
+  const tokenResponse = await fetchImpl(config.tokenUrl, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.secret,
+      code,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+    }),
+  });
+  const tokenPayload = await responseJson(tokenResponse, "OAuth token exchange");
+  const accessToken = stringField(tokenPayload, "access_token");
+  if (!accessToken) {
+    throw new Error("OAuth token exchange returned no access token");
+  }
+
+  const profileResponse = await fetchImpl(config.userInfoUrl, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+      "User-Agent": "camelAI-agentOS",
+    },
+  });
+  const profilePayload = await responseJson(
+    profileResponse,
+    "OAuth profile request",
+  );
+  const providerUserId = stringField(profilePayload, "sub", "id");
+  const email = stringField(profilePayload, "email").toLowerCase();
+  const name =
+    stringField(profilePayload, "name", "login") ||
+    (email ? email.split("@")[0] ?? email : "");
+  if (!providerUserId || !email) {
+    throw new Error("OAuth profile is missing a user ID or email address");
+  }
+  return { providerUserId, email, name };
+}
+
+export function createOAuthClient(
+  provider: OAuthProviderName,
+  options: { env?: OAuthEnvironment; fetch?: OAuthFetch } = {},
+): {
+  config: OAuthProviderConfig;
+  buildAuthorizeUrl: (state: string, redirectUri: string) => string;
+  exchangeCodeForProfile: (
+    code: string,
+    redirectUri: string,
+  ) => Promise<OAuthProfile>;
+} {
+  const config = getOAuthProviderConfig(provider, options.env);
+  return {
+    config,
+    buildAuthorizeUrl: (state, redirectUri) =>
+      buildAuthorizeUrl(config, state, redirectUri),
+    exchangeCodeForProfile: (code, redirectUri) =>
+      exchangeCodeForProfile(config, code, redirectUri, options.fetch),
+  };
+}

--- a/agentos-platform/src/server/auth/password.ts
+++ b/agentos-platform/src/server/auth/password.ts
@@ -1,0 +1,133 @@
+import {
+  randomBytes,
+  scrypt as nodeScrypt,
+  timingSafeEqual,
+} from "node:crypto";
+
+const SCRYPT_ALGORITHM = "scrypt";
+const SCRYPT_KEY_LENGTH = 64;
+const SCRYPT_COST = 16_384;
+const SCRYPT_BLOCK_SIZE = 8;
+const SCRYPT_PARALLELIZATION = 1;
+const SCRYPT_MAX_MEMORY = 32 * 1024 * 1024;
+
+function deriveKey(
+  password: string,
+  salt: Buffer,
+  keyLength: number,
+  cost: number,
+  blockSize: number,
+  parallelization: number,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    nodeScrypt(
+      password,
+      salt,
+      keyLength,
+      {
+        N: cost,
+        r: blockSize,
+        p: parallelization,
+        maxmem: SCRYPT_MAX_MEMORY,
+      },
+      (error, derivedKey) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(derivedKey);
+      },
+    );
+  });
+}
+
+/**
+ * Hash a password into a self-contained, versionable scrypt string.
+ *
+ * Format: scrypt$N$r$p$salt(base64url)$hash(base64url)
+ */
+export async function hashPassword(password: string): Promise<string> {
+  if (typeof password !== "string" || password.length === 0) {
+    throw new Error("Password must be a non-empty string");
+  }
+
+  const salt = randomBytes(16);
+  const hash = await deriveKey(
+    password,
+    salt,
+    SCRYPT_KEY_LENGTH,
+    SCRYPT_COST,
+    SCRYPT_BLOCK_SIZE,
+    SCRYPT_PARALLELIZATION,
+  );
+
+  return [
+    SCRYPT_ALGORITHM,
+    SCRYPT_COST,
+    SCRYPT_BLOCK_SIZE,
+    SCRYPT_PARALLELIZATION,
+    salt.toString("base64url"),
+    hash.toString("base64url"),
+  ].join("$");
+}
+
+/** Verify a password without throwing for malformed or unsupported hashes. */
+export async function verifyPassword(
+  password: string,
+  encodedHash: string,
+): Promise<boolean> {
+  if (typeof password !== "string" || typeof encodedHash !== "string") {
+    return false;
+  }
+
+  const [algorithm, costRaw, blockSizeRaw, parallelizationRaw, saltRaw, hashRaw] =
+    encodedHash.split("$");
+  if (
+    algorithm !== SCRYPT_ALGORITHM ||
+    !costRaw ||
+    !blockSizeRaw ||
+    !parallelizationRaw ||
+    !saltRaw ||
+    !hashRaw
+  ) {
+    return false;
+  }
+
+  const cost = Number(costRaw);
+  const blockSize = Number(blockSizeRaw);
+  const parallelization = Number(parallelizationRaw);
+  if (
+    !Number.isInteger(cost) ||
+    cost < 2 ||
+    (cost & (cost - 1)) !== 0 ||
+    !Number.isInteger(blockSize) ||
+    blockSize <= 0 ||
+    !Number.isInteger(parallelization) ||
+    parallelization <= 0
+  ) {
+    return false;
+  }
+
+  try {
+    const salt = Buffer.from(saltRaw, "base64url");
+    const expectedHash = Buffer.from(hashRaw, "base64url");
+    if (
+      salt.length === 0 ||
+      expectedHash.length === 0 ||
+      expectedHash.length > 1024
+    ) {
+      return false;
+    }
+    const actualHash = await deriveKey(
+      password,
+      salt,
+      expectedHash.length,
+      cost,
+      blockSize,
+      parallelization,
+    );
+    return timingSafeEqual(actualHash, expectedHash);
+  } catch {
+    return false;
+  }
+}

--- a/agentos-platform/src/server/auth/proxy-auth.ts
+++ b/agentos-platform/src/server/auth/proxy-auth.ts
@@ -1,0 +1,149 @@
+export type ProxyIdentity = {
+  email: string;
+  name: string;
+  groups?: string[];
+};
+
+export type ProxyAuthMode = "cloudflare-access" | "pomerium" | "off";
+export type ProxyAuthHeaders =
+  | Headers
+  | Record<string, string | string[] | undefined>;
+
+export interface ProxyAuthProvider {
+  name: string;
+  extractIdentity(headers: ProxyAuthHeaders): ProxyIdentity | null;
+}
+
+function headerValue(headers: ProxyAuthHeaders, name: string): string | null {
+  if (headers instanceof Headers) {
+    return headers.get(name);
+  }
+  const target = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== target || value === undefined) {
+      continue;
+    }
+    return Array.isArray(value) ? (value[0] ?? null) : value;
+  }
+  return null;
+}
+
+function normalizeIdentity(
+  emailValue: string | null,
+  nameValue?: string | null,
+  groups?: string[],
+): ProxyIdentity | null {
+  const email = emailValue?.trim().toLowerCase();
+  if (!email) {
+    return null;
+  }
+  const name =
+    nameValue?.trim() || email.split("@")[0]?.trim() || "camelAI User";
+  return groups?.length ? { email, name, groups } : { email, name };
+}
+
+function parseJwtIdentity(token: string | null): ProxyIdentity | null {
+  if (!token) {
+    return null;
+  }
+  const parts = token.split(".");
+  if (parts.length !== 3 || !parts[1]) {
+    return null;
+  }
+  try {
+    const payload: unknown = JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf8"),
+    );
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      return null;
+    }
+    const claims = payload as Record<string, unknown>;
+    const email = typeof claims.email === "string" ? claims.email : null;
+    const name =
+      typeof claims.name === "string"
+        ? claims.name
+        : typeof claims.common_name === "string"
+          ? claims.common_name
+          : null;
+    const groups = Array.isArray(claims.groups)
+      ? claims.groups.filter(
+          (group): group is string =>
+            typeof group === "string" && group.length > 0,
+        )
+      : undefined;
+    return normalizeIdentity(email, name, groups);
+  } catch {
+    return null;
+  }
+}
+
+function parseGroups(value: string | null): string[] | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      const groups = parsed.filter(
+        (group): group is string =>
+          typeof group === "string" && group.trim().length > 0,
+      );
+      return groups.length > 0 ? groups : undefined;
+    }
+  } catch {
+    // Pomerium may send a comma-delimited claim instead of JSON.
+  }
+  const groups = value
+    .split(",")
+    .map((group) => group.trim())
+    .filter(Boolean);
+  return groups.length > 0 ? groups : undefined;
+}
+
+export const cloudflareAccessProxyAuth: ProxyAuthProvider = {
+  name: "cloudflare-access",
+  extractIdentity(headers) {
+    const email = headerValue(
+      headers,
+      "CF-Access-Authenticated-User-Email",
+    );
+    if (email) {
+      return normalizeIdentity(
+        email,
+        headerValue(headers, "CF-Access-Authenticated-User-Name"),
+      );
+    }
+    return parseJwtIdentity(headerValue(headers, "CF_Authorization"));
+  },
+};
+
+export const pomeriumProxyAuth: ProxyAuthProvider = {
+  name: "pomerium",
+  extractIdentity(headers) {
+    return normalizeIdentity(
+      headerValue(headers, "X-Pomerium-Claim-Email") ??
+        headerValue(headers, "X-Pomerium-Email"),
+      headerValue(headers, "X-Pomerium-Claim-Name") ??
+        headerValue(headers, "X-Pomerium-Name"),
+      parseGroups(headerValue(headers, "X-Pomerium-Claim-Groups")),
+    );
+  },
+};
+
+export function resolveProxyAuth(
+  headers: ProxyAuthHeaders,
+  mode: ProxyAuthMode,
+): ProxyIdentity | null {
+  switch (mode) {
+    case "off":
+      return null;
+    case "cloudflare-access":
+      return cloudflareAccessProxyAuth.extractIdentity(headers);
+    case "pomerium":
+      return pomeriumProxyAuth.extractIdentity(headers);
+    default: {
+      const exhaustive: never = mode;
+      throw new Error(`Unsupported proxy auth mode: ${String(exhaustive)}`);
+    }
+  }
+}

--- a/agentos-platform/src/server/auth/service.ts
+++ b/agentos-platform/src/server/auth/service.ts
@@ -1,0 +1,194 @@
+import type {
+  IdentityService,
+  User,
+} from "../platform/identity.ts";
+import type { OAuthProfile } from "./oauth.ts";
+import { hashPassword, verifyPassword } from "./password.ts";
+import {
+  resolveProxyAuth,
+  type ProxyAuthHeaders,
+  type ProxyAuthMode,
+  type ProxyIdentity,
+} from "./proxy-auth.ts";
+import {
+  parseSessionCookie,
+  type SessionRecord,
+  type SessionService,
+} from "./session.ts";
+
+export type AuthServiceOptions = {
+  proxyAuthMode?: ProxyAuthMode;
+};
+
+export type RequiredSession = {
+  session: SessionRecord;
+  user: User;
+};
+
+function normalizeEmail(email: string): string {
+  const normalized = email?.trim().toLowerCase();
+  if (!normalized || !normalized.includes("@")) {
+    throw new Error("A valid email address is required");
+  }
+  return normalized;
+}
+
+function displayName(name: string | undefined, email: string): string {
+  return name?.trim() || email.split("@")[0]?.trim() || "camelAI User";
+}
+
+function proxyModeFromEnv(): ProxyAuthMode {
+  const mode = process.env.PROXY_AUTH_MODE?.trim() || "off";
+  if (
+    mode !== "off" &&
+    mode !== "cloudflare-access" &&
+    mode !== "pomerium"
+  ) {
+    throw new Error(`Invalid PROXY_AUTH_MODE: ${mode}`);
+  }
+  return mode;
+}
+
+export class AuthService {
+  private readonly proxyAuthMode: ProxyAuthMode;
+
+  constructor(
+    private readonly identity: IdentityService,
+    private readonly sessions: SessionService,
+    options: AuthServiceOptions = {},
+  ) {
+    this.proxyAuthMode = options.proxyAuthMode ?? proxyModeFromEnv();
+  }
+
+  async registerPassword(input: {
+    email: string;
+    password: string;
+    name: string;
+  }): Promise<SessionRecord> {
+    const email = normalizeEmail(input.email);
+    if (!input.password) {
+      throw new Error("Password is required");
+    }
+
+    let user = this.identity.findUserByEmail(email);
+    if (user && this.identity.getPasswordHash(user.id)) {
+      throw new Error("An account with this email already exists");
+    }
+    if (!user) {
+      user = this.createUserTenant({
+        email,
+        name: displayName(input.name, email),
+      });
+    }
+
+    const passwordHash = await hashPassword(input.password);
+    this.identity.setPasswordHash(user.id, passwordHash);
+    return this.sessions.createSession({
+      userId: user.id,
+      orgId: user.orgId,
+      provider: "password",
+    });
+  }
+
+  async loginPassword(input: {
+    email: string;
+    password: string;
+  }): Promise<SessionRecord> {
+    const email = normalizeEmail(input.email);
+    const user = this.identity.findUserByEmail(email);
+    const passwordHash = user
+      ? this.identity.getPasswordHash(user.id)
+      : undefined;
+    if (
+      !user ||
+      !passwordHash ||
+      !(await verifyPassword(input.password, passwordHash))
+    ) {
+      throw new Error("Invalid email or password");
+    }
+    return this.sessions.createSession({
+      userId: user.id,
+      orgId: user.orgId,
+      provider: "password",
+    });
+  }
+
+  loginFromProxy(
+    headers: ProxyAuthHeaders,
+    mode: ProxyAuthMode = this.proxyAuthMode,
+  ): SessionRecord {
+    const proxyIdentity = resolveProxyAuth(headers, mode);
+    if (!proxyIdentity) {
+      throw new Error(
+        mode === "off"
+          ? "Proxy authentication is disabled"
+          : "Proxy identity was not provided",
+      );
+    }
+    const user = this.findOrCreateUser(proxyIdentity);
+    return this.sessions.createSession({
+      userId: user.id,
+      orgId: user.orgId,
+      provider: "proxy",
+    });
+  }
+
+  loginFromOAuthProfile(profile: OAuthProfile): SessionRecord {
+    const email = normalizeEmail(profile.email);
+    if (!profile.providerUserId?.trim()) {
+      throw new Error("OAuth profile user ID is required");
+    }
+    const user = this.findOrCreateUser({
+      email,
+      name: displayName(profile.name, email),
+    });
+    return this.sessions.createSession({
+      userId: user.id,
+      orgId: user.orgId,
+      provider: "oauth",
+    });
+  }
+
+  requireSession(cookieHeader: string | null | undefined): RequiredSession {
+    const sessionId = parseSessionCookie(cookieHeader);
+    const session = sessionId
+      ? this.sessions.getSession(sessionId)
+      : undefined;
+    if (!session) {
+      throw new Error("Authentication required");
+    }
+    const user = this.identity.getUser(session.userId);
+    if (!user || user.orgId !== session.orgId) {
+      this.sessions.revokeSession(session.sessionId);
+      throw new Error("Authentication required");
+    }
+    return { session, user };
+  }
+
+  private findOrCreateUser(identity: ProxyIdentity): User {
+    const email = normalizeEmail(identity.email);
+    return (
+      this.identity.findUserByEmail(email) ??
+      this.createUserTenant({
+        email,
+        name: displayName(identity.name, email),
+      })
+    );
+  }
+
+  private createUserTenant(input: { email: string; name: string }): User {
+    const org = this.identity.createOrg({
+      name: `${input.name}'s Org`,
+    });
+    this.identity.createWorkspace({
+      orgId: org.id,
+      name: "My Workspace",
+      slug: "workspace",
+    });
+    return this.identity.createUser({
+      orgId: org.id,
+      email: input.email,
+      name: input.name,
+    });
+  }
+}

--- a/agentos-platform/src/server/auth/session.ts
+++ b/agentos-platform/src/server/auth/session.ts
@@ -1,0 +1,191 @@
+import { randomBytes } from "node:crypto";
+import type { Store } from "../platform/store.ts";
+
+export const SESSION_COOKIE_NAME = "camelai_session";
+export const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+export const DEFAULT_SESSION_TTL_SECONDS = SESSION_TTL_SECONDS;
+
+export type SessionProvider = "password" | "oauth" | "proxy";
+
+export type SessionRecord = {
+  sessionId: string;
+  userId: string;
+  orgId: string;
+  createdAt: string;
+  expiresAt: string;
+  provider: SessionProvider;
+};
+
+export type SessionServiceOptions = {
+  ttlSeconds?: number;
+  now?: () => Date;
+};
+
+export type SessionCookieOptions = {
+  secure?: boolean;
+  maxAge?: number;
+};
+
+function sessionKey(sessionId: string): string {
+  return `session:${sessionId}`;
+}
+
+function sessionTtlFromEnv(): number {
+  const raw = process.env.SESSION_TTL_SECONDS;
+  if (!raw) {
+    return DEFAULT_SESSION_TTL_SECONDS;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid SESSION_TTL_SECONDS: ${raw}`);
+  }
+  return value;
+}
+
+function cookieIsSecure(): boolean {
+  const configured = process.env.SESSION_COOKIE_SECURE?.trim().toLowerCase();
+  if (configured) {
+    if (configured === "true" || configured === "1") {
+      return true;
+    }
+    if (configured === "false" || configured === "0") {
+      return false;
+    }
+    throw new Error(
+      `Invalid SESSION_COOKIE_SECURE: ${process.env.SESSION_COOKIE_SECURE}`,
+    );
+  }
+  return process.env.NODE_ENV === "production";
+}
+
+export class SessionService {
+  readonly ttlSeconds: number;
+  private readonly now: () => Date;
+
+  constructor(
+    private readonly store: Store,
+    options: SessionServiceOptions = {},
+  ) {
+    this.ttlSeconds = options.ttlSeconds ?? sessionTtlFromEnv();
+    if (!Number.isInteger(this.ttlSeconds) || this.ttlSeconds <= 0) {
+      throw new Error("Session TTL must be a positive integer");
+    }
+    this.now = options.now ?? (() => new Date());
+  }
+
+  createSession(input: {
+    userId: string;
+    orgId: string;
+    provider: SessionProvider;
+  }): SessionRecord {
+    if (!input.userId?.trim()) {
+      throw new Error("createSession: userId is required");
+    }
+    if (!input.orgId?.trim()) {
+      throw new Error("createSession: orgId is required");
+    }
+    if (!["password", "oauth", "proxy"].includes(input.provider)) {
+      throw new Error(`createSession: unsupported provider: ${input.provider}`);
+    }
+
+    const createdAt = this.now();
+    const record: SessionRecord = {
+      sessionId: randomBytes(32).toString("base64url"),
+      userId: input.userId,
+      orgId: input.orgId,
+      createdAt: createdAt.toISOString(),
+      expiresAt: new Date(
+        createdAt.getTime() + this.ttlSeconds * 1000,
+      ).toISOString(),
+      provider: input.provider,
+    };
+    this.store.set(sessionKey(record.sessionId), record);
+    return record;
+  }
+
+  getSession(sessionId: string): SessionRecord | undefined {
+    if (!sessionId) {
+      return undefined;
+    }
+    const record = this.store.get<SessionRecord>(sessionKey(sessionId));
+    if (!record) {
+      return undefined;
+    }
+    const expiresAt = Date.parse(record.expiresAt);
+    if (!Number.isFinite(expiresAt) || expiresAt <= this.now().getTime()) {
+      this.store.delete(sessionKey(sessionId));
+      return undefined;
+    }
+    return record;
+  }
+
+  revokeSession(sessionId: string): boolean {
+    if (!sessionId) {
+      return false;
+    }
+    return this.store.delete(sessionKey(sessionId));
+  }
+
+  touchSession(sessionId: string): SessionRecord | undefined {
+    const current = this.getSession(sessionId);
+    if (!current) {
+      return undefined;
+    }
+    const updated: SessionRecord = {
+      ...current,
+      expiresAt: new Date(
+        this.now().getTime() + this.ttlSeconds * 1000,
+      ).toISOString(),
+    };
+    this.store.set(sessionKey(sessionId), updated);
+    return updated;
+  }
+}
+
+export function serializeSessionCookie(
+  sessionId: string,
+  options: SessionCookieOptions = {},
+): string {
+  const secure = options.secure ?? cookieIsSecure();
+  const maxAge = options.maxAge ?? sessionTtlFromEnv();
+  if (!Number.isInteger(maxAge) || maxAge < 0) {
+    throw new Error("Session cookie maxAge must be a non-negative integer");
+  }
+
+  const parts = [
+    `${SESSION_COOKIE_NAME}=${encodeURIComponent(sessionId)}`,
+    "HttpOnly",
+    "SameSite=Lax",
+    "Path=/",
+    `Max-Age=${maxAge}`,
+  ];
+  if (secure) {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+export function parseSessionCookie(
+  cookieHeader: string | null | undefined,
+): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+  for (const part of cookieHeader.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator < 0) {
+      continue;
+    }
+    const name = part.slice(0, separator).trim();
+    if (name !== SESSION_COOKIE_NAME) {
+      continue;
+    }
+    try {
+      const value = decodeURIComponent(part.slice(separator + 1).trim());
+      return value || null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}

--- a/agentos-platform/src/server/auth/tickets.ts
+++ b/agentos-platform/src/server/auth/tickets.ts
@@ -1,0 +1,87 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export type AuthTicketPayload = {
+  orgId: string;
+  workspaceId: string;
+  threadId: string;
+  userId: string;
+  /** Unix timestamp in seconds. */
+  exp: number;
+};
+
+function signingSecret(secret?: string): string {
+  return secret?.trim() || process.env.TOKEN_SIGNING_SECRET?.trim() || "dev-secret";
+}
+
+function encode(value: string | Buffer): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function signature(encodedPayload: string, secret?: string): Buffer {
+  return createHmac("sha256", signingSecret(secret))
+    .update(encodedPayload)
+    .digest();
+}
+
+function isTicketPayload(value: unknown): value is AuthTicketPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const payload = value as Partial<AuthTicketPayload>;
+  return (
+    typeof payload.orgId === "string" &&
+    payload.orgId.length > 0 &&
+    typeof payload.workspaceId === "string" &&
+    payload.workspaceId.length > 0 &&
+    typeof payload.threadId === "string" &&
+    payload.threadId.length > 0 &&
+    typeof payload.userId === "string" &&
+    payload.userId.length > 0 &&
+    Number.isInteger(payload.exp)
+  );
+}
+
+export function mintTicket(
+  payload: AuthTicketPayload,
+  secret?: string,
+): string {
+  if (!isTicketPayload(payload)) {
+    throw new Error("Invalid auth ticket payload");
+  }
+  const encodedPayload = encode(JSON.stringify(payload));
+  return `${encodedPayload}.${encode(signature(encodedPayload, secret))}`;
+}
+
+export function verifyTicket(
+  ticket: string,
+  secret?: string,
+): AuthTicketPayload | null {
+  const [encodedPayload, encodedSignature, extra] = ticket.split(".");
+  if (!encodedPayload || !encodedSignature || extra !== undefined) {
+    return null;
+  }
+
+  try {
+    const actualSignature = Buffer.from(encodedSignature, "base64url");
+    const expectedSignature = signature(encodedPayload, secret);
+    if (
+      actualSignature.length !== expectedSignature.length ||
+      !timingSafeEqual(actualSignature, expectedSignature)
+    ) {
+      return null;
+    }
+
+    const payload: unknown = JSON.parse(
+      Buffer.from(encodedPayload, "base64url").toString("utf8"),
+    );
+    if (
+      !isTicketPayload(payload) ||
+      payload.exp <= Math.floor(Date.now() / 1000)
+    ) {
+      return null;
+    }
+    return payload;
+  } catch {
+    return null;
+  }
+}

--- a/agentos-platform/src/server/billing/stripe.ts
+++ b/agentos-platform/src/server/billing/stripe.ts
@@ -1,0 +1,629 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import {
+  BILLING_PLAN_LIMITS,
+  BILLING_PLANS,
+  includedCreditsForPlan,
+  type BillingPlan,
+} from "../../shared/billing-plans.ts";
+import {
+  type BillingAccount,
+  type BillingService,
+  type BillingStatus,
+} from "../platform/billing.ts";
+
+export const STRIPE_API_VERSION = "2026-06-24.dahlia";
+
+export type StripeMode = "test" | "live";
+
+export interface StripeCheckoutSession {
+  id: string;
+  url: string | null;
+  mode?: string;
+  amount_total?: number | null;
+  payment_status?: string;
+  customer?: string | { id?: string } | null;
+  metadata?: Record<string, string>;
+  client_reference_id?: string | null;
+}
+
+export interface StripeWebhookEvent {
+  id: string;
+  type: string;
+  data: {
+    object: Record<string, unknown>;
+  };
+}
+
+export interface StripeBillingClientOptions {
+  secretKey?: string;
+  webhookSecret?: string;
+  mode?: StripeMode;
+  fetch?: typeof fetch;
+  now?: () => number;
+  signatureToleranceSeconds?: number;
+  priceIds?: Partial<Record<BillingPlan, string>>;
+}
+
+export interface CreateSubscriptionCheckoutInput {
+  orgId: string;
+  plan: BillingPlan;
+  successUrl: string;
+  cancelUrl: string;
+  customerId?: string;
+  seatCount?: number;
+}
+
+export interface CreateCreditsCheckoutInput {
+  orgId: string;
+  amountCents: number;
+  successUrl: string;
+  cancelUrl: string;
+  customerId?: string;
+}
+
+export class StripeBillingClient {
+  private readonly secretKey: string;
+  private readonly webhookSecret: string;
+  private readonly mode: StripeMode;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+  private readonly signatureToleranceSeconds: number;
+  private readonly priceIds: Partial<Record<BillingPlan, string>>;
+
+  constructor(options: StripeBillingClientOptions = {}) {
+    this.secretKey =
+      options.secretKey?.trim() ?? process.env.STRIPE_SECRET_KEY?.trim() ?? "";
+    this.webhookSecret =
+      options.webhookSecret?.trim() ??
+      process.env.STRIPE_WEBHOOK_SECRET?.trim() ??
+      "";
+    this.mode =
+      options.mode ?? parseStripeMode(process.env.STRIPE_MODE) ?? "test";
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.now = options.now ?? Date.now;
+    this.signatureToleranceSeconds =
+      options.signatureToleranceSeconds ?? 5 * 60;
+    this.priceIds = {
+      starter:
+        options.priceIds?.starter ??
+        process.env.STRIPE_STARTER_PRICE_ID?.trim(),
+      pro:
+        options.priceIds?.pro ?? process.env.STRIPE_PRO_PRICE_ID?.trim(),
+      team:
+        options.priceIds?.team ?? process.env.STRIPE_TEAM_PRICE_ID?.trim(),
+      ...options.priceIds,
+    };
+  }
+
+  async createCheckoutSessionForSubscription(
+    input: CreateSubscriptionCheckoutInput,
+  ): Promise<StripeCheckoutSession> {
+    this.requireConfiguredKey();
+    requireOrgId(input.orgId);
+    requireHttpUrl(input.successUrl, "successUrl");
+    requireHttpUrl(input.cancelUrl, "cancelUrl");
+
+    const limits = BILLING_PLAN_LIMITS[input.plan];
+    if (
+      !limits ||
+      limits.monthlyPriceCents === null ||
+      limits.monthlyPriceCents <= 0
+    ) {
+      throw new Error(
+        `Stripe subscription checkout is not available for plan ${input.plan}`,
+      );
+    }
+
+    const seatCount = normalizeSeatCount(input.plan, input.seatCount);
+    const body = new URLSearchParams();
+    body.set("mode", "subscription");
+    body.set("success_url", input.successUrl);
+    body.set("cancel_url", input.cancelUrl);
+    body.set("client_reference_id", input.orgId);
+    if (input.customerId?.trim()) {
+      body.set("customer", input.customerId.trim());
+    }
+    setMetadata(body, "metadata", {
+      type: "subscription",
+      purchase_type: "subscription",
+      orgId: input.orgId,
+      org_id: input.orgId,
+      plan: input.plan,
+      billing_plan: input.plan,
+      seatCount: String(seatCount),
+      seat_count: String(seatCount),
+    });
+    setMetadata(body, "subscription_data[metadata]", {
+      orgId: input.orgId,
+      org_id: input.orgId,
+      plan: input.plan,
+      billing_plan: input.plan,
+      seatCount: String(seatCount),
+      seat_count: String(seatCount),
+    });
+
+    const priceId = this.priceIds[input.plan]?.trim();
+    if (priceId) {
+      body.set("line_items[0][price]", priceId);
+    } else {
+      body.set("line_items[0][price_data][currency]", "usd");
+      body.set(
+        "line_items[0][price_data][unit_amount]",
+        String(limits.monthlyPriceCents),
+      );
+      body.set(
+        "line_items[0][price_data][recurring][interval]",
+        "month",
+      );
+      body.set(
+        "line_items[0][price_data][product_data][name]",
+        `camelAI ${limits.label}`,
+      );
+    }
+    body.set("line_items[0][quantity]", String(seatCount));
+
+    return this.stripeRequest<StripeCheckoutSession>(
+      "/v1/checkout/sessions",
+      body,
+    );
+  }
+
+  async createCheckoutSessionForCredits(
+    input: CreateCreditsCheckoutInput,
+  ): Promise<StripeCheckoutSession> {
+    this.requireConfiguredKey();
+    requireOrgId(input.orgId);
+    requirePositiveCents(input.amountCents, "amountCents");
+    requireHttpUrl(input.successUrl, "successUrl");
+    requireHttpUrl(input.cancelUrl, "cancelUrl");
+
+    const body = new URLSearchParams();
+    body.set("mode", "payment");
+    body.set("success_url", input.successUrl);
+    body.set("cancel_url", input.cancelUrl);
+    body.set("client_reference_id", input.orgId);
+    if (input.customerId?.trim()) {
+      body.set("customer", input.customerId.trim());
+    }
+    setMetadata(body, "metadata", {
+      type: "credits",
+      purchase_type: "credits",
+      orgId: input.orgId,
+      org_id: input.orgId,
+      amountCents: String(input.amountCents),
+      amount_cents: String(input.amountCents),
+    });
+    body.set("line_items[0][price_data][currency]", "usd");
+    body.set(
+      "line_items[0][price_data][unit_amount]",
+      String(input.amountCents),
+    );
+    body.set(
+      "line_items[0][price_data][product_data][name]",
+      "camelAI credits",
+    );
+    body.set("line_items[0][quantity]", "1");
+
+    return this.stripeRequest<StripeCheckoutSession>(
+      "/v1/checkout/sessions",
+      body,
+    );
+  }
+
+  constructEvent(
+    rawBody: string | Uint8Array,
+    signatureHeader: string | null | undefined,
+  ): StripeWebhookEvent {
+    if (!this.webhookSecret) {
+      throw new Error("Stripe webhook not configured");
+    }
+    if (!signatureHeader) {
+      throw new Error("Invalid Stripe signature");
+    }
+
+    const signatures = parseSignatureHeader(signatureHeader);
+    const timestamp = signatures.timestamp;
+    const ageSeconds = Math.abs(Math.floor(this.now() / 1000) - timestamp);
+    if (ageSeconds > this.signatureToleranceSeconds) {
+      throw new Error("Invalid Stripe signature: timestamp outside tolerance");
+    }
+
+    const payload = Buffer.isBuffer(rawBody)
+      ? rawBody
+      : Buffer.from(rawBody);
+    const expected = createHmac("sha256", this.webhookSecret)
+      .update(String(timestamp))
+      .update(".")
+      .update(payload)
+      .digest();
+    const valid = signatures.v1.some((candidate) => {
+      if (!/^[0-9a-f]{64}$/i.test(candidate)) {
+        return false;
+      }
+      const actual = Buffer.from(candidate, "hex");
+      return actual.length === expected.length && timingSafeEqual(actual, expected);
+    });
+    if (!valid) {
+      throw new Error("Invalid Stripe signature");
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(payload.toString("utf8"));
+    } catch {
+      throw new Error("Invalid Stripe webhook payload");
+    }
+    if (!isStripeWebhookEvent(parsed)) {
+      throw new Error("Invalid Stripe webhook event");
+    }
+    return parsed;
+  }
+
+  private requireConfiguredKey(): void {
+    if (!this.secretKey) {
+      throw new Error("Stripe not configured");
+    }
+    const keyMode = stripeKeyMode(this.secretKey);
+    if (keyMode && keyMode !== this.mode) {
+      throw new Error(
+        `Stripe key mode mismatch: STRIPE_MODE=${this.mode} requires a ${this.mode} key`,
+      );
+    }
+  }
+
+  private async stripeRequest<T>(
+    path: string,
+    body: URLSearchParams,
+  ): Promise<T> {
+    const response = await this.fetchImpl(`https://api.stripe.com${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.secretKey}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Stripe-Version": STRIPE_API_VERSION,
+      },
+      body,
+    });
+
+    const payload = (await response.json().catch(() => null)) as
+      | (T & { error?: { message?: string } })
+      | null;
+    if (!response.ok) {
+      const detail = payload?.error?.message?.trim();
+      throw new Error(
+        detail ? `Stripe request failed: ${detail}` : "Stripe request failed",
+      );
+    }
+    if (!payload) {
+      throw new Error("Stripe returned an invalid response");
+    }
+    return payload;
+  }
+}
+
+export function handleWebhookEvent(
+  event: StripeWebhookEvent,
+  billingService: BillingService,
+): BillingAccount | undefined {
+  const object = event.data.object;
+  switch (event.type) {
+    case "checkout.session.completed":
+      return handleCheckoutCompleted(object, billingService);
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted":
+      return handleSubscriptionChanged(object, billingService);
+    case "invoice.paid":
+    case "invoice.payment_succeeded":
+      return handlePaidInvoice(object, billingService);
+    default:
+      return undefined;
+  }
+}
+
+function handleCheckoutCompleted(
+  object: Record<string, unknown>,
+  billingService: BillingService,
+): BillingAccount | undefined {
+  const metadata = asMetadata(object.metadata);
+  if (
+    object.mode !== "payment" ||
+    (metadata.type !== "credits" && metadata.purchase_type !== "credits")
+  ) {
+    return undefined;
+  }
+  const orgId = firstString(
+    metadata.orgId,
+    metadata.org_id,
+    object.client_reference_id,
+  );
+  const sessionId = stringValue(object.id);
+  const amountCents =
+    positiveInteger(object.amount_total) ??
+    positiveInteger(metadata.amountCents) ??
+    positiveInteger(metadata.amount_cents);
+  if (!orgId || !sessionId || !amountCents) {
+    throw new Error("Stripe credits checkout is missing billing metadata");
+  }
+  const customerId = expandableId(object.customer);
+  if (customerId) {
+    billingService.setStripeIds(orgId, { customerId });
+  }
+  return billingService.grantPurchasedCredits(
+    orgId,
+    amountCents,
+    sessionId,
+  );
+}
+
+function handleSubscriptionChanged(
+  object: Record<string, unknown>,
+  billingService: BillingService,
+): BillingAccount {
+  const metadata = asMetadata(object.metadata);
+  const orgId = firstString(metadata.orgId, metadata.org_id);
+  if (!orgId) {
+    throw new Error("Stripe subscription is missing org metadata");
+  }
+  const current = billingService.getAccount(orgId);
+  const plan =
+    parseBillingPlan(firstString(metadata.plan, metadata.billing_plan)) ??
+    current.plan;
+  const seatCount =
+    positiveInteger(metadata.seatCount) ??
+    positiveInteger(metadata.seat_count) ??
+    subscriptionQuantity(object) ??
+    current.seatCount;
+  billingService.setPlan(orgId, plan, seatCount);
+  billingService.setBillingStatus(
+    orgId,
+    eventBillingStatus(stringValue(object.status)),
+  );
+  return billingService.setStripeIds(orgId, {
+    customerId: expandableId(object.customer),
+    subscriptionId: stringValue(object.id),
+  });
+}
+
+function handlePaidInvoice(
+  object: Record<string, unknown>,
+  billingService: BillingService,
+): BillingAccount | undefined {
+  const invoiceId = stringValue(object.id);
+  if (!invoiceId) {
+    throw new Error("Stripe paid invoice is missing an id");
+  }
+
+  const metadataSources = invoiceMetadataSources(object);
+  const orgId = firstFromMetadata(metadataSources, "orgId", "org_id");
+  if (!orgId) {
+    throw new Error("Stripe paid invoice is missing org metadata");
+  }
+  const current = billingService.getAccount(orgId);
+  const plan =
+    parseBillingPlan(
+      firstFromMetadata(metadataSources, "plan", "billing_plan"),
+    ) ?? current.plan;
+  const seatCount =
+    positiveInteger(
+      firstFromMetadata(metadataSources, "seatCount", "seat_count"),
+    ) ??
+    invoiceQuantity(object) ??
+    current.seatCount;
+  const grantCents = includedCreditsForPlan(plan, seatCount);
+  if (grantCents <= 0) {
+    return undefined;
+  }
+  billingService.setPlan(orgId, plan, seatCount);
+  return billingService.grantIncludedCredits(
+    orgId,
+    grantCents,
+    invoiceId,
+  );
+}
+
+function invoiceMetadataSources(
+  object: Record<string, unknown>,
+): Array<Record<string, string>> {
+  const sources = [asMetadata(object.metadata)];
+  const subscriptionDetails = asRecord(object.subscription_details);
+  sources.push(asMetadata(subscriptionDetails?.metadata));
+  const parent = asRecord(object.parent);
+  const parentSubscription = asRecord(parent?.subscription_details);
+  sources.push(asMetadata(parentSubscription?.metadata));
+  const lines = asRecord(object.lines);
+  const lineData = Array.isArray(lines?.data) ? lines.data : [];
+  for (const line of lineData) {
+    const record = asRecord(line);
+    sources.push(asMetadata(record?.metadata));
+    const lineParent = asRecord(record?.parent);
+    const lineSubscription = asRecord(lineParent?.subscription_item_details);
+    sources.push(asMetadata(lineSubscription?.metadata));
+  }
+  return sources;
+}
+
+function invoiceQuantity(object: Record<string, unknown>): number | undefined {
+  const lines = asRecord(object.lines);
+  const lineData = Array.isArray(lines?.data) ? lines.data : [];
+  for (const line of lineData) {
+    const quantity = positiveInteger(asRecord(line)?.quantity);
+    if (quantity) return quantity;
+  }
+  return undefined;
+}
+
+function subscriptionQuantity(
+  object: Record<string, unknown>,
+): number | undefined {
+  const items = asRecord(object.items);
+  const itemData = Array.isArray(items?.data) ? items.data : [];
+  for (const item of itemData) {
+    const quantity = positiveInteger(asRecord(item)?.quantity);
+    if (quantity) return quantity;
+  }
+  return undefined;
+}
+
+function firstFromMetadata(
+  sources: Array<Record<string, string>>,
+  ...keys: string[]
+): string | undefined {
+  for (const source of sources) {
+    for (const key of keys) {
+      const value = source[key]?.trim();
+      if (value) return value;
+    }
+  }
+  return undefined;
+}
+
+function eventBillingStatus(status: string | undefined): BillingStatus {
+  switch (status) {
+    case "trialing":
+      return "trialing";
+    case "active":
+      return "active";
+    case "past_due":
+    case "unpaid":
+      return "past_due";
+    case "canceled":
+      return "canceled";
+    default:
+      return "none";
+  }
+}
+
+function parseStripeMode(value: string | undefined): StripeMode | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === "test" || normalized === "live") return normalized;
+  throw new Error("STRIPE_MODE must be test or live");
+}
+
+function stripeKeyMode(key: string): StripeMode | undefined {
+  if (/^(?:sk|rk)_test_/.test(key)) return "test";
+  if (/^(?:sk|rk)_live_/.test(key)) return "live";
+  return undefined;
+}
+
+function setMetadata(
+  body: URLSearchParams,
+  prefix: string,
+  metadata: Record<string, string>,
+): void {
+  for (const [key, value] of Object.entries(metadata)) {
+    body.set(`${prefix}[${key}]`, value);
+  }
+}
+
+function parseSignatureHeader(header: string): {
+  timestamp: number;
+  v1: string[];
+} {
+  let timestamp: number | undefined;
+  const v1: string[] = [];
+  for (const part of header.split(",")) {
+    const [key, value] = part.trim().split("=", 2);
+    if (key === "t" && /^\d+$/.test(value ?? "")) {
+      timestamp = Number(value);
+    } else if (key === "v1" && value) {
+      v1.push(value);
+    }
+  }
+  if (!Number.isSafeInteger(timestamp) || !v1.length) {
+    throw new Error("Invalid Stripe signature");
+  }
+  return { timestamp: timestamp as number, v1 };
+}
+
+function isStripeWebhookEvent(value: unknown): value is StripeWebhookEvent {
+  const record = asRecord(value);
+  const data = asRecord(record?.data);
+  return Boolean(
+    stringValue(record?.id) &&
+      stringValue(record?.type) &&
+      asRecord(data?.object),
+  );
+}
+
+function parseBillingPlan(value: string | undefined): BillingPlan | undefined {
+  return BILLING_PLANS.includes(value as BillingPlan)
+    ? (value as BillingPlan)
+    : undefined;
+}
+
+function normalizeSeatCount(
+  plan: BillingPlan,
+  seatCount: number | undefined,
+): number {
+  const minimum = BILLING_PLAN_LIMITS[plan].minimumSeats;
+  return Number.isFinite(seatCount)
+    ? Math.max(minimum, Math.floor(seatCount ?? minimum))
+    : minimum;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asMetadata(value: unknown): Record<string, string> {
+  const record = asRecord(value);
+  if (!record) return {};
+  return Object.fromEntries(
+    Object.entries(record).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const parsed = stringValue(value);
+    if (parsed) return parsed;
+  }
+  return undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  const parsed =
+    typeof value === "string" && /^\d+$/.test(value)
+      ? Number(value)
+      : typeof value === "number"
+        ? value
+        : NaN;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function expandableId(value: unknown): string | undefined {
+  return stringValue(value) ?? stringValue(asRecord(value)?.id);
+}
+
+function requireOrgId(orgId: string): void {
+  if (!orgId?.trim()) {
+    throw new Error("orgId is required");
+  }
+}
+
+function requirePositiveCents(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive integer`);
+  }
+}
+
+function requireHttpUrl(value: string, field: string): void {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error();
+    }
+  } catch {
+    throw new Error(`${field} must be an HTTP(S) URL`);
+  }
+}

--- a/agentos-platform/src/server/bindings/camel.ts
+++ b/agentos-platform/src/server/bindings/camel.ts
@@ -1,0 +1,101 @@
+import { bindings, type Bindings } from "@rivet-dev/agentos-core";
+import { z } from "zod";
+import type { Platform } from "../platform/index.ts";
+
+export type CamelAskUserPayload = {
+  question: string;
+  options: string[];
+};
+
+export type CreateCamelBindingsContext = {
+  platform: Platform;
+  orgId: string;
+  workspaceId: string;
+  projectId: string;
+  broadcastAskUser?: (
+    payload: CamelAskUserPayload,
+  ) => void | Promise<void>;
+};
+
+export function createCamelBindings(
+  context: CreateCamelBindingsContext,
+): Bindings {
+  const filesystem = context.platform.projectFilesystem(
+    context.workspaceId,
+    context.projectId,
+  );
+
+  return bindings({
+    name: "camel",
+    description: "camelAI workspace, deployment, preview, and billing tools",
+    bindings: {
+      read_file: {
+        description: "Read a UTF-8 file from the current project.",
+        inputSchema: z.object({ path: z.string().min(1) }),
+        execute: ({ path }) => ({ path, content: filesystem.read(path) }),
+      },
+      write_file: {
+        description: "Write a UTF-8 file in the current project.",
+        inputSchema: z.object({
+          path: z.string().min(1),
+          content: z.string(),
+        }),
+        execute: ({ path, content }) => {
+          filesystem.write(path, content);
+          return { path, written: true };
+        },
+      },
+      list_files: {
+        description: "List files and directories in a project directory.",
+        inputSchema: z.object({ path: z.string().optional() }),
+        execute: ({ path }) => ({
+          path: path ?? ".",
+          entries: filesystem.ls(path),
+        }),
+      },
+      ask_user: {
+        description: "Queue a clarifying question for the chat UI.",
+        inputSchema: z.object({
+          question: z.string().min(1),
+          options: z.array(z.string().min(1)),
+        }),
+        execute: async ({ question, options }) => {
+          await context.broadcastAskUser?.({ question, options });
+          return {
+            status: "queued for UI",
+            question,
+            options,
+          };
+        },
+      },
+      deploy_project: {
+        description: "Deploy or dry-run the current project.",
+        inputSchema: z.object({
+          projectId: z.string().min(1).optional(),
+          dryRun: z.boolean().optional(),
+        }),
+        execute: ({ projectId, dryRun }) => {
+          const deployedProjectId = projectId ?? context.projectId;
+          return {
+            projectId: deployedProjectId,
+            dryRun: dryRun ?? false,
+            url: `https://${deployedProjectId}.apps.local`,
+          };
+        },
+      },
+      set_preview: {
+        description: "Select the URL displayed in the project preview.",
+        inputSchema: z.object({ url: z.string().url() }),
+        execute: ({ url }) => ({ previewUrl: url }),
+      },
+      get_credits: {
+        description: "Get the current organization credit balance in cents.",
+        inputSchema: z.object({}),
+        execute: () => ({
+          orgId: context.orgId,
+          creditCents: context.platform.billing.getCreditBalance(context.orgId),
+        }),
+      },
+    },
+  });
+}

--- a/agentos-platform/src/server/chat/acp-mapper.ts
+++ b/agentos-platform/src/server/chat/acp-mapper.ts
@@ -1,0 +1,225 @@
+import type { ChatEvent, TodoStatus, UiPart } from "../../shared/index.ts";
+
+/**
+ * Structural subset of AgentOS' SessionStreamEntry. Keeping this permissive
+ * makes the mapper usable with recorded ACP fixtures across protocol versions.
+ */
+export type SessionStreamEntryLike = Record<string, unknown> & {
+  type?: unknown;
+};
+
+export type AcpMapperOptions = {
+  /** UI message receiving agent deltas for this turn. */
+  messageId: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function textFromContent(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(textFromContent).filter(Boolean).join("\n");
+  }
+  if (!isRecord(value)) {
+    return "";
+  }
+
+  if (typeof value.text === "string") {
+    return value.text;
+  }
+  if (value.type === "content") {
+    return textFromContent(value.content);
+  }
+  if (value.type === "diff") {
+    const oldText = asString(value.oldText) ?? asString(value.old_text);
+    const newText = asString(value.newText) ?? asString(value.new_text);
+    return [oldText, newText].filter(Boolean).join("\n");
+  }
+  return "";
+}
+
+function toolState(
+  status: unknown,
+): "input-available" | "output-available" | "output-error" {
+  if (status === "failed") {
+    return "output-error";
+  }
+  if (status === "completed") {
+    return "output-available";
+  }
+  return "input-available";
+}
+
+function toolCallPart(entry: SessionStreamEntryLike): UiPart | undefined {
+  const toolCallId = asString(entry.toolCallId);
+  if (!toolCallId) {
+    return undefined;
+  }
+
+  return {
+    type: "tool-call",
+    toolCallId,
+    toolName:
+      asString(entry.title) ?? asString(entry.kind) ?? "tool",
+    input: asRecord(entry.rawInput),
+    state: toolState(entry.status),
+  };
+}
+
+function toolResultPart(entry: SessionStreamEntryLike): UiPart | undefined {
+  if (entry.status !== "completed" && entry.status !== "failed") {
+    return undefined;
+  }
+  const toolCallId = asString(entry.toolCallId);
+  if (!toolCallId) {
+    return undefined;
+  }
+
+  const contentText = textFromContent(entry.content);
+  const output =
+    entry.rawOutput !== undefined
+      ? entry.rawOutput
+      : contentText || (entry.status === "failed" ? "Tool failed" : "");
+
+  return {
+    type: "tool-result",
+    toolCallId,
+    toolName: asString(entry.title),
+    output,
+    isError: entry.status === "failed",
+  };
+}
+
+function permissionDecision(entry: SessionStreamEntryLike) {
+  const outcome = isRecord(entry.outcome) ? entry.outcome : {};
+  if (outcome.outcome === "cancelled") {
+    return "deny" as const;
+  }
+  const optionId = asString(outcome.optionId)?.toLowerCase() ?? "";
+  if (optionId.includes("reject") || optionId.includes("deny")) {
+    return "deny" as const;
+  }
+  if (optionId.includes("always")) {
+    return "allow_always" as const;
+  }
+  return "allow" as const;
+}
+
+/**
+ * Convert one flattened AgentOS/ACP session event to browser chat events.
+ * Unknown protocol extensions intentionally produce no output.
+ */
+export function mapAcpSessionEntry(
+  entry: SessionStreamEntryLike,
+  options: AcpMapperOptions,
+): ChatEvent[] {
+  const type = asString(entry.type);
+  switch (type) {
+    case "agent_message_chunk": {
+      const text = textFromContent(entry.content);
+      return text
+        ? [{ type: "messageDelta", messageId: options.messageId, textDelta: text }]
+        : [];
+    }
+    case "agent_thought_chunk": {
+      const text = textFromContent(entry.content);
+      return text
+        ? [
+            {
+              type: "messageDelta",
+              messageId: options.messageId,
+              parts: [{ type: "reasoning", text, state: "streaming" }],
+            },
+          ]
+        : [];
+    }
+    case "tool_call":
+    case "tool_call_update": {
+      const parts = [toolCallPart(entry), toolResultPart(entry)].filter(
+        (part): part is UiPart => part !== undefined,
+      );
+      return parts.length
+        ? [{ type: "messageDelta", messageId: options.messageId, parts }]
+        : [];
+    }
+    case "plan": {
+      if (!Array.isArray(entry.entries)) {
+        return [];
+      }
+      const currentTodos = entry.entries.flatMap((item) => {
+        if (!isRecord(item) || typeof item.content !== "string") {
+          return [];
+        }
+        const status: TodoStatus =
+          item.status === "in_progress" || item.status === "completed"
+            ? item.status
+            : "pending";
+        return [
+          {
+            content: item.content,
+            activeForm: asString(item.activeForm) ?? item.content,
+            status,
+          },
+        ];
+      });
+      return [{ type: "state", state: { currentTodos } }];
+    }
+    case "permission_request": {
+      const requestId = asString(entry.requestId);
+      const toolCall = asRecord(entry.toolCall);
+      const toolCallId = asString(toolCall.toolCallId);
+      if (!requestId || !toolCallId) {
+        return [];
+      }
+      return [
+        {
+          type: "permissionRequest",
+          requestId,
+          toolCallId,
+          toolName:
+            asString(toolCall.title) ?? asString(toolCall.kind) ?? "tool",
+          input: asRecord(toolCall.rawInput),
+          description: asString(toolCall.title),
+        },
+      ];
+    }
+    case "permission_response": {
+      const requestId = asString(entry.requestId);
+      if (!requestId) {
+        return [];
+      }
+      return [
+        {
+          type: "permissionResolved",
+          requestId,
+          decision: permissionDecision(entry),
+        },
+      ];
+    }
+    case "session_info_update": {
+      const title = asString(entry.title);
+      return title ? [{ type: "state", state: { title } }] : [];
+    }
+    default:
+      return [];
+  }
+}
+
+export function mapAcpSessionEntries(
+  entries: readonly SessionStreamEntryLike[],
+  options: AcpMapperOptions,
+): ChatEvent[] {
+  return entries.flatMap((entry) => mapAcpSessionEntry(entry, options));
+}

--- a/agentos-platform/src/server/chat/credits-gate.ts
+++ b/agentos-platform/src/server/chat/credits-gate.ts
@@ -1,0 +1,99 @@
+import type { BillingService } from "../platform/billing.ts";
+import type { UsageService } from "../platform/usage.ts";
+
+export type HostedBillingService = Pick<
+  BillingService,
+  "canUseHostedModel"
+> &
+  Partial<Pick<BillingService, "consumeCredits">>;
+
+export class CreditDeniedError extends Error {
+  readonly code = "credits_denied";
+  readonly status = 402;
+
+  constructor(
+    readonly orgId: string,
+    readonly estimatedCents: number,
+  ) {
+    super(
+      `Insufficient credits to start a hosted model turn for org ${orgId}`,
+    );
+    this.name = "CreditDeniedError";
+  }
+}
+
+export function assertCanStartHostedTurn(opts: {
+  billing: HostedBillingService;
+  orgId: string;
+  bypass?: boolean;
+  estimatedCents?: number;
+}): void {
+  if (opts.bypass) {
+    return;
+  }
+  if (!opts.orgId?.trim()) {
+    throw new Error("assertCanStartHostedTurn: orgId is required");
+  }
+  const estimatedCents = opts.estimatedCents ?? 1;
+  if (
+    !Number.isInteger(estimatedCents) ||
+    !Number.isFinite(estimatedCents) ||
+    estimatedCents <= 0
+  ) {
+    throw new Error(
+      "assertCanStartHostedTurn: estimatedCents must be a positive integer",
+    );
+  }
+  if (!opts.billing.canUseHostedModel(opts.orgId)) {
+    throw new CreditDeniedError(opts.orgId, estimatedCents);
+  }
+}
+
+export type ChargeTurnContext = {
+  orgId: string;
+  workspaceId: string;
+  threadId: string;
+  userId?: string;
+  /** BYOK turns are metered but do not consume camelAI credits. */
+  bypass?: boolean;
+};
+
+export function chargeTurn(
+  billing: HostedBillingService,
+  usage: UsageService,
+  ctx: ChargeTurnContext,
+  charge: {
+    cents: number;
+    durationMs?: number;
+    model?: string;
+  },
+): void {
+  if (
+    !Number.isInteger(charge.cents) ||
+    !Number.isFinite(charge.cents) ||
+    charge.cents < 0
+  ) {
+    throw new Error("chargeTurn: cents must be a non-negative integer");
+  }
+
+  const creditChargeable = !ctx.bypass;
+  if (creditChargeable && charge.cents > 0) {
+    billing.consumeCredits?.(ctx.orgId, charge.cents);
+  }
+
+  usage.recordUsage({
+    id: crypto.randomUUID(),
+    orgId: ctx.orgId,
+    workspaceId: ctx.workspaceId,
+    threadId: ctx.threadId,
+    ...(ctx.userId ? { userId: ctx.userId } : {}),
+    kind: "turn",
+    ...(charge.model ? { model: charge.model } : {}),
+    cents: charge.cents,
+    creditChargeable,
+    ...(charge.durationMs === undefined
+      ? {}
+      : { durationMs: charge.durationMs }),
+    createdAt: new Date().toISOString(),
+  });
+}

--- a/agentos-platform/src/server/chat/runtime.ts
+++ b/agentos-platform/src/server/chat/runtime.ts
@@ -1,0 +1,139 @@
+export type AgentRuntimeEvent =
+  | { type: "text_delta"; text: string }
+  | { type: "thinking_delta"; text: string }
+  | {
+      type: "tool_call";
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+    }
+  | { type: "tool_result"; id: string; content: string; isError?: boolean }
+  | { type: "tool_stream"; id: string; text: string }
+  | {
+      type: "ask_user";
+      questionId: string;
+      questions: Array<{
+        question: string;
+        options: Array<{ label: string; description?: string }>;
+      }>;
+    }
+  | { type: "done" }
+  | { type: "error"; error: string };
+
+export interface AgentRuntime {
+  prompt(input: {
+    content: string;
+    signal?: AbortSignal;
+    onEvent: (event: AgentRuntimeEvent) => void | Promise<void>;
+  }): Promise<void>;
+  cancel(): Promise<void>;
+}
+
+export type AgentRuntimePrompt = AgentRuntime["prompt"];
+
+function throwIfCancelled(cancelled: boolean, signal?: AbortSignal): void {
+  if (cancelled || signal?.aborted) {
+    throw new DOMException("Agent turn was cancelled", "AbortError");
+  }
+}
+
+/**
+ * Small deterministic runtime used by unit tests and local development.
+ */
+export class MockAgentRuntime implements AgentRuntime {
+  private cancelled = false;
+
+  async prompt({
+    content,
+    signal,
+    onEvent,
+  }: Parameters<AgentRuntime["prompt"]>[0]): Promise<void> {
+    this.cancelled = false;
+    throwIfCancelled(this.cancelled, signal);
+
+    if (content.toLowerCase().includes("tool")) {
+      await onEvent({
+        type: "tool_call",
+        id: "mock-tool-1",
+        name: "read",
+        input: { path: "README.md" },
+      });
+      throwIfCancelled(this.cancelled, signal);
+      await onEvent({
+        type: "tool_result",
+        id: "mock-tool-1",
+        content: "Mock file contents",
+      });
+    }
+
+    const askIndex = content.toLowerCase().indexOf("ask:");
+    if (askIndex !== -1) {
+      const question =
+        content.slice(askIndex + "ask:".length).trim() || "What should I do next?";
+      await onEvent({
+        type: "ask_user",
+        questionId: "mock-question-1",
+        questions: [
+          {
+            question,
+            options: [
+              { label: "Continue" },
+              { label: "Cancel", description: "Stop this task" },
+            ],
+          },
+        ],
+      });
+    }
+
+    throwIfCancelled(this.cancelled, signal);
+    const normalized = content.trim().replace(/\s+/g, " ").slice(0, 80);
+    await onEvent({
+      type: "text_delta",
+      text: normalized ? `Mock reply: ${normalized}` : "Mock reply.",
+    });
+    throwIfCancelled(this.cancelled, signal);
+    await onEvent({ type: "done" });
+  }
+
+  async cancel(): Promise<void> {
+    this.cancelled = true;
+  }
+}
+
+export type AgentOsRuntimeOptions = {
+  promptFn?: AgentRuntimePrompt;
+  cancelFn?: () => void | Promise<void>;
+};
+
+/**
+ * Injection seam for the live actor-owned agentOS session.
+ */
+export class AgentOsRuntime implements AgentRuntime {
+  constructor(private readonly options: AgentOsRuntimeOptions = {}) {}
+
+  async prompt(input: Parameters<AgentRuntime["prompt"]>[0]): Promise<void> {
+    if (!this.options.promptFn) {
+      throw new Error(
+        "AgentOsRuntime requires chatThread actor with live agentOS session — use mock in unit tests",
+      );
+    }
+    await this.options.promptFn(input);
+  }
+
+  async cancel(): Promise<void> {
+    await this.options.cancelFn?.();
+  }
+}
+
+export type CreateAgentRuntimeOptions =
+  | { mode: "mock" }
+  | ({ mode: "agentos" } & AgentOsRuntimeOptions);
+
+export function createAgentRuntime(
+  options: CreateAgentRuntimeOptions,
+): AgentRuntime {
+  if (options.mode === "mock") {
+    return new MockAgentRuntime();
+  }
+  return new AgentOsRuntime(options);
+}

--- a/agentos-platform/src/server/chat/runtime.ts
+++ b/agentos-platform/src/server/chat/runtime.ts
@@ -37,11 +37,57 @@ function throwIfCancelled(cancelled: boolean, signal?: AbortSignal): void {
   }
 }
 
+export type MockAgentRuntimeOptions = {
+  delayMs?: number;
+};
+
+function normalizeDelayMs(delayMs: number | undefined): number {
+  if (delayMs === undefined) {
+    return 0;
+  }
+  if (!Number.isFinite(delayMs) || delayMs < 0) {
+    throw new Error("MockAgentRuntime delayMs must be a non-negative number");
+  }
+  return delayMs;
+}
+
 /**
  * Small deterministic runtime used by unit tests and local development.
  */
 export class MockAgentRuntime implements AgentRuntime {
   private cancelled = false;
+  private cancelDelay: (() => void) | null = null;
+
+  constructor(private readonly options: MockAgentRuntimeOptions = {}) {
+    normalizeDelayMs(options.delayMs);
+  }
+
+  private async waitForDelay(signal?: AbortSignal): Promise<void> {
+    const delayMs = normalizeDelayMs(this.options.delayMs);
+    if (delayMs === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const abort = () => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", abort);
+        this.cancelDelay = null;
+        reject(new DOMException("Agent turn was cancelled", "AbortError"));
+      };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener("abort", abort);
+        this.cancelDelay = null;
+        resolve();
+      }, delayMs);
+
+      this.cancelDelay = abort;
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted) {
+        abort();
+      }
+    });
+  }
 
   async prompt({
     content,
@@ -49,6 +95,8 @@ export class MockAgentRuntime implements AgentRuntime {
     onEvent,
   }: Parameters<AgentRuntime["prompt"]>[0]): Promise<void> {
     this.cancelled = false;
+    throwIfCancelled(this.cancelled, signal);
+    await this.waitForDelay(signal);
     throwIfCancelled(this.cancelled, signal);
 
     if (content.toLowerCase().includes("tool")) {
@@ -97,6 +145,7 @@ export class MockAgentRuntime implements AgentRuntime {
 
   async cancel(): Promise<void> {
     this.cancelled = true;
+    this.cancelDelay?.();
   }
 }
 
@@ -126,14 +175,20 @@ export class AgentOsRuntime implements AgentRuntime {
 }
 
 export type CreateAgentRuntimeOptions =
-  | { mode: "mock" }
+  | ({ mode: "mock" } & MockAgentRuntimeOptions)
   | ({ mode: "agentos" } & AgentOsRuntimeOptions);
 
 export function createAgentRuntime(
   options: CreateAgentRuntimeOptions,
 ): AgentRuntime {
   if (options.mode === "mock") {
-    return new MockAgentRuntime();
+    const envDelay = process.env.MOCK_AGENT_DELAY_MS;
+    const delayMs =
+      options.delayMs ??
+      (envDelay === undefined || envDelay.trim() === ""
+        ? undefined
+        : Number(envDelay));
+    return new MockAgentRuntime({ delayMs });
   }
   return new AgentOsRuntime(options);
 }

--- a/agentos-platform/src/server/chat/turn.ts
+++ b/agentos-platform/src/server/chat/turn.ts
@@ -1,0 +1,277 @@
+import type {
+  ChatEvent,
+  ThreadState,
+  TurnStatus,
+  UiMessage,
+  UiPart,
+} from "../../shared/index.ts";
+import type { AgentRuntime, AgentRuntimeEvent } from "./runtime.ts";
+
+export type SendResult =
+  | { status: "completed"; messageId: string }
+  | { status: "duplicate"; messageId: string }
+  | { status: "busy" }
+  | { status: "stopped"; messageId: string }
+  | { status: "error"; messageId: string; error: string };
+
+export type RunChatTurnInput = {
+  messages: UiMessage[];
+  broadcast: (event: ChatEvent) => void | Promise<void>;
+  updateState: (patch: Partial<ThreadState>) => void | Promise<void>;
+  runtime: AgentRuntime;
+  content: string;
+  clientMessageId: string;
+  /** Current status, read before accepting the turn. Defaults to idle. */
+  turnStatus?: TurnStatus | (() => TurnStatus);
+  updateTurnStatus?: (status: TurnStatus) => void | Promise<void>;
+  signal?: AbortSignal;
+  keepAwake?: <T>(promise: Promise<T>) => Promise<T>;
+};
+
+function snapshot(message: UiMessage): UiMessage {
+  return structuredClone(message);
+}
+
+function currentStatus(
+  status: RunChatTurnInput["turnStatus"],
+): TurnStatus {
+  return typeof status === "function" ? status() : (status ?? "idle");
+}
+
+export async function runChatTurn({
+  messages,
+  broadcast,
+  updateState,
+  runtime,
+  content,
+  clientMessageId,
+  turnStatus,
+  updateTurnStatus = async () => {},
+  signal,
+  keepAwake,
+}: RunChatTurnInput): Promise<SendResult> {
+  const duplicate = messages.find((message) => message.id === clientMessageId);
+  if (duplicate) {
+    return { status: "duplicate", messageId: duplicate.id };
+  }
+  if (currentStatus(turnStatus) === "streaming") {
+    return { status: "busy" };
+  }
+
+  const now = Date.now();
+  const userMessage: UiMessage = {
+    id: clientMessageId,
+    role: "user",
+    parts: [{ type: "text", text: content, state: "done" }],
+    createdAt: now,
+  };
+  const assistantMessage: UiMessage = {
+    id: `assistant:${clientMessageId}`,
+    role: "assistant",
+    parts: [],
+    createdAt: now,
+  };
+
+  messages.push(userMessage, assistantMessage);
+  await broadcast({ type: "messageUpsert", message: snapshot(userMessage) });
+  await broadcast({ type: "messageUpsert", message: snapshot(assistantMessage) });
+  await setTurnStatus("streaming");
+
+  let terminalError: string | undefined;
+  const toolStreamSeq = new Map<string, number>();
+
+  const emitAssistantChange = async (
+    parts?: UiPart[],
+    textDelta?: string,
+  ): Promise<void> => {
+    await broadcast({
+      type: "messageDelta",
+      messageId: assistantMessage.id,
+      ...(parts ? { parts: structuredClone(parts) } : {}),
+      ...(textDelta !== undefined ? { textDelta } : {}),
+    });
+    await broadcast({
+      type: "messageUpsert",
+      message: snapshot(assistantMessage),
+    });
+  };
+
+  const onEvent = async (event: AgentRuntimeEvent): Promise<void> => {
+    switch (event.type) {
+      case "text_delta": {
+        const previous = assistantMessage.parts.at(-1);
+        if (previous?.type === "text" && previous.state === "streaming") {
+          previous.text += event.text;
+        } else {
+          assistantMessage.parts.push({
+            type: "text",
+            text: event.text,
+            state: "streaming",
+          });
+        }
+        await emitAssistantChange(undefined, event.text);
+        break;
+      }
+      case "thinking_delta": {
+        const previous = assistantMessage.parts.at(-1);
+        if (previous?.type === "reasoning" && previous.state === "streaming") {
+          previous.text += event.text;
+        } else {
+          assistantMessage.parts.push({
+            type: "reasoning",
+            text: event.text,
+            state: "streaming",
+          });
+        }
+        await emitAssistantChange([
+          {
+            type: "reasoning",
+            text: event.text,
+            state: "streaming",
+          },
+        ]);
+        break;
+      }
+      case "tool_call": {
+        const part: UiPart = {
+          type: "tool-call",
+          toolCallId: event.id,
+          toolName: event.name,
+          input: event.input,
+          state: "input-available",
+        };
+        assistantMessage.parts.push(part);
+        await emitAssistantChange([part]);
+        break;
+      }
+      case "tool_result": {
+        const call = assistantMessage.parts.find(
+          (part) =>
+            part.type === "tool-call" && part.toolCallId === event.id,
+        );
+        if (call?.type === "tool-call") {
+          call.state = event.isError ? "output-error" : "output-available";
+        }
+        const part: UiPart = {
+          type: "tool-result",
+          toolCallId: event.id,
+          toolName: call?.type === "tool-call" ? call.toolName : undefined,
+          output: event.content,
+          isError: event.isError,
+        };
+        assistantMessage.parts.push(part);
+        await emitAssistantChange([part]);
+        break;
+      }
+      case "tool_stream": {
+        const seq = (toolStreamSeq.get(event.id) ?? 0) + 1;
+        toolStreamSeq.set(event.id, seq);
+        const part: UiPart = {
+          type: "data-tool-stream",
+          data: { toolCallId: event.id, text: event.text, seq },
+        };
+        assistantMessage.parts.push(part);
+        await broadcast({
+          type: "toolStream",
+          toolCallId: event.id,
+          text: event.text,
+          seq,
+        });
+        await emitAssistantChange([part]);
+        break;
+      }
+      case "ask_user": {
+        const pendingQuestion = {
+          questionId: event.questionId,
+          questions: event.questions.map((question) => ({
+            ...question,
+            header: "Question",
+            allowOther: true,
+          })),
+        };
+        await updateState({ pendingQuestion });
+        await broadcast({
+          type: "state",
+          state: { pendingQuestion },
+        });
+        break;
+      }
+      case "done": {
+        for (const part of assistantMessage.parts) {
+          if (part.type === "text" || part.type === "reasoning") {
+            part.state = "done";
+          }
+        }
+        if (!terminalError) {
+          await setTurnStatus("idle");
+        }
+        await broadcast({
+          type: "messageUpsert",
+          message: snapshot(assistantMessage),
+        });
+        break;
+      }
+      case "error": {
+        terminalError = event.error;
+        const errorPart: UiPart = {
+          type: "data-error",
+          id: `error:${clientMessageId}`,
+          data: { error: event.error },
+        };
+        assistantMessage.parts.push(errorPart);
+        const lastError = {
+          id: `error:${clientMessageId}`,
+          error: event.error,
+        };
+        await updateState({ lastError });
+        await broadcast({ type: "state", state: { lastError } });
+        await emitAssistantChange([errorPart]);
+        await setTurnStatus("error", event.error);
+        break;
+      }
+    }
+  };
+
+  function setTurnStatus(
+    status: TurnStatus,
+    errorMessage?: string,
+  ): Promise<void> {
+    return Promise.resolve(updateTurnStatus(status)).then(() =>
+      Promise.resolve(
+        broadcast({
+          type: "turnStatus",
+          status,
+          ...(errorMessage ? { errorMessage } : {}),
+        }),
+      ),
+    );
+  }
+
+  try {
+    const prompt = runtime.prompt({ content, signal, onEvent });
+    await (keepAwake ? keepAwake(prompt) : prompt);
+    if (terminalError) {
+      return {
+        status: "error",
+        messageId: assistantMessage.id,
+        error: terminalError,
+      };
+    }
+    if (currentStatus(turnStatus) === "streaming") {
+      await setTurnStatus("idle");
+    }
+    return { status: "completed", messageId: assistantMessage.id };
+  } catch (error) {
+    if (signal?.aborted || (error instanceof DOMException && error.name === "AbortError")) {
+      await setTurnStatus("idle");
+      return { status: "stopped", messageId: assistantMessage.id };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    await onEvent({ type: "error", error: message });
+    return {
+      status: "error",
+      messageId: assistantMessage.id,
+      error: message,
+    };
+  }
+}

--- a/agentos-platform/src/server/http/api.ts
+++ b/agentos-platform/src/server/http/api.ts
@@ -1,0 +1,352 @@
+import { randomBytes } from "node:crypto";
+import {
+  createOAuthClient,
+  type OAuthProviderName,
+} from "../auth/oauth.ts";
+import { AuthService } from "../auth/service.ts";
+import {
+  parseSessionCookie,
+  serializeSessionCookie,
+  SessionService,
+} from "../auth/session.ts";
+import type { StripeBillingClient } from "../billing/stripe.ts";
+import type { BillingService } from "../platform/billing.ts";
+import type { Platform } from "../platform/index.ts";
+import {
+  createBillingRoutes,
+  type BillingRouteOptions,
+} from "./billing-routes.ts";
+
+export interface ApiOptions {
+  billingService: BillingService;
+  stripeClient?: StripeBillingClient;
+  authorizeBilling?: BillingRouteOptions["authorize"];
+  allowTestOrgHeader?: boolean;
+  platform?: Platform;
+  authService?: AuthService;
+  sessionService?: SessionService;
+}
+
+/**
+ * Composable API fetch handler. The Rivet HTTP host (or a standalone Bun
+ * listener) can mount this before its actor routes.
+ */
+export function createApiHandler(options: ApiOptions) {
+  const sessions = options.platform
+    ? (options.sessionService ?? new SessionService(options.platform.store))
+    : undefined;
+  const auth =
+    options.platform && sessions
+      ? (options.authService ??
+        new AuthService(options.platform.identity, sessions))
+      : undefined;
+  const billingRoutes = createBillingRoutes({
+    billingService: options.billingService,
+    ...(options.stripeClient ? { stripeClient: options.stripeClient } : {}),
+    ...(options.authorizeBilling || auth
+      ? {
+          authorize:
+            options.authorizeBilling ??
+            ((request, orgId) => {
+              try {
+                return (
+                  auth?.requireSession(request.headers.get("cookie")).session
+                    .orgId === orgId
+                );
+              } catch {
+                return undefined;
+              }
+            }),
+        }
+      : {}),
+    ...(options.allowTestOrgHeader === undefined
+      ? {}
+      : { allowTestOrgHeader: options.allowTestOrgHeader }),
+  });
+  const authRoutes = options.platform
+    ? createAuthHttpHandler({
+        platform: options.platform,
+        ...(options.authService ? { authService: options.authService } : {}),
+        ...(sessions ? { sessionService: sessions } : {}),
+      })
+    : undefined;
+
+  return async function apiHandler(request: Request): Promise<Response> {
+    const billingResponse = await billingRoutes(request);
+    if (billingResponse) return billingResponse;
+    if (authRoutes) return authRoutes(request);
+    return new Response(JSON.stringify({ error: "Not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+const OAUTH_STATE_COOKIE = "camelai_oauth_state";
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+type OAuthStateRecord = {
+  provider: OAuthProviderName;
+  redirectUri: string;
+  expiresAt: string;
+};
+
+export type AuthHttpApiOptions = {
+  platform: Platform;
+  authService?: AuthService;
+  sessionService?: SessionService;
+  port?: number;
+};
+
+function json(data: unknown, status = 200, headers?: HeadersInit): Response {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("Content-Type", "application/json; charset=utf-8");
+  return new Response(JSON.stringify(data), { status, headers: responseHeaders });
+}
+
+async function readJson(request: Request): Promise<Record<string, unknown>> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    throw new Error("Content-Type must be application/json");
+  }
+  const body: unknown = await request.json();
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("JSON request body must be an object");
+  }
+  return body as Record<string, unknown>;
+}
+
+function requiredString(
+  body: Record<string, unknown>,
+  field: string,
+): string {
+  const value = body[field];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
+function oauthProvider(pathname: string, suffix: "start" | "callback"):
+  | OAuthProviderName
+  | null {
+  const match = pathname.match(
+    new RegExp(`^/api/auth/oauth/(github|google)/${suffix}$`),
+  );
+  return (match?.[1] as OAuthProviderName | undefined) ?? null;
+}
+
+function publicUrl(request: Request): URL {
+  const configured = process.env.AUTH_PUBLIC_URL?.trim();
+  return new URL(configured || request.url);
+}
+
+function oauthRedirectUri(
+  request: Request,
+  provider: OAuthProviderName,
+): string {
+  return new URL(
+    `/api/auth/oauth/${provider}/callback`,
+    publicUrl(request),
+  ).toString();
+}
+
+function oauthStateCookie(state: string, maxAge = 600): string {
+  const secure =
+    process.env.SESSION_COOKIE_SECURE === "true" ||
+    process.env.SESSION_COOKIE_SECURE === "1" ||
+    process.env.NODE_ENV === "production";
+  return [
+    `${OAUTH_STATE_COOKIE}=${encodeURIComponent(state)}`,
+    "HttpOnly",
+    "SameSite=Lax",
+    "Path=/api/auth/oauth",
+    `Max-Age=${maxAge}`,
+    secure ? "Secure" : "",
+  ]
+    .filter(Boolean)
+    .join("; ");
+}
+
+function cookieValue(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValue] = part.trim().split("=");
+    if (rawName === name) {
+      try {
+        return decodeURIComponent(rawValue.join("=")) || null;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function errorStatus(error: unknown): number {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/Authentication required|Invalid email or password/.test(message)) {
+    return 401;
+  }
+  if (/already exists/.test(message)) {
+    return 409;
+  }
+  if (/OAuth not configured/.test(message)) {
+    return 503;
+  }
+  return 400;
+}
+
+export function createAuthHttpHandler(options: AuthHttpApiOptions) {
+  const sessions =
+    options.sessionService ?? new SessionService(options.platform.store);
+  const auth =
+    options.authService ??
+    new AuthService(options.platform.identity, sessions);
+
+  return async function handleAuthHttpRequest(
+    request: Request,
+  ): Promise<Response> {
+    const url = new URL(request.url);
+
+    try {
+      if (request.method === "GET" && url.pathname === "/health") {
+        return json({ ok: true, service: "camelai-agentos" });
+      }
+
+      if (request.method === "POST" && url.pathname === "/api/auth/register") {
+        const body = await readJson(request);
+        const session = await auth.registerPassword({
+          email: requiredString(body, "email"),
+          password: requiredString(body, "password"),
+          name: requiredString(body, "name"),
+        });
+        const user = options.platform.identity.getUser(session.userId);
+        return json(
+          { session, user },
+          201,
+          { "Set-Cookie": serializeSessionCookie(session.sessionId) },
+        );
+      }
+
+      if (request.method === "POST" && url.pathname === "/api/auth/login") {
+        const body = await readJson(request);
+        const session = await auth.loginPassword({
+          email: requiredString(body, "email"),
+          password: requiredString(body, "password"),
+        });
+        const user = options.platform.identity.getUser(session.userId);
+        return json(
+          { session, user },
+          200,
+          { "Set-Cookie": serializeSessionCookie(session.sessionId) },
+        );
+      }
+
+      if (request.method === "POST" && url.pathname === "/api/auth/logout") {
+        const sessionId = parseSessionCookie(request.headers.get("cookie"));
+        if (sessionId) {
+          sessions.revokeSession(sessionId);
+        }
+        return json(
+          { ok: true },
+          200,
+          {
+            "Set-Cookie": serializeSessionCookie("", { maxAge: 0 }),
+          },
+        );
+      }
+
+      if (request.method === "GET" && url.pathname === "/api/auth/me") {
+        const current = auth.requireSession(request.headers.get("cookie"));
+        return json(current);
+      }
+
+      const startProvider = oauthProvider(url.pathname, "start");
+      if (request.method === "GET" && startProvider) {
+        const state = randomBytes(32).toString("base64url");
+        const redirectUri = oauthRedirectUri(request, startProvider);
+        const stateRecord: OAuthStateRecord = {
+          provider: startProvider,
+          redirectUri,
+          expiresAt: new Date(Date.now() + OAUTH_STATE_TTL_MS).toISOString(),
+        };
+        const client = createOAuthClient(startProvider);
+        const location = client.buildAuthorizeUrl(state, redirectUri);
+        options.platform.store.set(`oauth-state:${state}`, stateRecord);
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: location,
+            "Set-Cookie": oauthStateCookie(state),
+          },
+        });
+      }
+
+      const callbackProvider = oauthProvider(url.pathname, "callback");
+      if (request.method === "GET" && callbackProvider) {
+        const code = url.searchParams.get("code");
+        const returnedState = url.searchParams.get("state");
+        const cookieState = cookieValue(
+          request.headers.get("cookie"),
+          OAUTH_STATE_COOKIE,
+        );
+        if (!code || !returnedState || returnedState !== cookieState) {
+          throw new Error("Invalid OAuth callback state");
+        }
+        const stateKey = `oauth-state:${returnedState}`;
+        const stateRecord =
+          options.platform.store.get<OAuthStateRecord>(stateKey);
+        options.platform.store.delete(stateKey);
+        if (
+          !stateRecord ||
+          stateRecord.provider !== callbackProvider ||
+          Date.parse(stateRecord.expiresAt) <= Date.now()
+        ) {
+          throw new Error("OAuth callback state expired or was not found");
+        }
+
+        const client = createOAuthClient(callbackProvider);
+        const profile = await client.exchangeCodeForProfile(
+          code,
+          stateRecord.redirectUri,
+        );
+        const session = auth.loginFromOAuthProfile(profile);
+        const destination = process.env.AUTH_SUCCESS_REDIRECT?.trim() || "/";
+        const headers = new Headers({
+          Location: new URL(destination, publicUrl(request)).toString(),
+          "Set-Cookie": serializeSessionCookie(session.sessionId),
+        });
+        headers.append("Set-Cookie", oauthStateCookie("", 0));
+        return new Response(null, { status: 302, headers });
+      }
+
+      return json({ error: "Not found" }, 404);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return json({ error: message }, errorStatus(error));
+    }
+  };
+}
+
+function authHttpPort(explicitPort?: number): number {
+  const raw =
+    explicitPort ??
+    Number(process.env.AUTH_HTTP_PORT ?? process.env.PORT_HTTP ?? "6422");
+  if (!Number.isInteger(raw) || raw <= 0 || raw > 65_535) {
+    throw new Error(
+      `Invalid AUTH_HTTP_PORT: ${process.env.AUTH_HTTP_PORT ?? process.env.PORT_HTTP}`,
+    );
+  }
+  return raw;
+}
+
+export function startAuthHttpServer(options: AuthHttpApiOptions) {
+  const port = authHttpPort(options.port);
+  const fetch = createAuthHttpHandler(options);
+  const server = Bun.serve({ port, fetch });
+  console.log(`camelAI auth HTTP API ready at http://127.0.0.1:${server.port}`);
+  return server;
+}

--- a/agentos-platform/src/server/http/billing-routes.ts
+++ b/agentos-platform/src/server/http/billing-routes.ts
@@ -1,0 +1,237 @@
+import {
+  BILLING_PLANS,
+  type BillingPlan,
+} from "../../shared/billing-plans.ts";
+import { verifyTicket } from "../auth/tickets.ts";
+import {
+  StripeBillingClient,
+  handleWebhookEvent,
+} from "../billing/stripe.ts";
+import type { BillingService } from "../platform/billing.ts";
+
+export interface BillingRouteOptions {
+  billingService: BillingService;
+  stripeClient?: StripeBillingClient;
+  authorize?: (
+    request: Request,
+    orgId: string,
+  ) => boolean | undefined | Promise<boolean | undefined>;
+  allowTestOrgHeader?: boolean;
+}
+
+type CheckoutBody = {
+  orgId?: unknown;
+  plan?: unknown;
+  amountCents?: unknown;
+  successUrl?: unknown;
+  cancelUrl?: unknown;
+  seatCount?: unknown;
+};
+
+export function createBillingRoutes(options: BillingRouteOptions) {
+  const stripeClient = options.stripeClient ?? new StripeBillingClient();
+
+  return async function handleBillingRoute(
+    request: Request,
+  ): Promise<Response | null> {
+    const url = new URL(request.url);
+
+    try {
+      if (url.pathname === "/api/billing/stripe/webhook") {
+        if (request.method !== "POST") return methodNotAllowed(["POST"]);
+        const rawBody = await request.text();
+        const event = stripeClient.constructEvent(
+          rawBody,
+          request.headers.get("stripe-signature"),
+        );
+        handleWebhookEvent(event, options.billingService);
+        return json({ received: true });
+      }
+
+      if (url.pathname === "/api/billing/account") {
+        if (request.method !== "GET") return methodNotAllowed(["GET"]);
+        const orgId = url.searchParams.get("orgId")?.trim() ?? "";
+        requireOrgId(orgId);
+        await requireAuthorization(request, orgId, options);
+        const account = options.billingService.getAccount(orgId);
+        return json({
+          ...account,
+          creditBalanceCents: options.billingService.getCreditBalance(orgId),
+        });
+      }
+
+      if (url.pathname === "/api/billing/checkout/subscription") {
+        if (request.method !== "POST") return methodNotAllowed(["POST"]);
+        const body = await readCheckoutBody(request);
+        const orgId = requireString(body.orgId, "orgId");
+        await requireAuthorization(request, orgId, options);
+        const plan = requireBillingPlan(body.plan);
+        const account = options.billingService.getAccount(orgId);
+        const session =
+          await stripeClient.createCheckoutSessionForSubscription({
+            orgId,
+            plan,
+            successUrl: requireString(body.successUrl, "successUrl"),
+            cancelUrl: requireString(body.cancelUrl, "cancelUrl"),
+            ...(account.stripeCustomerId
+              ? { customerId: account.stripeCustomerId }
+              : {}),
+            ...(body.seatCount === undefined
+              ? {}
+              : { seatCount: requirePositiveInteger(body.seatCount, "seatCount") }),
+          });
+        return json({ id: session.id, url: session.url }, 201);
+      }
+
+      if (url.pathname === "/api/billing/checkout/credits") {
+        if (request.method !== "POST") return methodNotAllowed(["POST"]);
+        const body = await readCheckoutBody(request);
+        const orgId = requireString(body.orgId, "orgId");
+        await requireAuthorization(request, orgId, options);
+        const account = options.billingService.getAccount(orgId);
+        const session = await stripeClient.createCheckoutSessionForCredits({
+          orgId,
+          amountCents: requirePositiveInteger(body.amountCents, "amountCents"),
+          successUrl: requireString(body.successUrl, "successUrl"),
+          cancelUrl: requireString(body.cancelUrl, "cancelUrl"),
+          ...(account.stripeCustomerId
+            ? { customerId: account.stripeCustomerId }
+            : {}),
+        });
+        return json({ id: session.id, url: session.url }, 201);
+      }
+
+      return null;
+    } catch (error) {
+      return routeErrorResponse(error);
+    }
+  };
+}
+
+async function requireAuthorization(
+  request: Request,
+  orgId: string,
+  options: BillingRouteOptions,
+): Promise<void> {
+  if (options.authorize) {
+    const authorized = await options.authorize(request, orgId);
+    if (authorized === true) return;
+    if (authorized === false) throw new BillingRouteError(403, "Forbidden");
+  }
+
+  const authorization = request.headers.get("authorization");
+  const bearer = authorization?.match(/^Bearer\s+(.+)$/i)?.[1];
+  const ticket = bearer ?? request.headers.get("x-auth-ticket");
+  if (ticket) {
+    const payload = verifyTicket(ticket);
+    if (!payload) throw new BillingRouteError(401, "Unauthorized");
+    if (payload.orgId !== orgId) throw new BillingRouteError(403, "Forbidden");
+    return;
+  }
+
+  const allowTestHeader =
+    options.allowTestOrgHeader ?? process.env.NODE_ENV === "test";
+  if (
+    allowTestHeader &&
+    request.headers.get("x-org-id")?.trim() === orgId
+  ) {
+    return;
+  }
+  throw new BillingRouteError(401, "Unauthorized");
+}
+
+async function readCheckoutBody(request: Request): Promise<CheckoutBody> {
+  let value: unknown;
+  try {
+    value = await request.json();
+  } catch {
+    throw new BillingRouteError(400, "Invalid JSON body");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new BillingRouteError(400, "JSON body must be an object");
+  }
+  return value as CheckoutBody;
+}
+
+function requireBillingPlan(value: unknown): BillingPlan {
+  if (
+    typeof value !== "string" ||
+    !BILLING_PLANS.includes(value as BillingPlan)
+  ) {
+    throw new BillingRouteError(400, "plan is invalid");
+  }
+  return value as BillingPlan;
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new BillingRouteError(400, `${field} is required`);
+  }
+  return value.trim();
+}
+
+function requireOrgId(value: string): void {
+  if (!value) {
+    throw new BillingRouteError(400, "orgId is required");
+  }
+}
+
+function requirePositiveInteger(value: unknown, field: string): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value <= 0
+  ) {
+    throw new BillingRouteError(400, `${field} must be a positive integer`);
+  }
+  return value;
+}
+
+function routeErrorResponse(error: unknown): Response {
+  if (error instanceof BillingRouteError) {
+    return json({ error: error.message }, error.status);
+  }
+  const message = error instanceof Error ? error.message : "Billing request failed";
+  if (
+    message === "Stripe not configured" ||
+    message === "Stripe webhook not configured"
+  ) {
+    return json({ error: message }, 503);
+  }
+  if (
+    message.startsWith("Invalid Stripe signature") ||
+    message.startsWith("Invalid Stripe webhook")
+  ) {
+    return json({ error: message }, 400);
+  }
+  if (message.startsWith("Stripe request failed")) {
+    return json({ error: message }, 502);
+  }
+  return json({ error: message }, 400);
+}
+
+function methodNotAllowed(methods: string[]): Response {
+  return new Response(JSON.stringify({ error: "Method not allowed" }), {
+    status: 405,
+    headers: {
+      "Content-Type": "application/json",
+      Allow: methods.join(", "),
+    },
+  });
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+class BillingRouteError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}

--- a/agentos-platform/src/server/http/metrics.ts
+++ b/agentos-platform/src/server/http/metrics.ts
@@ -1,0 +1,68 @@
+import {
+  getObservabilitySnapshot,
+  recordEvent,
+} from "../observability.ts";
+
+export const SERVER_VERSION = "0.1.0";
+
+export function handlePlatformHttpRequest(request: Request): Response {
+  const url = new URL(request.url);
+  const status =
+    request.method === "GET" &&
+    (url.pathname === "/health" || url.pathname === "/api/metrics")
+      ? 200
+      : 404;
+
+  recordHttpRequest(request, status);
+
+  if (request.method === "GET" && url.pathname === "/health") {
+    return json({ ok: true, version: SERVER_VERSION });
+  }
+  if (request.method === "GET" && url.pathname === "/api/metrics") {
+    return json(getObservabilitySnapshot());
+  }
+  return json({ error: "Not found" }, { status: 404 });
+}
+
+export function startPlatformHttpServer(
+  port = Number(process.env.PORT_HTTP ?? "6422"),
+  fallback?: (request: Request) => Response | Promise<Response>,
+): Bun.Server<undefined> {
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`Invalid PORT_HTTP: ${process.env.PORT_HTTP ?? port}`);
+  }
+  return Bun.serve({
+    port,
+    fetch: fallback
+      ? async (request) => {
+          const url = new URL(request.url);
+          if (
+            request.method === "GET" &&
+            (url.pathname === "/health" || url.pathname === "/api/metrics")
+          ) {
+            return handlePlatformHttpRequest(request);
+          }
+          const response = await fallback(request);
+          recordHttpRequest(request, response.status);
+          return response;
+        }
+      : handlePlatformHttpRequest,
+  });
+}
+
+function recordHttpRequest(request: Request, status: number): void {
+  const url = new URL(request.url);
+  recordEvent({
+    event: "http_requests",
+    component: "http",
+    operation: `${request.method} ${url.pathname}`,
+    status: String(status),
+    meta: { method: request.method, path: url.pathname, statusCode: status },
+  });
+}
+
+function json(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("content-type", "application/json; charset=utf-8");
+  return new Response(JSON.stringify(body), { ...init, headers });
+}

--- a/agentos-platform/src/server/index.ts
+++ b/agentos-platform/src/server/index.ts
@@ -1,0 +1,20 @@
+import { createPlatform } from "./platform/index.ts";
+import { registry } from "./registry.ts";
+
+export const platform = createPlatform({ ensureDemoTenant: true });
+
+const demo = platform.identity.ensureDemoTenant();
+const port = Number(process.env.PORT ?? "6420");
+
+if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+  throw new Error(`Invalid PORT: ${process.env.PORT}`);
+}
+
+console.log("camelAI agentOS demo tenant", {
+  orgId: demo.org.id,
+  workspaceId: demo.workspace.id,
+  userId: demo.user.id,
+});
+console.log(`camelAI agentOS server listening at http://localhost:${port}`);
+
+await registry.listen({ port });

--- a/agentos-platform/src/server/index.ts
+++ b/agentos-platform/src/server/index.ts
@@ -1,9 +1,7 @@
 import { createPlatform } from "./platform/index.ts";
 import { registry } from "./registry.ts";
-import { setChatThreadAgentOsPlatform } from "./actors/chat-thread-agentos.ts";
 
 export const platform = createPlatform({ ensureDemoTenant: true });
-setChatThreadAgentOsPlatform(platform);
 
 const demo = platform.identity.ensureDemoTenant();
 const port = Number(process.env.PORT ?? "6420");
@@ -17,6 +15,12 @@ console.log("camelAI agentOS demo tenant", {
   workspaceId: demo.workspace.id,
   userId: demo.user.id,
 });
-console.log(`camelAI agentOS server listening at http://localhost:${port}`);
 
-await registry.listen({ port });
+// Rivetkit embedded mode: start() boots the local engine (default :6420) and
+// serves actor RPCs. Prefer start() over listen() — listen() races the engine
+// bind when the runner already owns the port.
+registry.start();
+
+console.log(
+  `camelAI agentOS server ready (Rivetkit client endpoint http://127.0.0.1:6420, PORT hint ${port})`,
+);

--- a/agentos-platform/src/server/index.ts
+++ b/agentos-platform/src/server/index.ts
@@ -1,7 +1,9 @@
 import { createPlatform } from "./platform/index.ts";
 import { registry } from "./registry.ts";
+import { setChatThreadAgentOsPlatform } from "./actors/chat-thread-agentos.ts";
 
 export const platform = createPlatform({ ensureDemoTenant: true });
+setChatThreadAgentOsPlatform(platform);
 
 const demo = platform.identity.ensureDemoTenant();
 const port = Number(process.env.PORT ?? "6420");

--- a/agentos-platform/src/server/index.ts
+++ b/agentos-platform/src/server/index.ts
@@ -1,7 +1,10 @@
-import { createPlatform } from "./platform/index.ts";
+import { startPlatformHttpServer } from "./http/metrics.ts";
+import { createPlatform, setPlatform } from "./platform/index.ts";
 import { registry } from "./registry.ts";
 
 export const platform = createPlatform({ ensureDemoTenant: true });
+setPlatform(platform);
+export const httpServer = startPlatformHttpServer();
 
 const demo = platform.identity.ensureDemoTenant();
 const port = Number(process.env.PORT ?? "6420");
@@ -22,5 +25,5 @@ console.log("camelAI agentOS demo tenant", {
 registry.start();
 
 console.log(
-  `camelAI agentOS server ready (Rivetkit client endpoint http://127.0.0.1:6420, PORT hint ${port})`,
+  `camelAI agentOS server ready (Rivetkit http://127.0.0.1:6420, HTTP API http://127.0.0.1:${httpServer.port}, PORT hint ${port})`,
 );

--- a/agentos-platform/src/server/index.ts
+++ b/agentos-platform/src/server/index.ts
@@ -1,10 +1,17 @@
+import { createApiHandler } from "./http/api.ts";
 import { startPlatformHttpServer } from "./http/metrics.ts";
 import { createPlatform, setPlatform } from "./platform/index.ts";
 import { registry } from "./registry.ts";
 
 export const platform = createPlatform({ ensureDemoTenant: true });
 setPlatform(platform);
-export const httpServer = startPlatformHttpServer();
+export const httpServer = startPlatformHttpServer(
+  Number(process.env.AUTH_HTTP_PORT ?? process.env.PORT_HTTP ?? "6422"),
+  createApiHandler({
+    platform,
+    billingService: platform.billing,
+  }),
+);
 
 const demo = platform.identity.ensureDemoTenant();
 const port = Number(process.env.PORT ?? "6420");

--- a/agentos-platform/src/server/observability.ts
+++ b/agentos-platform/src/server/observability.ts
@@ -1,0 +1,148 @@
+export type EventSeverity = "debug" | "info" | "warn" | "error";
+
+export type RecordEventInput = {
+  event: string;
+  severity?: EventSeverity;
+  component: string;
+  operation?: string;
+  status?: string;
+  threadId?: string;
+  workspaceId?: string;
+  orgId?: string;
+  userId?: string;
+  durationMs?: number;
+  count?: number;
+  meta?: Record<string, unknown>;
+};
+
+export type StructuredEvent = RecordEventInput & {
+  timestamp: string;
+  severity: EventSeverity;
+};
+
+export type ObservabilityCounters = {
+  turns_started: number;
+  turns_completed: number;
+  turns_denied_credits: number;
+  http_requests: number;
+};
+
+const MAX_RECENT_EVENTS = 500;
+const recentEvents: StructuredEvent[] = [];
+const counters: ObservabilityCounters = {
+  turns_started: 0,
+  turns_completed: 0,
+  turns_denied_credits: 0,
+  http_requests: 0,
+};
+
+const sensitiveKey =
+  /(?:authorization|cookie|password|passwd|secret|token|api[-_]?key)/i;
+
+export function recordEvent(input: RecordEventInput): StructuredEvent {
+  requireNonEmpty(input.event, "recordEvent: event is required");
+  requireNonEmpty(input.component, "recordEvent: component is required");
+
+  const structured: StructuredEvent = {
+    timestamp: new Date().toISOString(),
+    ...input,
+    severity: input.severity ?? "info",
+    ...(input.meta ? { meta: sanitizeRecord(input.meta) } : {}),
+  };
+
+  if (isCounterName(structured.event)) {
+    counters[structured.event] += structured.count ?? 1;
+  }
+  recentEvents.push(structured);
+  if (recentEvents.length > MAX_RECENT_EVENTS) {
+    recentEvents.splice(0, recentEvents.length - MAX_RECENT_EVENTS);
+  }
+
+  process.stdout.write(`${JSON.stringify(structured)}\n`);
+  return structuredClone(structured);
+}
+
+export function recordError(
+  input: RecordEventInput & { error?: unknown },
+): StructuredEvent {
+  const { error, ...event } = input;
+  const errorMeta =
+    error === undefined
+      ? {}
+      : error instanceof Error
+        ? { errorName: error.name, errorMessage: error.message }
+        : { errorMessage: String(error) };
+  return recordEvent({
+    ...event,
+    severity: "error",
+    status: event.status ?? "error",
+    meta: { ...event.meta, ...errorMeta },
+  });
+}
+
+export function getObservabilitySnapshot(): {
+  counters: ObservabilityCounters;
+  recentEvents: StructuredEvent[];
+} {
+  return {
+    counters: { ...counters },
+    recentEvents: structuredClone(recentEvents),
+  };
+}
+
+export function getCounters(): ObservabilityCounters {
+  return { ...counters };
+}
+
+export function getRecentEvents(): StructuredEvent[] {
+  return structuredClone(recentEvents);
+}
+
+/** Test-only reset for process-global metrics state. */
+export function resetObservabilityForTests(): void {
+  recentEvents.splice(0, recentEvents.length);
+  for (const name of Object.keys(counters) as Array<
+    keyof ObservabilityCounters
+  >) {
+    counters[name] = 0;
+  }
+}
+
+function isCounterName(value: string): value is keyof ObservabilityCounters {
+  return Object.hasOwn(counters, value);
+}
+
+function sanitizeRecord(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      sensitiveKey.test(key) ? "[REDACTED]" : sanitizeValue(entry),
+    ]),
+  );
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeValue);
+  }
+  if (value && typeof value === "object") {
+    return sanitizeRecord(value as Record<string, unknown>);
+  }
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  return String(value);
+}
+
+function requireNonEmpty(value: string, message: string): void {
+  if (!value?.trim()) {
+    throw new Error(message);
+  }
+}

--- a/agentos-platform/src/server/platform/billing.ts
+++ b/agentos-platform/src/server/platform/billing.ts
@@ -1,9 +1,31 @@
 import type { Store } from "./store.ts";
+import {
+  BILLING_PLANS,
+  BILLING_PLAN_LIMITS,
+  planAllowsHostedModels,
+  type BillingPlan,
+} from "../../shared/billing-plans.ts";
+
+export type BillingStatus =
+  | "none"
+  | "trialing"
+  | "active"
+  | "past_due"
+  | "canceled"
+  | "enterprise";
 
 export type BillingAccount = {
   orgId: string;
-  /** Available credits in USD cents. */
-  creditBalanceCents: number;
+  plan: BillingPlan;
+  billingStatus: BillingStatus;
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
+  purchasedCreditCents: number;
+  includedCreditCents: number;
+  creditGrantTotalCents: number;
+  usageChargeCents: number;
+  seatCount: number;
+  lastIncludedCreditInvoiceId?: string;
   updatedAt: string;
 };
 
@@ -11,68 +33,277 @@ function billingKey(orgId: string): string {
   return `billing:${orgId}`;
 }
 
+function idempotencyKey(
+  kind: "included" | "purchased",
+  orgId: string,
+  sourceId: string,
+): string {
+  return `billing-idempotency:${kind}:${orgId}:${sourceId}`;
+}
+
 function nowIso(): string {
   return new Date().toISOString();
 }
 
 /**
- * Lightweight billing stub: per-org credit balance persisted via Store.
- * Hosted model access requires a positive balance.
+ * Per-org billing state persisted via Store.
+ *
+ * Credit balance is derived from durable grant and usage totals rather than
+ * maintained as a second mutable value that can drift.
  */
 export class BillingService {
   constructor(private readonly store: Store) {}
 
   getAccount(orgId: string): BillingAccount {
     this.requireOrgId(orgId);
-    const existing = this.store.get<BillingAccount>(billingKey(orgId));
+    const existing = this.store.get<
+      Partial<BillingAccount> & { creditBalanceCents?: number }
+    >(billingKey(orgId));
     if (existing) {
-      return existing;
+      return this.normalizeAccount(orgId, existing);
     }
     return {
       orgId,
-      creditBalanceCents: 0,
+      plan: "payg",
+      billingStatus: "none",
+      purchasedCreditCents: 0,
+      includedCreditCents: 0,
+      creditGrantTotalCents: 0,
+      usageChargeCents: 0,
+      seatCount: 1,
       updatedAt: nowIso(),
     };
   }
 
   getCreditBalance(orgId: string): number {
-    return this.getAccount(orgId).creditBalanceCents;
+    const account = this.getAccount(orgId);
+    return Math.max(
+      0,
+      account.purchasedCreditCents +
+        account.includedCreditCents +
+        account.creditGrantTotalCents -
+        account.usageChargeCents,
+    );
   }
 
   canUseHostedModel(orgId: string): boolean {
-    return this.getCreditBalance(orgId) > 0;
+    const account = this.getAccount(orgId);
+    if (
+      account.plan === "enterprise" ||
+      account.billingStatus === "enterprise"
+    ) {
+      return true;
+    }
+    if (!planAllowsHostedModels(account.plan)) {
+      return false;
+    }
+    if (this.getCreditBalance(orgId) <= 0) {
+      return false;
+    }
+    return (
+      account.plan === "payg" ||
+      account.billingStatus === "trialing" ||
+      account.billingStatus === "active"
+    );
+  }
+
+  setPlan(
+    orgId: string,
+    plan: BillingPlan,
+    seatCount?: number,
+  ): BillingAccount {
+    this.requireOrgId(orgId);
+    if (!BILLING_PLANS.includes(plan)) {
+      throw new Error(`setPlan: unsupported billing plan ${String(plan)}`);
+    }
+    const current = this.getAccount(orgId);
+    const nextSeatCount = this.normalizeSeatCount(
+      plan,
+      seatCount ?? current.seatCount,
+    );
+    return this.save({
+      ...current,
+      plan,
+      seatCount: nextSeatCount,
+      updatedAt: nowIso(),
+    });
+  }
+
+  setBillingStatus(orgId: string, billingStatus: BillingStatus): BillingAccount {
+    this.requireOrgId(orgId);
+    const allowed: readonly BillingStatus[] = [
+      "none",
+      "trialing",
+      "active",
+      "past_due",
+      "canceled",
+      "enterprise",
+    ];
+    if (!allowed.includes(billingStatus)) {
+      throw new Error(
+        `setBillingStatus: unsupported status ${String(billingStatus)}`,
+      );
+    }
+    return this.save({
+      ...this.getAccount(orgId),
+      billingStatus,
+      updatedAt: nowIso(),
+    });
+  }
+
+  setStripeIds(
+    orgId: string,
+    ids:
+      | {
+          customerId?: string | null;
+          subscriptionId?: string | null;
+        }
+      | string
+      | null,
+    subscriptionId?: string | null,
+  ): BillingAccount {
+    this.requireOrgId(orgId);
+    const current = this.getAccount(orgId);
+    const values =
+      ids !== null && typeof ids === "object"
+        ? ids
+        : { customerId: ids, subscriptionId };
+    const next = { ...current, updatedAt: nowIso() };
+    if (values.customerId !== undefined) {
+      this.assignOptionalId(next, "stripeCustomerId", values.customerId);
+    }
+    if (values.subscriptionId !== undefined) {
+      this.assignOptionalId(
+        next,
+        "stripeSubscriptionId",
+        values.subscriptionId,
+      );
+    }
+    return this.save(next);
+  }
+
+  grantIncludedCredits(
+    orgId: string,
+    cents: number,
+    invoiceId: string,
+  ): BillingAccount {
+    this.requireOrgId(orgId);
+    this.requirePositiveCents(cents, "grantIncludedCredits");
+    this.requireSourceId(invoiceId, "grantIncludedCredits", "invoiceId");
+    const key = idempotencyKey("included", orgId, invoiceId);
+    if (this.store.get(key)) {
+      return this.getAccount(orgId);
+    }
+    const current = this.getAccount(orgId);
+    const next = this.save({
+      ...current,
+      includedCreditCents: current.includedCreditCents + cents,
+      lastIncludedCreditInvoiceId: invoiceId,
+      updatedAt: nowIso(),
+    });
+    this.store.set(key, true);
+    return next;
+  }
+
+  grantPurchasedCredits(
+    orgId: string,
+    cents: number,
+    checkoutSessionId: string,
+  ): BillingAccount {
+    this.requireOrgId(orgId);
+    this.requirePositiveCents(cents, "grantPurchasedCredits");
+    this.requireSourceId(
+      checkoutSessionId,
+      "grantPurchasedCredits",
+      "checkoutSessionId",
+    );
+    const key = idempotencyKey("purchased", orgId, checkoutSessionId);
+    if (this.store.get(key)) {
+      return this.getAccount(orgId);
+    }
+    const current = this.getAccount(orgId);
+    const next = this.save({
+      ...current,
+      purchasedCreditCents: current.purchasedCreditCents + cents,
+      updatedAt: nowIso(),
+    });
+    this.store.set(key, true);
+    return next;
   }
 
   grantCredits(orgId: string, cents: number): BillingAccount {
     this.requireOrgId(orgId);
     this.requirePositiveCents(cents, "grantCredits");
     const current = this.getAccount(orgId);
-    const next: BillingAccount = {
-      orgId,
-      creditBalanceCents: current.creditBalanceCents + cents,
+    return this.save({
+      ...current,
+      creditGrantTotalCents: current.creditGrantTotalCents + cents,
       updatedAt: nowIso(),
-    };
-    this.store.set(billingKey(orgId), next);
-    return next;
+    });
   }
 
   consumeCredits(orgId: string, cents: number): BillingAccount {
     this.requireOrgId(orgId);
     this.requirePositiveCents(cents, "consumeCredits");
     const current = this.getAccount(orgId);
-    if (current.creditBalanceCents < cents) {
+    const balance = this.getCreditBalance(orgId);
+    if (balance < cents) {
       throw new Error(
         `consumeCredits: insufficient credits for org ${orgId} ` +
-          `(have ${current.creditBalanceCents}¢, need ${cents}¢)`,
+          `(have ${balance}¢, need ${cents}¢)`,
       );
     }
-    const next: BillingAccount = {
-      orgId,
-      creditBalanceCents: current.creditBalanceCents - cents,
+    return this.save({
+      ...current,
+      usageChargeCents: current.usageChargeCents + cents,
       updatedAt: nowIso(),
+    });
+  }
+
+  private normalizeAccount(
+    orgId: string,
+    existing: Partial<BillingAccount> & { creditBalanceCents?: number },
+  ): BillingAccount {
+    const plan = BILLING_PLANS.includes(existing.plan as BillingPlan)
+      ? (existing.plan as BillingPlan)
+      : "payg";
+    const billingStatus = this.isBillingStatus(existing.billingStatus)
+      ? existing.billingStatus
+      : "none";
+    const legacyBalance = this.nonNegativeCents(existing.creditBalanceCents);
+    return {
+      orgId,
+      plan,
+      billingStatus,
+      ...(existing.stripeCustomerId
+        ? { stripeCustomerId: existing.stripeCustomerId }
+        : {}),
+      ...(existing.stripeSubscriptionId
+        ? { stripeSubscriptionId: existing.stripeSubscriptionId }
+        : {}),
+      purchasedCreditCents: this.nonNegativeCents(
+        existing.purchasedCreditCents,
+      ),
+      includedCreditCents: this.nonNegativeCents(existing.includedCreditCents),
+      creditGrantTotalCents:
+        existing.creditGrantTotalCents === undefined
+          ? legacyBalance
+          : this.nonNegativeCents(existing.creditGrantTotalCents),
+      usageChargeCents: this.nonNegativeCents(existing.usageChargeCents),
+      seatCount: this.normalizeSeatCount(plan, existing.seatCount ?? 1),
+      ...(existing.lastIncludedCreditInvoiceId
+        ? {
+            lastIncludedCreditInvoiceId:
+              existing.lastIncludedCreditInvoiceId,
+          }
+        : {}),
+      updatedAt: existing.updatedAt ?? nowIso(),
     };
-    this.store.set(billingKey(orgId), next);
-    return next;
+  }
+
+  private save(account: BillingAccount): BillingAccount {
+    this.store.set(billingKey(account.orgId), account);
+    return account;
   }
 
   private requireOrgId(orgId: string): void {
@@ -84,6 +315,50 @@ export class BillingService {
   private requirePositiveCents(cents: number, op: string): void {
     if (!Number.isFinite(cents) || !Number.isInteger(cents) || cents <= 0) {
       throw new Error(`${op}: cents must be a positive integer`);
+    }
+  }
+
+  private requireSourceId(value: string, op: string, field: string): void {
+    if (!value?.trim()) {
+      throw new Error(`${op}: ${field} is required`);
+    }
+  }
+
+  private nonNegativeCents(value: number | undefined): number {
+    return Number.isSafeInteger(value) && (value ?? -1) >= 0 ? (value ?? 0) : 0;
+  }
+
+  private normalizeSeatCount(plan: BillingPlan, seatCount: number): number {
+    if (!Number.isFinite(seatCount)) {
+      return BILLING_PLAN_LIMITS[plan].minimumSeats;
+    }
+    return Math.max(
+      BILLING_PLAN_LIMITS[plan].minimumSeats,
+      Math.floor(seatCount),
+    );
+  }
+
+  private isBillingStatus(value: unknown): value is BillingStatus {
+    return (
+      value === "none" ||
+      value === "trialing" ||
+      value === "active" ||
+      value === "past_due" ||
+      value === "canceled" ||
+      value === "enterprise"
+    );
+  }
+
+  private assignOptionalId(
+    account: BillingAccount,
+    field: "stripeCustomerId" | "stripeSubscriptionId",
+    value: string | null,
+  ): void {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      account[field] = trimmed;
+    } else {
+      delete account[field];
     }
   }
 }

--- a/agentos-platform/src/server/platform/billing.ts
+++ b/agentos-platform/src/server/platform/billing.ts
@@ -1,0 +1,89 @@
+import type { Store } from "./store.ts";
+
+export type BillingAccount = {
+  orgId: string;
+  /** Available credits in USD cents. */
+  creditBalanceCents: number;
+  updatedAt: string;
+};
+
+function billingKey(orgId: string): string {
+  return `billing:${orgId}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Lightweight billing stub: per-org credit balance persisted via Store.
+ * Hosted model access requires a positive balance.
+ */
+export class BillingService {
+  constructor(private readonly store: Store) {}
+
+  getAccount(orgId: string): BillingAccount {
+    this.requireOrgId(orgId);
+    const existing = this.store.get<BillingAccount>(billingKey(orgId));
+    if (existing) {
+      return existing;
+    }
+    return {
+      orgId,
+      creditBalanceCents: 0,
+      updatedAt: nowIso(),
+    };
+  }
+
+  getCreditBalance(orgId: string): number {
+    return this.getAccount(orgId).creditBalanceCents;
+  }
+
+  canUseHostedModel(orgId: string): boolean {
+    return this.getCreditBalance(orgId) > 0;
+  }
+
+  grantCredits(orgId: string, cents: number): BillingAccount {
+    this.requireOrgId(orgId);
+    this.requirePositiveCents(cents, "grantCredits");
+    const current = this.getAccount(orgId);
+    const next: BillingAccount = {
+      orgId,
+      creditBalanceCents: current.creditBalanceCents + cents,
+      updatedAt: nowIso(),
+    };
+    this.store.set(billingKey(orgId), next);
+    return next;
+  }
+
+  consumeCredits(orgId: string, cents: number): BillingAccount {
+    this.requireOrgId(orgId);
+    this.requirePositiveCents(cents, "consumeCredits");
+    const current = this.getAccount(orgId);
+    if (current.creditBalanceCents < cents) {
+      throw new Error(
+        `consumeCredits: insufficient credits for org ${orgId} ` +
+          `(have ${current.creditBalanceCents}¢, need ${cents}¢)`,
+      );
+    }
+    const next: BillingAccount = {
+      orgId,
+      creditBalanceCents: current.creditBalanceCents - cents,
+      updatedAt: nowIso(),
+    };
+    this.store.set(billingKey(orgId), next);
+    return next;
+  }
+
+  private requireOrgId(orgId: string): void {
+    if (!orgId?.trim()) {
+      throw new Error("BillingService: orgId is required");
+    }
+  }
+
+  private requirePositiveCents(cents: number, op: string): void {
+    if (!Number.isFinite(cents) || !Number.isInteger(cents) || cents <= 0) {
+      throw new Error(`${op}: cents must be a positive integer`);
+    }
+  }
+}

--- a/agentos-platform/src/server/platform/filesystem.ts
+++ b/agentos-platform/src/server/platform/filesystem.ts
@@ -1,0 +1,205 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { resolveDataDir } from "./store.ts";
+
+export type FsEntry = {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  size?: number;
+};
+
+export type ProjectFilesystemOptions = {
+  dataDir?: string;
+  workspaceId: string;
+  projectId: string;
+};
+
+/**
+ * Project-scoped filesystem rooted at
+ * `{DATA_DIR}/projects/{workspaceId}/{projectId}`.
+ */
+export class ProjectFilesystem {
+  readonly root: string;
+  readonly workspaceId: string;
+  readonly projectId: string;
+
+  constructor(options: ProjectFilesystemOptions) {
+    if (!options.workspaceId?.trim()) {
+      throw new Error("ProjectFilesystem: workspaceId is required");
+    }
+    if (!options.projectId?.trim()) {
+      throw new Error("ProjectFilesystem: projectId is required");
+    }
+    this.workspaceId = options.workspaceId.trim();
+    this.projectId = options.projectId.trim();
+    this.root = resolve(
+      resolveDataDir(options.dataDir),
+      "projects",
+      this.workspaceId,
+      this.projectId,
+    );
+    mkdirSync(this.root, { recursive: true });
+  }
+
+  exists(path: string): boolean {
+    return existsSync(this.resolveSafe(path));
+  }
+
+  read(path: string): string {
+    const abs = this.resolveSafe(path);
+    if (!existsSync(abs)) {
+      throw new Error(`File not found: ${this.displayPath(path)}`);
+    }
+    const st = statSync(abs);
+    if (!st.isFile()) {
+      throw new Error(`Not a file: ${this.displayPath(path)}`);
+    }
+    return readFileSync(abs, "utf8");
+  }
+
+  write(path: string, content: string): void {
+    const abs = this.resolveSafe(path);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content, "utf8");
+  }
+
+  /**
+   * Search/replace edit. Fails if `oldText` is missing or matches more than once
+   * (pass `replaceAll: true` to replace every occurrence).
+   */
+  edit(
+    path: string,
+    oldText: string,
+    newText: string,
+    options: { replaceAll?: boolean } = {},
+  ): { replacements: number } {
+    if (oldText === "") {
+      throw new Error(`edit: oldText must be non-empty (${this.displayPath(path)})`);
+    }
+    const before = this.read(path);
+    const count = countOccurrences(before, oldText);
+    if (count === 0) {
+      throw new Error(
+        `edit: oldText not found in ${this.displayPath(path)}`,
+      );
+    }
+    if (!options.replaceAll && count > 1) {
+      throw new Error(
+        `edit: oldText matched ${count} times in ${this.displayPath(path)}; pass replaceAll: true or narrow the match`,
+      );
+    }
+    const after = options.replaceAll
+      ? before.split(oldText).join(newText)
+      : before.replace(oldText, newText);
+    this.write(path, after);
+    return { replacements: options.replaceAll ? count : 1 };
+  }
+
+  delete(path: string): void {
+    const abs = this.resolveSafe(path);
+    if (abs === this.root) {
+      throw new Error("delete: refusing to delete project root");
+    }
+    if (!existsSync(abs)) {
+      throw new Error(`Path not found: ${this.displayPath(path)}`);
+    }
+    rmSync(abs, { recursive: true, force: false });
+  }
+
+  mkdir(path: string): void {
+    const abs = this.resolveSafe(path);
+    mkdirSync(abs, { recursive: true });
+  }
+
+  ls(path = "."): FsEntry[] {
+    const abs = this.resolveSafe(path);
+    if (!existsSync(abs)) {
+      throw new Error(`Directory not found: ${this.displayPath(path)}`);
+    }
+    const st = statSync(abs);
+    if (!st.isDirectory()) {
+      throw new Error(`Not a directory: ${this.displayPath(path)}`);
+    }
+    const baseRel = this.toRelative(abs);
+    return readdirSync(abs)
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => {
+        const childAbs = join(abs, name);
+        const childSt = statSync(childAbs);
+        const childRel =
+          baseRel === "." ? name : `${baseRel.replace(/\\/g, "/")}/${name}`;
+        if (childSt.isDirectory()) {
+          return { name, path: childRel, type: "directory" as const };
+        }
+        return {
+          name,
+          path: childRel,
+          type: "file" as const,
+          size: childSt.size,
+        };
+      });
+  }
+
+  /** Resolve a relative project path under root only. */
+  resolveSafe(path: string): string {
+    const normalized = normalizeRelative(path);
+    const abs = resolve(this.root, normalized);
+    const rel = relative(this.root, abs);
+    if (rel.startsWith("..") || rel === ".." || abs === ".." || isAbsoluteEscape(rel)) {
+      throw new Error(
+        `Path escapes project root: ${path || "."} (resolved under ${this.root})`,
+      );
+    }
+    // Defend against resolve() landing outside on weird inputs.
+    if (abs !== this.root && !abs.startsWith(this.root + sep)) {
+      throw new Error(
+        `Path escapes project root: ${path || "."} (resolved under ${this.root})`,
+      );
+    }
+    return abs;
+  }
+
+  private toRelative(abs: string): string {
+    const rel = relative(this.root, abs);
+    return rel === "" ? "." : rel.replace(/\\/g, "/");
+  }
+
+  private displayPath(path: string): string {
+    return normalizeRelative(path) || ".";
+  }
+}
+
+function normalizeRelative(path: string): string {
+  const trimmed = (path ?? "").replace(/\\/g, "/").trim();
+  if (!trimmed || trimmed === ".") {
+    return ".";
+  }
+  return trimmed.replace(/^\/+/, "");
+}
+
+function isAbsoluteEscape(rel: string): boolean {
+  // On Windows relative() can yield an absolute path when roots differ.
+  return /^([a-zA-Z]:)?[\\/]/.test(rel);
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let idx = 0;
+  while (true) {
+    const found = haystack.indexOf(needle, idx);
+    if (found === -1) break;
+    count += 1;
+    idx = found + needle.length;
+  }
+  return count;
+}

--- a/agentos-platform/src/server/platform/identity.ts
+++ b/agentos-platform/src/server/platform/identity.ts
@@ -1,0 +1,286 @@
+import { randomUUID } from "node:crypto";
+import type { Store } from "./store.ts";
+
+export type Org = {
+  id: string;
+  name: string;
+  slug: string;
+  createdAt: string;
+};
+
+export type Workspace = {
+  id: string;
+  orgId: string;
+  name: string;
+  slug: string;
+  createdAt: string;
+};
+
+export type User = {
+  id: string;
+  email: string;
+  name: string;
+  orgId: string;
+  createdAt: string;
+};
+
+export type Thread = {
+  id: string;
+  workspaceId: string;
+  orgId: string;
+  title: string;
+  model: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DemoTenant = {
+  org: Org;
+  workspace: Workspace;
+  user: User;
+};
+
+const DEMO_ORG_ID = "org_demo";
+const DEMO_WORKSPACE_ID = "ws_demo";
+const DEMO_USER_ID = "user_demo";
+const DEFAULT_MODEL = "anthropic/claude-sonnet-4-5";
+
+function orgKey(id: string): string {
+  return `org:${id}`;
+}
+
+function workspaceKey(id: string): string {
+  return `workspace:${id}`;
+}
+
+function userKey(id: string): string {
+  return `user:${id}`;
+}
+
+function threadKey(id: string): string {
+  return `thread:${id}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function slugify(input: string): string {
+  const slug = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "untitled";
+}
+
+export class IdentityService {
+  constructor(private readonly store: Store) {}
+
+  createOrg(input: { name: string; slug?: string; id?: string }): Org {
+    const name = input.name?.trim();
+    if (!name) {
+      throw new Error("createOrg: name is required");
+    }
+    const id = input.id ?? `org_${randomUUID()}`;
+    if (this.store.get(orgKey(id))) {
+      throw new Error(`createOrg: org already exists: ${id}`);
+    }
+    const org: Org = {
+      id,
+      name,
+      slug: input.slug?.trim() || slugify(name),
+      createdAt: nowIso(),
+    };
+    this.store.set(orgKey(id), org);
+    return org;
+  }
+
+  getOrg(id: string): Org | undefined {
+    return this.store.get<Org>(orgKey(id));
+  }
+
+  createWorkspace(input: {
+    orgId: string;
+    name: string;
+    slug?: string;
+    id?: string;
+  }): Workspace {
+    const name = input.name?.trim();
+    if (!name) {
+      throw new Error("createWorkspace: name is required");
+    }
+    if (!input.orgId) {
+      throw new Error("createWorkspace: orgId is required");
+    }
+    if (!this.store.get(orgKey(input.orgId))) {
+      throw new Error(`createWorkspace: org not found: ${input.orgId}`);
+    }
+    const id = input.id ?? `ws_${randomUUID()}`;
+    if (this.store.get(workspaceKey(id))) {
+      throw new Error(`createWorkspace: workspace already exists: ${id}`);
+    }
+    const workspace: Workspace = {
+      id,
+      orgId: input.orgId,
+      name,
+      slug: input.slug?.trim() || slugify(name),
+      createdAt: nowIso(),
+    };
+    this.store.set(workspaceKey(id), workspace);
+    return workspace;
+  }
+
+  getWorkspace(id: string): Workspace | undefined {
+    return this.store.get<Workspace>(workspaceKey(id));
+  }
+
+  createUser(input: {
+    email: string;
+    name: string;
+    orgId: string;
+    id?: string;
+  }): User {
+    const email = input.email?.trim().toLowerCase();
+    const name = input.name?.trim();
+    if (!email) {
+      throw new Error("createUser: email is required");
+    }
+    if (!name) {
+      throw new Error("createUser: name is required");
+    }
+    if (!input.orgId) {
+      throw new Error("createUser: orgId is required");
+    }
+    if (!this.store.get(orgKey(input.orgId))) {
+      throw new Error(`createUser: org not found: ${input.orgId}`);
+    }
+    const id = input.id ?? `user_${randomUUID()}`;
+    if (this.store.get(userKey(id))) {
+      throw new Error(`createUser: user already exists: ${id}`);
+    }
+    const user: User = {
+      id,
+      email,
+      name,
+      orgId: input.orgId,
+      createdAt: nowIso(),
+    };
+    this.store.set(userKey(id), user);
+    return user;
+  }
+
+  getUser(id: string): User | undefined {
+    return this.store.get<User>(userKey(id));
+  }
+
+  createThread(input: {
+    workspaceId: string;
+    orgId?: string;
+    title?: string;
+    model?: string;
+    id?: string;
+  }): Thread {
+    if (!input.workspaceId) {
+      throw new Error("createThread: workspaceId is required");
+    }
+    const workspace = this.store.get<Workspace>(workspaceKey(input.workspaceId));
+    if (!workspace) {
+      throw new Error(`createThread: workspace not found: ${input.workspaceId}`);
+    }
+    const orgId = input.orgId ?? workspace.orgId;
+    if (orgId !== workspace.orgId) {
+      throw new Error(
+        `createThread: orgId ${orgId} does not own workspace ${workspace.id}`,
+      );
+    }
+    const id = input.id ?? `thread_${randomUUID()}`;
+    if (this.store.get(threadKey(id))) {
+      throw new Error(`createThread: thread already exists: ${id}`);
+    }
+    const stamp = nowIso();
+    const thread: Thread = {
+      id,
+      workspaceId: workspace.id,
+      orgId,
+      title: input.title?.trim() || "New chat",
+      model: input.model?.trim() || DEFAULT_MODEL,
+      createdAt: stamp,
+      updatedAt: stamp,
+    };
+    this.store.set(threadKey(id), thread);
+    return thread;
+  }
+
+  getThread(id: string): Thread | undefined {
+    if (!id) {
+      throw new Error("getThread: id is required");
+    }
+    return this.store.get<Thread>(threadKey(id));
+  }
+
+  listThreads(workspaceId: string): Thread[] {
+    if (!workspaceId) {
+      throw new Error("listThreads: workspaceId is required");
+    }
+    return this.store
+      .listByPrefix<Thread>("thread:")
+      .map((entry) => entry.value)
+      .filter((thread) => thread.workspaceId === workspaceId)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  updateThread(
+    id: string,
+    patch: Partial<Pick<Thread, "title" | "model">>,
+  ): Thread {
+    const thread = this.getThread(id);
+    if (!thread) {
+      throw new Error(`updateThread: thread not found: ${id}`);
+    }
+    const next: Thread = {
+      ...thread,
+      title: patch.title?.trim() || thread.title,
+      model: patch.model?.trim() || thread.model,
+      updatedAt: nowIso(),
+    };
+    this.store.set(threadKey(id), next);
+    return next;
+  }
+
+  /**
+   * Idempotent local-dev bootstrap: demo org, workspace, and user.
+   */
+  ensureDemoTenant(): DemoTenant {
+    let org = this.getOrg(DEMO_ORG_ID);
+    if (!org) {
+      org = this.createOrg({
+        id: DEMO_ORG_ID,
+        name: "Demo Org",
+        slug: "demo",
+      });
+    }
+
+    let workspace = this.getWorkspace(DEMO_WORKSPACE_ID);
+    if (!workspace) {
+      workspace = this.createWorkspace({
+        id: DEMO_WORKSPACE_ID,
+        orgId: org.id,
+        name: "Demo Workspace",
+        slug: "demo",
+      });
+    }
+
+    let user = this.getUser(DEMO_USER_ID);
+    if (!user) {
+      user = this.createUser({
+        id: DEMO_USER_ID,
+        orgId: org.id,
+        email: "demo@localhost",
+        name: "Demo User",
+      });
+    }
+
+    return { org, workspace, user };
+  }
+}

--- a/agentos-platform/src/server/platform/identity.ts
+++ b/agentos-platform/src/server/platform/identity.ts
@@ -57,6 +57,10 @@ function userKey(id: string): string {
   return `user:${id}`;
 }
 
+function userPasswordKey(id: string): string {
+  return `user-password:${id}`;
+}
+
 function threadKey(id: string): string {
   return `thread:${id}`;
 }
@@ -155,6 +159,10 @@ export class IdentityService {
     if (!this.store.get(orgKey(input.orgId))) {
       throw new Error(`createUser: org not found: ${input.orgId}`);
     }
+    const existingUser = this.findUserByEmail(email);
+    if (existingUser) {
+      throw new Error(`createUser: email already exists: ${email}`);
+    }
     const id = input.id ?? `user_${randomUUID()}`;
     if (this.store.get(userKey(id))) {
       throw new Error(`createUser: user already exists: ${id}`);
@@ -172,6 +180,34 @@ export class IdentityService {
 
   getUser(id: string): User | undefined {
     return this.store.get<User>(userKey(id));
+  }
+
+  findUserByEmail(email: string): User | undefined {
+    const normalizedEmail = email?.trim().toLowerCase();
+    if (!normalizedEmail) {
+      return undefined;
+    }
+    return this.store
+      .listByPrefix<User>("user:")
+      .map((entry) => entry.value)
+      .find((user) => user.email.toLowerCase() === normalizedEmail);
+  }
+
+  setPasswordHash(userId: string, passwordHash: string): void {
+    if (!this.getUser(userId)) {
+      throw new Error(`setPasswordHash: user not found: ${userId}`);
+    }
+    if (!passwordHash?.trim()) {
+      throw new Error("setPasswordHash: passwordHash is required");
+    }
+    this.store.set(userPasswordKey(userId), passwordHash);
+  }
+
+  getPasswordHash(userId: string): string | undefined {
+    if (!userId) {
+      return undefined;
+    }
+    return this.store.get<string>(userPasswordKey(userId));
   }
 
   createThread(input: {

--- a/agentos-platform/src/server/platform/index.ts
+++ b/agentos-platform/src/server/platform/index.ts
@@ -4,7 +4,11 @@ import { IdentityService } from "./identity.ts";
 import { Store, resolveDataDir, type StoreOptions } from "./store.ts";
 import { UsageService } from "./usage.ts";
 
-export { BillingService, type BillingAccount } from "./billing.ts";
+export {
+  BillingService,
+  type BillingAccount,
+  type BillingStatus,
+} from "./billing.ts";
 export {
   ProjectFilesystem,
   type FsEntry,

--- a/agentos-platform/src/server/platform/index.ts
+++ b/agentos-platform/src/server/platform/index.ts
@@ -2,6 +2,7 @@ import { BillingService } from "./billing.ts";
 import { ProjectFilesystem } from "./filesystem.ts";
 import { IdentityService } from "./identity.ts";
 import { Store, resolveDataDir, type StoreOptions } from "./store.ts";
+import { UsageService } from "./usage.ts";
 
 export { BillingService, type BillingAccount } from "./billing.ts";
 export {
@@ -18,6 +19,11 @@ export {
   type Workspace,
 } from "./identity.ts";
 export { Store, resolveDataDir, type StoreOptions } from "./store.ts";
+export {
+  UsageService,
+  type ListUsageOptions,
+  type UsageEvent,
+} from "./usage.ts";
 
 export type PlatformOptions = StoreOptions & {
   /** Seed the demo org/workspace/user on create. Default false. */
@@ -31,6 +37,7 @@ export type Platform = {
   store: Store;
   identity: IdentityService;
   billing: BillingService;
+  usage: UsageService;
   /** Open a project filesystem under DATA_DIR/projects/{workspaceId}/{projectId}. */
   projectFilesystem: (
     workspaceId: string,
@@ -46,6 +53,7 @@ export function createPlatform(options: PlatformOptions = {}): Platform {
   });
   const identity = new IdentityService(store);
   const billing = new BillingService(store);
+  const usage = new UsageService(store);
 
   if (options.ensureDemoTenant) {
     const demo = identity.ensureDemoTenant();
@@ -60,6 +68,7 @@ export function createPlatform(options: PlatformOptions = {}): Platform {
     store,
     identity,
     billing,
+    usage,
     projectFilesystem: (workspaceId, projectId) =>
       new ProjectFilesystem({
         dataDir: store.dataDir,
@@ -67,4 +76,21 @@ export function createPlatform(options: PlatformOptions = {}): Platform {
         projectId,
       }),
   };
+}
+
+let activePlatform: Platform | undefined;
+
+/** Configure the process-wide platform used by actor definitions. */
+export function setPlatform(platform: Platform): void {
+  activePlatform = platform;
+}
+
+/** Return the process-wide platform configured by the server or test harness. */
+export function getPlatform(): Platform {
+  if (!activePlatform) {
+    throw new Error(
+      "Platform is not configured; call setPlatform(createPlatform(...)) first",
+    );
+  }
+  return activePlatform;
 }

--- a/agentos-platform/src/server/platform/index.ts
+++ b/agentos-platform/src/server/platform/index.ts
@@ -1,0 +1,70 @@
+import { BillingService } from "./billing.ts";
+import { ProjectFilesystem } from "./filesystem.ts";
+import { IdentityService } from "./identity.ts";
+import { Store, resolveDataDir, type StoreOptions } from "./store.ts";
+
+export { BillingService, type BillingAccount } from "./billing.ts";
+export {
+  ProjectFilesystem,
+  type FsEntry,
+  type ProjectFilesystemOptions,
+} from "./filesystem.ts";
+export {
+  IdentityService,
+  type DemoTenant,
+  type Org,
+  type Thread,
+  type User,
+  type Workspace,
+} from "./identity.ts";
+export { Store, resolveDataDir, type StoreOptions } from "./store.ts";
+
+export type PlatformOptions = StoreOptions & {
+  /** Seed the demo org/workspace/user on create. Default false. */
+  ensureDemoTenant?: boolean;
+  /** Initial demo credit grant in cents when seeding. Default 1000 ($10). */
+  demoCreditCents?: number;
+};
+
+export type Platform = {
+  dataDir: string;
+  store: Store;
+  identity: IdentityService;
+  billing: BillingService;
+  /** Open a project filesystem under DATA_DIR/projects/{workspaceId}/{projectId}. */
+  projectFilesystem: (
+    workspaceId: string,
+    projectId: string,
+  ) => ProjectFilesystem;
+};
+
+/** Create the in-process platform services sharing one Store. */
+export function createPlatform(options: PlatformOptions = {}): Platform {
+  const store = new Store({
+    dataDir: options.dataDir,
+    filename: options.filename,
+  });
+  const identity = new IdentityService(store);
+  const billing = new BillingService(store);
+
+  if (options.ensureDemoTenant) {
+    const demo = identity.ensureDemoTenant();
+    const grant = options.demoCreditCents ?? 1000;
+    if (grant > 0 && billing.getCreditBalance(demo.org.id) <= 0) {
+      billing.grantCredits(demo.org.id, grant);
+    }
+  }
+
+  return {
+    dataDir: store.dataDir,
+    store,
+    identity,
+    billing,
+    projectFilesystem: (workspaceId, projectId) =>
+      new ProjectFilesystem({
+        dataDir: store.dataDir,
+        workspaceId,
+        projectId,
+      }),
+  };
+}

--- a/agentos-platform/src/server/platform/store.ts
+++ b/agentos-platform/src/server/platform/store.ts
@@ -1,0 +1,141 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+export type StoreOptions = {
+  /** Override data directory. Defaults to `DATA_DIR` env or `.data/`. */
+  dataDir?: string;
+  /** JSON filename inside dataDir. Defaults to `store.json`. */
+  filename?: string;
+};
+
+/** Resolve the platform data directory. */
+export function resolveDataDir(override?: string): string {
+  return resolve(override ?? process.env.DATA_DIR ?? ".data");
+}
+
+/**
+ * Simple JSON-file + in-memory key/value store.
+ * Swap later for SQLite / Durable Object storage without changing callers.
+ */
+export class Store {
+  readonly dataDir: string;
+  private readonly filePath: string;
+  private readonly memory = new Map<string, unknown>();
+
+  constructor(options: StoreOptions = {}) {
+    this.dataDir = resolveDataDir(options.dataDir);
+    this.filePath = join(this.dataDir, options.filename ?? "store.json");
+    mkdirSync(this.dataDir, { recursive: true });
+    this.load();
+  }
+
+  get<T = unknown>(key: string): T | undefined {
+    if (!key) {
+      throw new Error("Store.get: key must be a non-empty string");
+    }
+    return this.memory.get(key) as T | undefined;
+  }
+
+  set(key: string, value: unknown): void {
+    if (!key) {
+      throw new Error("Store.set: key must be a non-empty string");
+    }
+    this.memory.set(key, value);
+    this.persist();
+  }
+
+  delete(key: string): boolean {
+    if (!key) {
+      throw new Error("Store.delete: key must be a non-empty string");
+    }
+    const existed = this.memory.delete(key);
+    if (existed) {
+      this.persist();
+    }
+    return existed;
+  }
+
+  listByPrefix<T = unknown>(prefix: string): Array<{ key: string; value: T }> {
+    if (prefix === undefined || prefix === null) {
+      throw new Error("Store.listByPrefix: prefix is required");
+    }
+    const out: Array<{ key: string; value: T }> = [];
+    for (const [key, value] of this.memory) {
+      if (key.startsWith(prefix)) {
+        out.push({ key, value: value as T });
+      }
+    }
+    out.sort((a, b) => a.key.localeCompare(b.key));
+    return out;
+  }
+
+  /** Clear all keys (tests / reset). */
+  clear(): void {
+    this.memory.clear();
+    this.persist();
+  }
+
+  private load(): void {
+    if (!existsSync(this.filePath)) {
+      return;
+    }
+    let raw: string;
+    try {
+      raw = readFileSync(this.filePath, "utf8");
+    } catch (error) {
+      throw new Error(
+        `Store: failed to read ${this.filePath}: ${errorMessage(error)}`,
+      );
+    }
+    if (!raw.trim()) {
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(
+        `Store: invalid JSON in ${this.filePath}: ${errorMessage(error)}`,
+      );
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(
+        `Store: expected a JSON object in ${this.filePath}, got ${typeof parsed}`,
+      );
+    }
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      this.memory.set(key, value);
+    }
+  }
+
+  private persist(): void {
+    mkdirSync(this.dataDir, { recursive: true });
+    const payload = JSON.stringify(Object.fromEntries(this.memory), null, 2);
+    const tmpPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      writeFileSync(tmpPath, payload, "utf8");
+      renameSync(tmpPath, this.filePath);
+    } catch (error) {
+      try {
+        if (existsSync(tmpPath)) {
+          writeFileSync(this.filePath, payload, "utf8");
+        }
+      } catch {
+        // fall through to the wrapped error below
+      }
+      throw new Error(
+        `Store: failed to persist ${this.filePath}: ${errorMessage(error)}`,
+      );
+    }
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/agentos-platform/src/server/platform/usage.ts
+++ b/agentos-platform/src/server/platform/usage.ts
@@ -1,0 +1,117 @@
+import type { Store } from "./store.ts";
+
+export type UsageEvent = {
+  id: string;
+  orgId: string;
+  workspaceId: string;
+  threadId: string;
+  userId?: string;
+  kind: "turn" | "tool" | "inference";
+  model?: string;
+  /** Cost in USD cents. */
+  cents: number;
+  creditChargeable: boolean;
+  durationMs?: number;
+  createdAt: string;
+};
+
+export type ListUsageOptions = {
+  since?: string;
+  limit?: number;
+};
+
+function usagePrefix(orgId: string): string {
+  return `usage:${orgId}:`;
+}
+
+function usageKey(event: UsageEvent): string {
+  return `${usagePrefix(event.orgId)}${event.id}`;
+}
+
+/** Persistent per-organization usage ledger backed by the platform Store. */
+export class UsageService {
+  constructor(private readonly store: Store) {}
+
+  recordUsage(event: UsageEvent): UsageEvent {
+    validateEvent(event);
+    const snapshot = structuredClone(event);
+    this.store.set(usageKey(snapshot), snapshot);
+    return snapshot;
+  }
+
+  listUsage(orgId: string, options: ListUsageOptions = {}): UsageEvent[] {
+    requireNonEmpty(orgId, "UsageService: orgId is required");
+    const sinceMs =
+      options.since === undefined
+        ? undefined
+        : requireTimestamp(options.since, "listUsage: since");
+    const limit = options.limit ?? 100;
+    if (!Number.isInteger(limit) || limit < 0) {
+      throw new Error("listUsage: limit must be a non-negative integer");
+    }
+
+    return this.store
+      .listByPrefix<UsageEvent>(usagePrefix(orgId))
+      .map(({ value }) => structuredClone(value))
+      .filter(
+        (event) =>
+          sinceMs === undefined || Date.parse(event.createdAt) >= sinceMs,
+      )
+      .sort(
+        (a, b) =>
+          Date.parse(b.createdAt) - Date.parse(a.createdAt) ||
+          b.id.localeCompare(a.id),
+      )
+      .slice(0, limit);
+  }
+
+  sumChargeableCents(orgId: string): number {
+    return this.listUsage(orgId, { limit: Number.MAX_SAFE_INTEGER })
+      .filter((event) => event.creditChargeable)
+      .reduce((total, event) => total + event.cents, 0);
+  }
+}
+
+function validateEvent(event: UsageEvent): void {
+  if (!event || typeof event !== "object") {
+    throw new Error("recordUsage: event is required");
+  }
+  requireNonEmpty(event.id, "recordUsage: id is required");
+  requireNonEmpty(event.orgId, "recordUsage: orgId is required");
+  requireNonEmpty(event.workspaceId, "recordUsage: workspaceId is required");
+  requireNonEmpty(event.threadId, "recordUsage: threadId is required");
+  if (!["turn", "tool", "inference"].includes(event.kind)) {
+    throw new Error("recordUsage: invalid usage kind");
+  }
+  if (
+    !Number.isFinite(event.cents) ||
+    !Number.isInteger(event.cents) ||
+    event.cents < 0
+  ) {
+    throw new Error("recordUsage: cents must be a non-negative integer");
+  }
+  if (typeof event.creditChargeable !== "boolean") {
+    throw new Error("recordUsage: creditChargeable must be a boolean");
+  }
+  if (
+    event.durationMs !== undefined &&
+    (!Number.isFinite(event.durationMs) || event.durationMs < 0)
+  ) {
+    throw new Error("recordUsage: durationMs must be non-negative");
+  }
+  requireTimestamp(event.createdAt, "recordUsage: createdAt");
+}
+
+function requireNonEmpty(value: string, message: string): void {
+  if (!value?.trim()) {
+    throw new Error(message);
+  }
+}
+
+function requireTimestamp(value: string, field: string): number {
+  const timestamp = Date.parse(value);
+  if (!value?.trim() || !Number.isFinite(timestamp)) {
+    throw new Error(`${field} must be a valid timestamp`);
+  }
+  return timestamp;
+}

--- a/agentos-platform/src/server/registry.ts
+++ b/agentos-platform/src/server/registry.ts
@@ -1,10 +1,20 @@
-import { setup } from "rivetkit";
+import { setup as agentOsSetup } from "@rivet-dev/agentos";
+import { setup as rivetSetup } from "rivetkit";
+import { chatThreadAgentOs } from "./actors/chat-thread-agentos.ts";
 import { chatThread } from "./actors/chat-thread.ts";
 import { org } from "./actors/org.ts";
 import { workspace } from "./actors/workspace.ts";
 
+// agentOS currently carries RivetKit 2.3.9 while this app uses 2.3.10. Their
+// setup functions are runtime-compatible, but Registry's private type identity
+// differs across those package instances.
+const setup: typeof rivetSetup =
+  process.env.AGENT_RUNTIME === "agentos"
+    ? (agentOsSetup as unknown as typeof rivetSetup)
+    : rivetSetup;
+
 export const registry = setup({
-  use: { chatThread, org, workspace },
+  use: { chatThread, chatThreadAgentOs, org, workspace },
   envoy: { version: Number(process.env.RIVET_ENVOY_VERSION ?? "1") },
 });
 

--- a/agentos-platform/src/server/registry.ts
+++ b/agentos-platform/src/server/registry.ts
@@ -1,0 +1,11 @@
+import { setup } from "rivetkit";
+import { chatThread } from "./actors/chat-thread.ts";
+import { org } from "./actors/org.ts";
+import { workspace } from "./actors/workspace.ts";
+
+export const registry = setup({
+  use: { chatThread, org, workspace },
+  envoy: { version: Number(process.env.RIVET_ENVOY_VERSION ?? "1") },
+});
+
+export type AppRegistry = typeof registry;

--- a/agentos-platform/src/shared/billing-plans.ts
+++ b/agentos-platform/src/shared/billing-plans.ts
@@ -1,0 +1,154 @@
+export const BILLING_PLANS = [
+  "free",
+  "payg",
+  "starter",
+  "pro",
+  "team",
+  "enterprise",
+] as const;
+
+export type BillingPlan = (typeof BILLING_PLANS)[number];
+
+export interface BillingPlanLimits {
+  plan: BillingPlan;
+  label: string;
+  monthlyPriceCents: number | null;
+  minimumSeats: number;
+  includedWorkspaceCount: number | null;
+  storageGbPerWorkspace: number | null;
+  includedCreditCentsPerSeat: number;
+  includedCreditCentsBase: number;
+  maxDeployedAppsPerWorkspace: number | null;
+  maxCustomDomains: number | null;
+  maxCronJobsPerWorkspace: number | null;
+  maxCronJobsPerUser: number | null;
+  minCronIntervalMs: number | null;
+  byokOnly: boolean;
+  emailInbox: boolean;
+}
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export const BILLING_PLAN_LIMITS: Record<BillingPlan, BillingPlanLimits> = {
+  free: {
+    plan: "free",
+    label: "Free",
+    monthlyPriceCents: 0,
+    minimumSeats: 1,
+    includedWorkspaceCount: 1,
+    storageGbPerWorkspace: 5,
+    includedCreditCentsPerSeat: 0,
+    includedCreditCentsBase: 0,
+    maxDeployedAppsPerWorkspace: 3,
+    maxCustomDomains: 0,
+    maxCronJobsPerWorkspace: 1,
+    maxCronJobsPerUser: null,
+    minCronIntervalMs: DAY_MS,
+    byokOnly: true,
+    emailInbox: false,
+  },
+  payg: {
+    plan: "payg",
+    label: "Free",
+    monthlyPriceCents: 0,
+    minimumSeats: 1,
+    includedWorkspaceCount: 1,
+    storageGbPerWorkspace: 5,
+    includedCreditCentsPerSeat: 0,
+    includedCreditCentsBase: 0,
+    maxDeployedAppsPerWorkspace: 3,
+    maxCustomDomains: 0,
+    maxCronJobsPerWorkspace: 1,
+    maxCronJobsPerUser: null,
+    minCronIntervalMs: DAY_MS,
+    byokOnly: false,
+    emailInbox: false,
+  },
+  starter: {
+    plan: "starter",
+    label: "Starter",
+    monthlyPriceCents: 1000,
+    minimumSeats: 1,
+    includedWorkspaceCount: 1,
+    storageGbPerWorkspace: 50,
+    includedCreditCentsPerSeat: 0,
+    includedCreditCentsBase: 1000,
+    maxDeployedAppsPerWorkspace: 30,
+    maxCustomDomains: 10,
+    maxCronJobsPerWorkspace: 1,
+    maxCronJobsPerUser: null,
+    minCronIntervalMs: HOUR_MS,
+    byokOnly: false,
+    emailInbox: true,
+  },
+  pro: {
+    plan: "pro",
+    label: "Pro",
+    monthlyPriceCents: 4000,
+    minimumSeats: 1,
+    includedWorkspaceCount: 1,
+    storageGbPerWorkspace: 100,
+    includedCreditCentsPerSeat: 0,
+    includedCreditCentsBase: 4000,
+    maxDeployedAppsPerWorkspace: null,
+    maxCustomDomains: null,
+    maxCronJobsPerWorkspace: 50,
+    maxCronJobsPerUser: null,
+    minCronIntervalMs: 5 * MINUTE_MS,
+    byokOnly: false,
+    emailInbox: true,
+  },
+  team: {
+    plan: "team",
+    label: "Team",
+    monthlyPriceCents: 5000,
+    minimumSeats: 3,
+    includedWorkspaceCount: 2,
+    storageGbPerWorkspace: 100,
+    includedCreditCentsPerSeat: 5000,
+    includedCreditCentsBase: 0,
+    maxDeployedAppsPerWorkspace: null,
+    maxCustomDomains: null,
+    maxCronJobsPerWorkspace: null,
+    maxCronJobsPerUser: 50,
+    minCronIntervalMs: 5 * MINUTE_MS,
+    byokOnly: false,
+    emailInbox: true,
+  },
+  enterprise: {
+    plan: "enterprise",
+    label: "Enterprise",
+    monthlyPriceCents: null,
+    minimumSeats: 1,
+    includedWorkspaceCount: null,
+    storageGbPerWorkspace: null,
+    includedCreditCentsPerSeat: 0,
+    includedCreditCentsBase: 0,
+    maxDeployedAppsPerWorkspace: null,
+    maxCustomDomains: null,
+    maxCronJobsPerWorkspace: null,
+    maxCronJobsPerUser: null,
+    minCronIntervalMs: null,
+    byokOnly: false,
+    emailInbox: true,
+  },
+};
+
+export function includedCreditsForPlan(
+  plan: BillingPlan,
+  seatCount: number | null | undefined,
+): number {
+  const limits = BILLING_PLAN_LIMITS[plan];
+  const seats = Number.isFinite(seatCount)
+    ? Math.max(limits.minimumSeats, Math.floor(seatCount ?? limits.minimumSeats))
+    : limits.minimumSeats;
+  return (
+    limits.includedCreditCentsBase + limits.includedCreditCentsPerSeat * seats
+  );
+}
+
+export function planAllowsHostedModels(plan: BillingPlan): boolean {
+  return !BILLING_PLAN_LIMITS[plan].byokOnly;
+}

--- a/agentos-platform/src/shared/events.ts
+++ b/agentos-platform/src/shared/events.ts
@@ -1,0 +1,116 @@
+/**
+ * Websocket / event-bus contracts between agentOS server and web client.
+ */
+
+import type { ChatMessage, UiMessage, UiPart } from "./messages";
+import type { ThreadState } from "./thread-state";
+
+// ---------------------------------------------------------------------------
+// Turn lifecycle
+// ---------------------------------------------------------------------------
+
+export type TurnStatus = "idle" | "streaming" | "recovering" | "error";
+
+// ---------------------------------------------------------------------------
+// Client → server inputs
+// ---------------------------------------------------------------------------
+
+/** User send payload. */
+export type SendMessageInput = {
+  content: string;
+  /** Client-generated delivery id for reconnect-safe sends. */
+  clientMessageId: string;
+};
+
+/** Answer to a pending AskUserQuestion prompt. */
+export type AnswerQuestionInput = {
+  questionId: string;
+  /** Map of question text → selected label (or Other free text). */
+  answers: Record<string, string>;
+};
+
+/** Client response to a tool permission gate. */
+export type PermissionDecisionInput = {
+  requestId: string;
+  decision: "allow" | "deny" | "allow_always";
+};
+
+// ---------------------------------------------------------------------------
+// Server → client events
+// ---------------------------------------------------------------------------
+
+export type MessageUpsertEvent = {
+  type: "messageUpsert";
+  /** Full message snapshot (ChatMessage and/or UiMessage). */
+  message: ChatMessage | UiMessage;
+};
+
+/** Incremental part/text append onto an in-flight assistant message. */
+export type MessageDeltaEvent = {
+  type: "messageDelta";
+  messageId: string;
+  /** Appended or replaced parts for this delta. */
+  parts?: UiPart[];
+  /** Convenience text append when only streaming plain text. */
+  textDelta?: string;
+};
+
+/** Transient live tool stdout/stderr (also available as a UiPart). */
+export type ToolStreamEvent = {
+  type: "toolStream";
+  toolCallId: string;
+  text: string;
+  /** Monotonic per-tool sequence; clients ignore non-advancing seq. */
+  seq: number;
+};
+
+/** Partial thread-state patch; missing keys are left unchanged. */
+export type StateEvent = {
+  type: "state";
+  state: Partial<ThreadState>;
+};
+
+export type TurnStatusEvent = {
+  type: "turnStatus";
+  status: TurnStatus;
+  /** Optional human-readable detail when status is error. */
+  errorMessage?: string;
+};
+
+/** Server asks the user to approve a tool call before execution. */
+export type PermissionRequestEvent = {
+  type: "permissionRequest";
+  requestId: string;
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  /** Short description shown in the permission UI. */
+  description?: string;
+};
+
+export type PermissionResolvedEvent = {
+  type: "permissionResolved";
+  requestId: string;
+  decision: "allow" | "deny" | "allow_always";
+};
+
+export type ErrorEvent = {
+  type: "error";
+  error: string;
+  /** Optional stable id for one-shot display / dismissal. */
+  id?: string;
+  status?: number;
+};
+
+/**
+ * Discriminated union of all server → client chat events.
+ */
+export type ChatEvent =
+  | MessageUpsertEvent
+  | MessageDeltaEvent
+  | ToolStreamEvent
+  | StateEvent
+  | TurnStatusEvent
+  | PermissionRequestEvent
+  | PermissionResolvedEvent
+  | ErrorEvent;

--- a/agentos-platform/src/shared/index.ts
+++ b/agentos-platform/src/shared/index.ts
@@ -2,6 +2,18 @@
  * Shared agentOS types — safe for both server and web (no React / Cloudflare).
  */
 
+export {
+  BILLING_PLANS,
+  BILLING_PLAN_LIMITS,
+  includedCreditsForPlan,
+  planAllowsHostedModels,
+} from "./billing-plans";
+
+export type {
+  BillingPlan,
+  BillingPlanLimits,
+} from "./billing-plans";
+
 export type {
   TextBlock,
   ToolUseBlock,

--- a/agentos-platform/src/shared/index.ts
+++ b/agentos-platform/src/shared/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared agentOS types — safe for both server and web (no React / Cloudflare).
+ */
+
+export type {
+  TextBlock,
+  ToolUseBlock,
+  ToolResultBlock,
+  ThinkingBlock,
+  ErrorBlock,
+  ContentBlock,
+  ChatRole,
+  ChatMessage,
+  UiTextPart,
+  UiReasoningPart,
+  UiToolCallPart,
+  UiToolResultPart,
+  UiDataErrorPart,
+  TodoStatus,
+  TodoItem,
+  UiDataTodosPart,
+  UiDataToolStreamPart,
+  UiPart,
+  UiMessage,
+} from "./messages";
+
+export type {
+  AskUserQuestionOption,
+  AskUserQuestionItem,
+  AskUserQuestion,
+  ThreadLastError,
+  ThreadState,
+} from "./thread-state";
+
+export { EMPTY_THREAD_STATE } from "./thread-state";
+
+export type {
+  TurnStatus,
+  SendMessageInput,
+  AnswerQuestionInput,
+  PermissionDecisionInput,
+  MessageUpsertEvent,
+  MessageDeltaEvent,
+  ToolStreamEvent,
+  StateEvent,
+  TurnStatusEvent,
+  PermissionRequestEvent,
+  PermissionResolvedEvent,
+  ErrorEvent,
+  ChatEvent,
+} from "./events";
+
+export {
+  SLASH_COMMANDS,
+  MANUAL_COMPACT_COMMAND,
+  isSlashCommand,
+  isManualCompactCommand,
+} from "./slash-commands";
+
+export type { SlashCommand } from "./slash-commands";

--- a/agentos-platform/src/shared/messages.ts
+++ b/agentos-platform/src/shared/messages.ts
@@ -1,0 +1,185 @@
+/**
+ * Shared chat message + streaming UI part types for agentOS.
+ * Mirrors the ContentBlock surface camelAI Chat renders, plus a simplified
+ * UIMessage-like part model for live streaming (no AI SDK dependency).
+ */
+
+// ---------------------------------------------------------------------------
+// Content blocks (durable / render transcript)
+// ---------------------------------------------------------------------------
+
+/** Plain assistant or user text. */
+export type TextBlock = {
+  type: "text";
+  text: string;
+};
+
+/** Tool invocation issued by the model. */
+export type ToolUseBlock = {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+
+/** Result paired to a prior tool_use by id. */
+export type ToolResultBlock = {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string | ContentBlock[];
+  /** True when the tool execution failed. */
+  is_error?: boolean;
+  /** Optional structured metadata (diff, patch, etc.). */
+  details?: Record<string, unknown>;
+};
+
+/** Extended thinking / reasoning text. */
+export type ThinkingBlock = {
+  type: "thinking";
+  thinking: string;
+  /** Optional provider signature for verified thinking blocks. */
+  signature?: string;
+};
+
+/** Terminal or inline turn error surfaced in the transcript. */
+export type ErrorBlock = {
+  type: "error";
+  error: string;
+  title?: string;
+  status?: number;
+  errorType?: string;
+};
+
+/**
+ * Structured message content blocks.
+ * Subset of camelAI ContentBlock: text | tool_use | tool_result | thinking | error.
+ */
+export type ContentBlock =
+  | TextBlock
+  | ToolUseBlock
+  | ToolResultBlock
+  | ThinkingBlock
+  | ErrorBlock;
+
+// ---------------------------------------------------------------------------
+// Chat messages (legacy-style render shape)
+// ---------------------------------------------------------------------------
+
+export type ChatRole = "user" | "assistant";
+
+/**
+ * A single chat transcript message.
+ * `content` may be plain text (user) or structured blocks (assistant).
+ */
+export type ChatMessage = {
+  id: string;
+  threadId: string;
+  role: ChatRole;
+  content: string | ContentBlock[];
+  /** Creation time (ms since epoch). */
+  createdAt: number;
+  /** Client-generated id used to recover sends across reconnects. */
+  clientMessageId?: string;
+  /** True while this assistant message is still being streamed. */
+  isStreaming?: boolean;
+  /** Model-reported duration of the completed turn (ms). */
+  turnDurationMs?: number;
+};
+
+// ---------------------------------------------------------------------------
+// UI parts (simplified UIMessage-like streaming model)
+// ---------------------------------------------------------------------------
+
+export type UiTextPart = {
+  type: "text";
+  text: string;
+  /** Streaming lifecycle; omit or `done` when complete. */
+  state?: "streaming" | "done";
+};
+
+export type UiReasoningPart = {
+  type: "reasoning";
+  text: string;
+  state?: "streaming" | "done";
+};
+
+export type UiToolCallPart = {
+  type: "tool-call";
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  state?: "input-streaming" | "input-available" | "output-available" | "output-error";
+};
+
+export type UiToolResultPart = {
+  type: "tool-result";
+  toolCallId: string;
+  toolName?: string;
+  output: unknown;
+  isError?: boolean;
+};
+
+/** Durable terminal error carried on the message (survives reload). */
+export type UiDataErrorPart = {
+  type: "data-error";
+  id?: string;
+  data: {
+    error: string;
+    title?: string;
+    status?: number | string | null;
+    errorType?: string | null;
+  };
+};
+
+export type TodoStatus = "pending" | "in_progress" | "completed";
+
+export type TodoItem = {
+  content: string;
+  status: TodoStatus;
+  /** Present-tense label shown while the todo is active. */
+  activeForm: string;
+};
+
+/** In-turn plan / todo panel. */
+export type UiDataTodosPart = {
+  type: "data-todos";
+  id?: string;
+  data: {
+    explanation?: string;
+    todos: TodoItem[];
+  };
+};
+
+/**
+ * Transient live tool stdout/stderr delta.
+ * Clients accumulate by toolCallId using monotonically increasing `seq`.
+ */
+export type UiDataToolStreamPart = {
+  type: "data-tool-stream";
+  data: {
+    toolCallId: string;
+    text: string;
+    seq: number;
+  };
+};
+
+export type UiPart =
+  | UiTextPart
+  | UiReasoningPart
+  | UiToolCallPart
+  | UiToolResultPart
+  | UiDataErrorPart
+  | UiDataTodosPart
+  | UiDataToolStreamPart;
+
+/**
+ * Simplified UIMessage: id + role + ordered parts.
+ * Prefer this for streaming; adapt to ChatMessage for legacy render paths.
+ */
+export type UiMessage = {
+  id: string;
+  role: ChatRole;
+  parts: UiPart[];
+  /** Creation time (ms since epoch). */
+  createdAt: number;
+};

--- a/agentos-platform/src/shared/slash-commands.ts
+++ b/agentos-platform/src/shared/slash-commands.ts
@@ -1,0 +1,27 @@
+/**
+ * Allowlisted slash commands — same set as camelAI.
+ * Leading slash is part of the command string.
+ */
+
+export const SLASH_COMMANDS = [
+  "/compact",
+  "/context",
+  "/debug",
+  "/insights",
+  "/security-review",
+] as const;
+
+export type SlashCommand = (typeof SLASH_COMMANDS)[number];
+
+const SLASH_COMMAND_SET = new Set<string>(SLASH_COMMANDS);
+
+export function isSlashCommand(value: string): value is SlashCommand {
+  return SLASH_COMMAND_SET.has(value.trim());
+}
+
+/** Manual context compaction. */
+export const MANUAL_COMPACT_COMMAND: SlashCommand = "/compact";
+
+export function isManualCompactCommand(value: string): boolean {
+  return value.trim() === MANUAL_COMPACT_COMMAND;
+}

--- a/agentos-platform/src/shared/thread-state.ts
+++ b/agentos-platform/src/shared/thread-state.ts
@@ -1,0 +1,81 @@
+/**
+ * Coarse thread UI state pushed over the chat websocket / event bus.
+ * Intentionally small — streaming content lives on messages, not here.
+ */
+
+import type { TodoItem } from "./messages";
+
+// ---------------------------------------------------------------------------
+// AskUserQuestion
+// ---------------------------------------------------------------------------
+
+export type AskUserQuestionOption = {
+  label: string;
+  description?: string;
+};
+
+export type AskUserQuestionItem = {
+  /** Prompt text; also used as the answer map key. */
+  question: string;
+  /** Short header shown above the question. */
+  header: string;
+  options: AskUserQuestionOption[];
+  multiSelect?: boolean;
+  /** When true (default), allow a free-text "Other" answer. */
+  allowOther?: boolean;
+};
+
+/**
+ * Pending clarifying-question prompt shown in the chat composer area.
+ * Mirrors camelAI AskUserQuestionData.
+ */
+export type AskUserQuestion = {
+  questionId: string;
+  /** Tool-use id when the prompt came from the AskUserQuestion tool. */
+  toolUseId?: string;
+  questions: AskUserQuestionItem[];
+};
+
+// ---------------------------------------------------------------------------
+// Thread state
+// ---------------------------------------------------------------------------
+
+/** Terminal error surfaced once via thread state (composer recovery). */
+export type ThreadLastError = {
+  id: string;
+  error: string;
+  title?: string;
+  status?: number | string | null;
+  errorType?: string | null;
+};
+
+/**
+ * Coarse Agent-state payload for a chat thread.
+ * Clients merge partial updates from `ChatEvent` of type `state`.
+ */
+export type ThreadState = {
+  title: string | null;
+  /** Active model id (provider-specific string). */
+  model: string | null;
+  /** Live preview URL, when a deploy/notebook/file is open. */
+  previewUrl: string | null;
+  /** Bumped when the preview target should reload. */
+  previewVersion: number;
+  currentTodos: TodoItem[];
+  pendingQuestion: AskUserQuestion | null;
+  lastError: ThreadLastError | null;
+  /** Context window fill estimate, 0–100; null when unknown. */
+  contextUsedPercent: number | null;
+};
+
+/** Empty / default thread state for a new session. */
+export const EMPTY_THREAD_STATE: ThreadState = {
+  title: null,
+  model: null,
+  previewUrl: null,
+  previewVersion: 0,
+  currentTodos: [],
+  pendingQuestion: null,
+  lastError: null,
+  contextUsedPercent: null,
+};

--- a/agentos-platform/tests/acp-mapper.test.ts
+++ b/agentos-platform/tests/acp-mapper.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "vitest";
+import {
+  mapAcpSessionEntries,
+  mapAcpSessionEntry,
+} from "../src/server/chat/acp-mapper.ts";
+
+const options = { messageId: "assistant:client-1" };
+
+describe("ACP session event mapper", () => {
+  test("maps agent text and thought chunks", () => {
+    expect(
+      mapAcpSessionEntries(
+        [
+          {
+            type: "agent_message_chunk",
+            content: { type: "text", text: "Hello" },
+          },
+          {
+            type: "agent_thought_chunk",
+            content: { type: "text", text: "Considering files" },
+          },
+        ],
+        options,
+      ),
+    ).toEqual([
+      {
+        type: "messageDelta",
+        messageId: "assistant:client-1",
+        textDelta: "Hello",
+      },
+      {
+        type: "messageDelta",
+        messageId: "assistant:client-1",
+        parts: [
+          {
+            type: "reasoning",
+            text: "Considering files",
+            state: "streaming",
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("maps tool calls and terminal updates", () => {
+    expect(
+      mapAcpSessionEntry(
+        {
+          type: "tool_call",
+          toolCallId: "tool-1",
+          title: "Read file",
+          kind: "read",
+          rawInput: { path: "README.md" },
+          status: "in_progress",
+        },
+        options,
+      ),
+    ).toEqual([
+      {
+        type: "messageDelta",
+        messageId: "assistant:client-1",
+        parts: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "Read file",
+            input: { path: "README.md" },
+            state: "input-available",
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      mapAcpSessionEntry(
+        {
+          type: "tool_call_update",
+          toolCallId: "tool-1",
+          title: "Read file",
+          status: "completed",
+          content: [
+            {
+              type: "content",
+              content: { type: "text", text: "file contents" },
+            },
+          ],
+        },
+        options,
+      ),
+    ).toEqual([
+      {
+        type: "messageDelta",
+        messageId: "assistant:client-1",
+        parts: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "Read file",
+            input: {},
+            state: "output-available",
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-1",
+            toolName: "Read file",
+            output: "file contents",
+            isError: false,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("maps plans to thread todos", () => {
+    expect(
+      mapAcpSessionEntry(
+        {
+          type: "plan",
+          entries: [
+            {
+              content: "Inspect the project",
+              status: "completed",
+              priority: "high",
+            },
+            {
+              content: "Implement the change",
+              status: "in_progress",
+              priority: "high",
+            },
+          ],
+        },
+        options,
+      ),
+    ).toEqual([
+      {
+        type: "state",
+        state: {
+          currentTodos: [
+            {
+              content: "Inspect the project",
+              activeForm: "Inspect the project",
+              status: "completed",
+            },
+            {
+              content: "Implement the change",
+              activeForm: "Implement the change",
+              status: "in_progress",
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("maps permission lifecycle events", () => {
+    expect(
+      mapAcpSessionEntries(
+        [
+          {
+            type: "permission_request",
+            requestId: "permission-1",
+            toolCall: {
+              toolCallId: "tool-1",
+              title: "Run command",
+              kind: "execute",
+              rawInput: { command: "bun test" },
+            },
+          },
+          {
+            type: "permission_response",
+            requestId: "permission-1",
+            outcome: {
+              outcome: "selected",
+              optionId: "allow_always",
+            },
+          },
+        ],
+        options,
+      ),
+    ).toEqual([
+      {
+        type: "permissionRequest",
+        requestId: "permission-1",
+        toolCallId: "tool-1",
+        toolName: "Run command",
+        input: { command: "bun test" },
+        description: "Run command",
+      },
+      {
+        type: "permissionResolved",
+        requestId: "permission-1",
+        decision: "allow_always",
+      },
+    ]);
+  });
+
+  test("ignores unknown or malformed extension events", () => {
+    expect(
+      mapAcpSessionEntries(
+        [
+          { type: "future_extension", payload: true },
+          { type: "agent_message_chunk", content: { type: "image" } },
+          { notAType: true },
+        ],
+        options,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/agentos-platform/tests/auth-oauth.test.ts
+++ b/agentos-platform/tests/auth-oauth.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForProfile,
+  getOAuthProviderConfig,
+} from "../src/server/auth/oauth.ts";
+
+describe("OAuth", () => {
+  it("builds provider authorization URLs from environment config", () => {
+    const config = getOAuthProviderConfig("github", {
+      GITHUB_CLIENT_ID: "client-id",
+      GITHUB_CLIENT_SECRET: "client-secret",
+      GITHUB_AUTHORIZE_URL: "https://identity.example/authorize",
+    });
+    const authorizeUrl = new URL(
+      buildAuthorizeUrl(config, "state-value", "https://app.example/callback"),
+    );
+
+    expect(authorizeUrl.origin).toBe("https://identity.example");
+    expect(authorizeUrl.searchParams.get("client_id")).toBe("client-id");
+    expect(authorizeUrl.searchParams.get("state")).toBe("state-value");
+    expect(authorizeUrl.searchParams.get("scope")).toContain("user:email");
+  });
+
+  it("exchanges a code and maps the provider profile with mocked fetch", async () => {
+    const config = getOAuthProviderConfig("google", {
+      GOOGLE_CLIENT_ID: "google-client",
+      GOOGLE_CLIENT_SECRET: "google-secret",
+      GOOGLE_TOKEN_URL: "https://identity.example/token",
+      GOOGLE_USER_INFO_URL: "https://identity.example/userinfo",
+    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "access-token" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            sub: "google-user-1",
+            email: "Ada@Example.com",
+            name: "Ada Lovelace",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+    await expect(
+      exchangeCodeForProfile(
+        config,
+        "authorization-code",
+        "https://app.example/callback",
+        fetchMock,
+      ),
+    ).resolves.toEqual({
+      providerUserId: "google-user-1",
+      email: "ada@example.com",
+      name: "Ada Lovelace",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer access-token",
+        }),
+      }),
+    );
+  });
+
+  it("throws a clear error when provider credentials are absent", async () => {
+    const config = getOAuthProviderConfig("github", {});
+    expect(() =>
+      buildAuthorizeUrl(config, "state", "https://app.example/callback"),
+    ).toThrow("OAuth not configured for github");
+    await expect(
+      exchangeCodeForProfile(
+        config,
+        "code",
+        "https://app.example/callback",
+      ),
+    ).rejects.toThrow("OAuth not configured for github");
+  });
+});

--- a/agentos-platform/tests/auth-password.test.ts
+++ b/agentos-platform/tests/auth-password.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  hashPassword,
+  verifyPassword,
+} from "../src/server/auth/password.ts";
+
+describe("password auth", () => {
+  it("hashes and verifies passwords with a unique salt", async () => {
+    const first = await hashPassword("correct horse battery staple");
+    const second = await hashPassword("correct horse battery staple");
+
+    expect(first).toMatch(/^scrypt\$/);
+    expect(second).not.toBe(first);
+    await expect(
+      verifyPassword("correct horse battery staple", first),
+    ).resolves.toBe(true);
+    await expect(verifyPassword("incorrect", first)).resolves.toBe(false);
+  });
+
+  it("rejects malformed hashes without throwing", async () => {
+    await expect(verifyPassword("password", "not-a-hash")).resolves.toBe(false);
+    await expect(
+      verifyPassword("password", "scrypt$999999$8$1$salt$hash"),
+    ).resolves.toBe(false);
+  });
+});

--- a/agentos-platform/tests/auth-proxy.test.ts
+++ b/agentos-platform/tests/auth-proxy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  cloudflareAccessProxyAuth,
+  pomeriumProxyAuth,
+  resolveProxyAuth,
+} from "../src/server/auth/proxy-auth.ts";
+
+describe("proxy authentication", () => {
+  it("prefers Cloudflare Access's authenticated email header", () => {
+    const headers = new Headers({
+      "CF-Access-Authenticated-User-Email": "Ada@Example.com",
+      "CF_Authorization": "invalid.jwt.value",
+    });
+    expect(cloudflareAccessProxyAuth.extractIdentity(headers)).toEqual({
+      email: "ada@example.com",
+      name: "ada",
+    });
+  });
+
+  it("can read a simple Cloudflare Access JWT payload", () => {
+    const payload = Buffer.from(
+      JSON.stringify({
+        email: "grace@example.com",
+        name: "Grace Hopper",
+        groups: ["engineering"],
+      }),
+    ).toString("base64url");
+    const token = `header.${payload}.signature`;
+    expect(
+      resolveProxyAuth(
+        { CF_Authorization: token },
+        "cloudflare-access",
+      ),
+    ).toEqual({
+      email: "grace@example.com",
+      name: "Grace Hopper",
+      groups: ["engineering"],
+    });
+  });
+
+  it("reads Pomerium claim headers and groups", () => {
+    expect(
+      pomeriumProxyAuth.extractIdentity(
+        new Headers({
+          "X-Pomerium-Email": "linus@example.com",
+          "X-Pomerium-Claim-Name": "Linus",
+          "X-Pomerium-Claim-Groups": '["admins","engineering"]',
+        }),
+      ),
+    ).toEqual({
+      email: "linus@example.com",
+      name: "Linus",
+      groups: ["admins", "engineering"],
+    });
+  });
+
+  it("returns null when proxy auth is off or identity is absent", () => {
+    expect(resolveProxyAuth(new Headers(), "off")).toBeNull();
+    expect(resolveProxyAuth(new Headers(), "pomerium")).toBeNull();
+  });
+});

--- a/agentos-platform/tests/auth-service.test.ts
+++ b/agentos-platform/tests/auth-service.test.ts
@@ -1,0 +1,160 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthService } from "../src/server/auth/service.ts";
+import {
+  serializeSessionCookie,
+  SessionService,
+} from "../src/server/auth/session.ts";
+import { createAuthHttpHandler } from "../src/server/http/api.ts";
+import { createPlatform, type Platform } from "../src/server/platform/index.ts";
+
+const tempDirs: string[] = [];
+
+function createServices(
+  proxyAuthMode: "off" | "cloudflare-access" | "pomerium" = "off",
+): {
+  platform: Platform;
+  sessions: SessionService;
+  auth: AuthService;
+} {
+  const dataDir = mkdtempSync(join(tmpdir(), "agentos-auth-service-"));
+  tempDirs.push(dataDir);
+  const platform = createPlatform({ dataDir });
+  const sessions = new SessionService(platform.store);
+  const auth = new AuthService(platform.identity, sessions, { proxyAuthMode });
+  return { platform, sessions, auth };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("AuthService", () => {
+  it("registers a complete tenant and logs the user in by password", async () => {
+    const { platform, auth } = createServices();
+    const registration = await auth.registerPassword({
+      email: "New.User@example.com",
+      password: "a strong test password",
+      name: "New User",
+    });
+    const user = platform.identity.getUser(registration.userId);
+
+    expect(registration.provider).toBe("password");
+    expect(user).toEqual(
+      expect.objectContaining({
+        email: "new.user@example.com",
+        name: "New User",
+        orgId: registration.orgId,
+      }),
+    );
+    expect(platform.store.listByPrefix("workspace:")).toHaveLength(1);
+    expect(platform.identity.getPasswordHash(registration.userId)).toMatch(
+      /^scrypt\$/,
+    );
+
+    const login = await auth.loginPassword({
+      email: "new.user@example.com",
+      password: "a strong test password",
+    });
+    expect(login.userId).toBe(registration.userId);
+    expect(
+      auth.requireSession(serializeSessionCookie(login.sessionId)).user,
+    ).toEqual(user);
+  });
+
+  it("rejects duplicate registration and invalid credentials", async () => {
+    const { auth } = createServices();
+    const input = {
+      email: "user@example.com",
+      password: "password one",
+      name: "User",
+    };
+    await auth.registerPassword(input);
+    await expect(auth.registerPassword(input)).rejects.toThrow(/already exists/);
+    await expect(
+      auth.loginPassword({
+        email: input.email,
+        password: "wrong password",
+      }),
+    ).rejects.toThrow("Invalid email or password");
+  });
+
+  it("finds or creates users from proxy and OAuth identities", () => {
+    const { platform, auth } = createServices("pomerium");
+    const proxySession = auth.loginFromProxy(
+      new Headers({
+        "X-Pomerium-Claim-Email": "external@example.com",
+        "X-Pomerium-Claim-Name": "External User",
+      }),
+    );
+    const oauthSession = auth.loginFromOAuthProfile({
+      providerUserId: "provider-123",
+      email: "external@example.com",
+      name: "External User",
+    });
+
+    expect(proxySession.provider).toBe("proxy");
+    expect(oauthSession.provider).toBe("oauth");
+    expect(oauthSession.userId).toBe(proxySession.userId);
+    expect(platform.store.listByPrefix("user:")).toHaveLength(1);
+    expect(platform.store.listByPrefix("org:")).toHaveLength(1);
+  });
+
+  it("rejects missing and revoked sessions", async () => {
+    const { auth, sessions } = createServices();
+    expect(() => auth.requireSession(null)).toThrow("Authentication required");
+    const session = await auth.registerPassword({
+      email: "user@example.com",
+      password: "password",
+      name: "User",
+    });
+    sessions.revokeSession(session.sessionId);
+    expect(() =>
+      auth.requireSession(serializeSessionCookie(session.sessionId)),
+    ).toThrow("Authentication required");
+  });
+
+  it("serves register, me, and logout through the HTTP API", async () => {
+    const { platform } = createServices();
+    const handler = createAuthHttpHandler({ platform });
+    const registration = await handler(
+      new Request("http://localhost/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "http@example.com",
+          password: "http password",
+          name: "HTTP User",
+        }),
+      }),
+    );
+    expect(registration.status).toBe(201);
+    const cookie = registration.headers.get("set-cookie");
+    expect(cookie).toContain("camelai_session=");
+
+    const me = await handler(
+      new Request("http://localhost/api/auth/me", {
+        headers: { Cookie: cookie ?? "" },
+      }),
+    );
+    expect(me.status).toBe(200);
+    expect(await me.json()).toEqual(
+      expect.objectContaining({
+        user: expect.objectContaining({ email: "http@example.com" }),
+      }),
+    );
+
+    const logout = await handler(
+      new Request("http://localhost/api/auth/logout", {
+        method: "POST",
+        headers: { Cookie: cookie ?? "" },
+      }),
+    );
+    expect(logout.status).toBe(200);
+    expect(logout.headers.get("set-cookie")).toContain("Max-Age=0");
+  });
+});

--- a/agentos-platform/tests/auth-session.test.ts
+++ b/agentos-platform/tests/auth-session.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  parseSessionCookie,
+  serializeSessionCookie,
+  SessionService,
+} from "../src/server/auth/session.ts";
+import { Store } from "../src/server/platform/store.ts";
+
+const tempDirs: string[] = [];
+
+function createStore(): Store {
+  const dataDir = mkdtempSync(join(tmpdir(), "agentos-auth-session-"));
+  tempDirs.push(dataDir);
+  return new Store({ dataDir });
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("SessionService", () => {
+  it("creates, retrieves, touches, and revokes persisted sessions", () => {
+    let now = new Date("2026-01-01T00:00:00.000Z");
+    const store = createStore();
+    const sessions = new SessionService(store, {
+      ttlSeconds: 60,
+      now: () => now,
+    });
+    const created = sessions.createSession({
+      userId: "user_1",
+      orgId: "org_1",
+      provider: "password",
+    });
+
+    expect(store.get(`session:${created.sessionId}`)).toEqual(created);
+    expect(sessions.getSession(created.sessionId)).toEqual(created);
+
+    now = new Date("2026-01-01T00:00:30.000Z");
+    const touched = sessions.touchSession(created.sessionId);
+    expect(touched?.expiresAt).toBe("2026-01-01T00:01:30.000Z");
+    expect(sessions.revokeSession(created.sessionId)).toBe(true);
+    expect(sessions.getSession(created.sessionId)).toBeUndefined();
+  });
+
+  it("deletes expired sessions on read", () => {
+    let now = new Date("2026-01-01T00:00:00.000Z");
+    const store = createStore();
+    const sessions = new SessionService(store, {
+      ttlSeconds: 10,
+      now: () => now,
+    });
+    const session = sessions.createSession({
+      userId: "user_1",
+      orgId: "org_1",
+      provider: "oauth",
+    });
+
+    now = new Date("2026-01-01T00:00:11.000Z");
+    expect(sessions.getSession(session.sessionId)).toBeUndefined();
+    expect(store.get(`session:${session.sessionId}`)).toBeUndefined();
+  });
+});
+
+describe("session cookies", () => {
+  it("serializes a secure HTTP-only cookie and parses it", () => {
+    const cookie = serializeSessionCookie("abc/123", {
+      secure: true,
+      maxAge: 60,
+    });
+    expect(cookie).toContain("camelai_session=abc%2F123");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Lax");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("Secure");
+    expect(parseSessionCookie(`theme=dark; ${cookie}`)).toBe("abc/123");
+  });
+
+  it("returns null when the session cookie is missing or malformed", () => {
+    expect(parseSessionCookie(null)).toBeNull();
+    expect(parseSessionCookie("other=value")).toBeNull();
+    expect(parseSessionCookie("camelai_session=%E0%A4%A")).toBeNull();
+  });
+});

--- a/agentos-platform/tests/billing-plans.test.ts
+++ b/agentos-platform/tests/billing-plans.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  BILLING_PLANS,
+  BILLING_PLAN_LIMITS,
+  includedCreditsForPlan,
+  planAllowsHostedModels,
+} from "../src/shared/billing-plans.ts";
+
+describe("billing plans", () => {
+  it("ports every camelAI plan and its core limits", () => {
+    expect(BILLING_PLANS).toEqual([
+      "free",
+      "payg",
+      "starter",
+      "pro",
+      "team",
+      "enterprise",
+    ]);
+    expect(BILLING_PLAN_LIMITS.free.byokOnly).toBe(true);
+    expect(BILLING_PLAN_LIMITS.starter.monthlyPriceCents).toBe(1000);
+    expect(BILLING_PLAN_LIMITS.pro.includedCreditCentsBase).toBe(4000);
+    expect(BILLING_PLAN_LIMITS.team.minimumSeats).toBe(3);
+    expect(BILLING_PLAN_LIMITS.enterprise.includedWorkspaceCount).toBeNull();
+  });
+
+  it("calculates base and seat-based included credits", () => {
+    expect(includedCreditsForPlan("starter", 1)).toBe(1000);
+    expect(includedCreditsForPlan("pro", 20)).toBe(4000);
+    expect(includedCreditsForPlan("team", 1)).toBe(15_000);
+    expect(includedCreditsForPlan("team", 4)).toBe(20_000);
+    expect(includedCreditsForPlan("payg", undefined)).toBe(0);
+  });
+
+  it("only blocks hosted models on the BYOK-only free plan", () => {
+    expect(planAllowsHostedModels("free")).toBe(false);
+    for (const plan of BILLING_PLANS.filter((value) => value !== "free")) {
+      expect(planAllowsHostedModels(plan)).toBe(true);
+    }
+  });
+});

--- a/agentos-platform/tests/billing-service.test.ts
+++ b/agentos-platform/tests/billing-service.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { BillingService } from "../src/server/platform/billing.ts";
+import { Store } from "../src/server/platform/store.ts";
+
+const tempDirs: string[] = [];
+
+function createBilling(): { billing: BillingService; store: Store } {
+  const dataDir = mkdtempSync(join(tmpdir(), "agentos-billing-"));
+  tempDirs.push(dataDir);
+  const store = new Store({ dataDir });
+  return { billing: new BillingService(store), store };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("BillingService accounts", () => {
+  it("creates a pay-as-you-go account with production ledger fields", () => {
+    const { billing } = createBilling();
+    expect(billing.getAccount("org-1")).toMatchObject({
+      orgId: "org-1",
+      plan: "payg",
+      billingStatus: "none",
+      purchasedCreditCents: 0,
+      includedCreditCents: 0,
+      creditGrantTotalCents: 0,
+      usageChargeCents: 0,
+      seatCount: 1,
+    });
+    expect(billing.getCreditBalance("org-1")).toBe(0);
+  });
+
+  it("derives balance from all grant sources minus metered usage", () => {
+    const { billing } = createBilling();
+    billing.grantPurchasedCredits("org-1", 500, "cs_1");
+    billing.grantIncludedCredits("org-1", 1000, "in_1");
+    billing.grantCredits("org-1", 250);
+    billing.consumeCredits("org-1", 600);
+
+    expect(billing.getAccount("org-1")).toMatchObject({
+      purchasedCreditCents: 500,
+      includedCreditCents: 1000,
+      creditGrantTotalCents: 250,
+      usageChargeCents: 600,
+      lastIncludedCreditInvoiceId: "in_1",
+    });
+    expect(billing.getCreditBalance("org-1")).toBe(1150);
+  });
+
+  it("makes Stripe-origin grants idempotent", () => {
+    const { billing } = createBilling();
+    billing.grantPurchasedCredits("org-1", 500, "cs_same");
+    billing.grantPurchasedCredits("org-1", 500, "cs_same");
+    billing.grantIncludedCredits("org-1", 1000, "in_same");
+    billing.grantIncludedCredits("org-1", 1000, "in_same");
+    expect(billing.getCreditBalance("org-1")).toBe(1500);
+  });
+
+  it("enforces hosted-model plan, status, and credit rules", () => {
+    const { billing } = createBilling();
+    billing.grantCredits("org-1", 100);
+    expect(billing.canUseHostedModel("org-1")).toBe(true);
+
+    billing.setPlan("org-1", "free");
+    expect(billing.canUseHostedModel("org-1")).toBe(false);
+
+    billing.setPlan("org-1", "starter");
+    expect(billing.canUseHostedModel("org-1")).toBe(false);
+    billing.setBillingStatus("org-1", "active");
+    expect(billing.canUseHostedModel("org-1")).toBe(true);
+    billing.consumeCredits("org-1", 100);
+    expect(billing.canUseHostedModel("org-1")).toBe(false);
+
+    billing.setPlan("org-1", "enterprise");
+    expect(billing.canUseHostedModel("org-1")).toBe(true);
+  });
+
+  it("normalizes team seats and persists Stripe identifiers", () => {
+    const { billing } = createBilling();
+    billing.setPlan("org-1", "team", 1);
+    billing.setStripeIds("org-1", {
+      customerId: "cus_1",
+      subscriptionId: "sub_1",
+    });
+    expect(billing.getAccount("org-1")).toMatchObject({
+      plan: "team",
+      seatCount: 3,
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_1",
+    });
+  });
+
+  it("preserves balances written by the Phase 1 billing stub", () => {
+    const { billing, store } = createBilling();
+    store.set("billing:legacy", {
+      orgId: "legacy",
+      creditBalanceCents: 375,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(billing.getCreditBalance("legacy")).toBe(375);
+    expect(billing.getAccount("legacy").creditGrantTotalCents).toBe(375);
+  });
+});

--- a/agentos-platform/tests/chat-thread.test.ts
+++ b/agentos-platform/tests/chat-thread.test.ts
@@ -1,13 +1,46 @@
-import { expect, test, type TestContext } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  expect,
+  test,
+  type TestContext,
+} from "vitest";
 import { setupTest } from "rivetkit/test";
+import {
+  createPlatform,
+  setPlatform,
+  type Platform,
+} from "../src/server/platform/index.ts";
 import { registry } from "../src/server/registry.ts";
 
-async function setupChat(c: TestContext) {
+let platform: Platform;
+let dataDir: string;
+
+beforeAll(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "agentos-chat-"));
+  platform = createPlatform({ dataDir });
+  setPlatform(platform);
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+async function setupChat(
+  c: TestContext,
+  options: { grantCredits?: boolean } = {},
+) {
   const { client } = await setupTest(c, registry);
   const suffix = crypto.randomUUID();
   const threadId = `thread-${suffix}`;
   const workspaceId = `workspace-${suffix}`;
   const orgId = `org-${suffix}`;
+  if (options.grantCredits !== false) {
+    platform.billing.grantCredits(orgId, 10_000);
+  }
   const chat = client.chatThread.getOrCreate(threadId, {
     createWithInput: {
       threadId,
@@ -30,7 +63,7 @@ async function waitUntil(check: () => Promise<boolean>): Promise<void> {
 }
 
 test("chatThread persists a happy-path user and assistant exchange", async (c) => {
-  const { chat } = await setupChat(c);
+  const { chat, orgId } = await setupChat(c);
 
   await expect(chat.sendMessage("hello", "client-1")).resolves.toEqual({
     status: "completed",
@@ -49,6 +82,32 @@ test("chatThread persists a happy-path user and assistant exchange", async (c) =
       parts: [{ type: "text", text: "Mock reply: hello", state: "done" }],
     },
   ]);
+  expect(platform.billing.getCreditBalance(orgId)).toBe(9_999);
+  expect(platform.usage.listUsage(orgId)).toMatchObject([
+    { kind: "turn", cents: 1, creditChargeable: true },
+  ]);
+});
+
+test("chatThread denies hosted turns when the org has no credits", async (c) => {
+  const { chat, orgId } = await setupChat(c, { grantCredits: false });
+
+  await expect(chat.sendMessage("hello", "client-denied")).resolves.toEqual({
+    status: "error",
+    messageId: "assistant:client-denied",
+    error: expect.stringMatching(/insufficient credits/i),
+  });
+  expect(platform.billing.getCreditBalance(orgId)).toBe(0);
+  expect(platform.usage.listUsage(orgId)).toEqual([]);
+  await expect(chat.getMessages()).resolves.toEqual([]);
+  await expect(chat.getThreadState()).resolves.toMatchObject({
+    turnStatus: "error",
+    threadState: {
+      lastError: {
+        status: 402,
+        errorType: "credits_denied",
+      },
+    },
+  });
 });
 
 test("chatThread deduplicates client message ids", async (c) => {
@@ -205,7 +264,7 @@ test("workspace actor registers and lists unique threads", async (c) => {
 });
 
 test("chatThread handles allowlisted slash commands without the runtime", async (c) => {
-  const { chat } = await setupChat(c);
+  const { chat, orgId } = await setupChat(c, { grantCredits: false });
 
   await expect(chat.sendMessage("/compact", "client-compact")).resolves.toEqual({
     status: "completed",
@@ -222,6 +281,8 @@ test("chatThread handles allowlisted slash commands without the runtime", async 
       },
     ],
   });
+  expect(platform.billing.getCreditBalance(orgId)).toBe(0);
+  expect(platform.usage.listUsage(orgId)).toEqual([]);
 });
 
 test("chatThread rejects unknown slash commands with an assistant error", async (c) => {

--- a/agentos-platform/tests/chat-thread.test.ts
+++ b/agentos-platform/tests/chat-thread.test.ts
@@ -1,46 +1,103 @@
-import { expect, test } from "vitest";
+import { expect, test, type TestContext } from "vitest";
 import { setupTest } from "rivetkit/test";
-import { EMPTY_THREAD_STATE } from "../src/shared/index.ts";
-import { chatThread } from "../src/server/actors/chat-thread.ts";
 import { registry } from "../src/server/registry.ts";
 
-test("chatThread sends, deduplicates, reports busy, and records tools", async (c) => {
+async function setupChat(c: TestContext) {
   const { client } = await setupTest(c, registry);
   const suffix = crypto.randomUUID();
   const threadId = `thread-${suffix}`;
-  const createWithInput = {
-    threadId,
-    workspaceId: `workspace-${suffix}`,
-    orgId: `org-${suffix}`,
-    projectId: `project-${suffix}`,
-  };
+  const workspaceId = `workspace-${suffix}`;
+  const orgId = `org-${suffix}`;
   const chat = client.chatThread.getOrCreate(threadId, {
-    createWithInput,
+    createWithInput: {
+      threadId,
+      workspaceId,
+      orgId,
+      projectId: `project-${suffix}`,
+    },
+  });
+  return { client, chat, threadId, workspaceId, orgId };
+}
+
+async function waitUntil(check: () => Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!(await check())) {
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for actor state");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+test("chatThread persists a happy-path user and assistant exchange", async (c) => {
+  const { chat } = await setupChat(c);
+
+  await expect(chat.sendMessage("hello", "client-1")).resolves.toEqual({
+    status: "completed",
+    messageId: "assistant:client-1",
   });
 
-  await expect(chat.sendMessage("hello", "client-1")).resolves.toMatchObject({
-    status: "completed",
-  });
-  await expect(chat.sendMessage("hello", "client-1")).resolves.toEqual({
+  await expect(chat.getMessages()).resolves.toMatchObject([
+    {
+      id: "client-1",
+      role: "user",
+      parts: [{ type: "text", text: "hello", state: "done" }],
+    },
+    {
+      id: "assistant:client-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "Mock reply: hello", state: "done" }],
+    },
+  ]);
+});
+
+test("chatThread deduplicates client message ids", async (c) => {
+  const { chat } = await setupChat(c);
+  await chat.sendMessage("hello", "client-1");
+
+  await expect(chat.sendMessage("different", "client-1")).resolves.toEqual({
     status: "duplicate",
     messageId: "client-1",
   });
+  await expect(chat.getMessages()).resolves.toHaveLength(2);
+});
 
-  let messages = await chat.getMessages();
-  expect(messages).toHaveLength(2);
-  expect(messages.map((message) => message.role)).toEqual([
-    "user",
-    "assistant",
-  ]);
+test("chatThread rejects a concurrent send while streaming", async (c) => {
+  const previousDelay = process.env.MOCK_AGENT_DELAY_MS;
+  process.env.MOCK_AGENT_DELAY_MS = "200";
+  try {
+    const { chat } = await setupChat(c);
+    const firstSend = chat.sendMessage("first", "client-first");
+    await waitUntil(async () => {
+      const state = await chat.getThreadState();
+      return state.turnStatus === "streaming";
+    });
+
+    await expect(
+      chat.sendMessage("second", "client-second"),
+    ).resolves.toEqual({ status: "busy" });
+    await expect(firstSend).resolves.toMatchObject({ status: "completed" });
+    await expect(chat.getMessages()).resolves.toHaveLength(2);
+  } finally {
+    if (previousDelay === undefined) {
+      delete process.env.MOCK_AGENT_DELAY_MS;
+    } else {
+      process.env.MOCK_AGENT_DELAY_MS = previousDelay;
+    }
+  }
+});
+
+test("chatThread records tool parts from the mock runtime", async (c) => {
+  const { chat } = await setupChat(c);
 
   await expect(
     chat.sendMessage("please use a tool", "client-tool"),
   ).resolves.toMatchObject({ status: "completed" });
-  messages = await chat.getMessages();
-  const toolAssistant = messages.find(
+  const messages = await chat.getMessages();
+  const assistant = messages.find(
     (message) => message.id === "assistant:client-tool",
   );
-  expect(toolAssistant?.parts).toEqual(
+  expect(assistant?.parts).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         type: "tool-call",
@@ -53,28 +110,138 @@ test("chatThread sends, deduplicates, reports busy, and records tools", async (c
       }),
     ]),
   );
+});
 
-  const sendMessageAction = chatThread.config.actions?.sendMessage;
-  if (typeof sendMessageAction !== "function") {
-    throw new Error("chatThread sendMessage action is unavailable");
+test("chatThread exposes pending questions in thread state", async (c) => {
+  const { chat } = await setupChat(c);
+
+  await chat.sendMessage("ask: Which option?", "client-ask");
+  const state = await chat.getThreadState();
+  expect(state.threadState.pendingQuestion).toMatchObject({
+    questionId: "mock-question-1",
+    questions: [{ question: "Which option?" }],
+  });
+});
+
+test("chatThread stops an in-flight send", async (c) => {
+  const previousDelay = process.env.MOCK_AGENT_DELAY_MS;
+  process.env.MOCK_AGENT_DELAY_MS = "500";
+  try {
+    const { chat } = await setupChat(c);
+    const send = chat.sendMessage("stop this", "client-stop");
+    await waitUntil(async () => {
+      const state = await chat.getThreadState();
+      return state.turnStatus === "streaming";
+    });
+
+    await expect(chat.requestStop()).resolves.toEqual({ status: "stopped" });
+    await expect(send).resolves.toEqual({
+      status: "stopped",
+      messageId: "assistant:client-stop",
+    });
+    await expect(chat.getThreadState()).resolves.toMatchObject({
+      turnStatus: "idle",
+    });
+  } finally {
+    if (previousDelay === undefined) {
+      delete process.env.MOCK_AGENT_DELAY_MS;
+    } else {
+      process.env.MOCK_AGENT_DELAY_MS = previousDelay;
+    }
   }
-  const busyResult = await sendMessageAction(
-    {
-      state: {
-        threadId: "busy-thread",
-        workspaceId: "busy-workspace",
-        orgId: "busy-org",
-        projectId: "busy-project",
-        title: "Busy test",
-        model: "mock",
-        messages: [],
-        threadState: structuredClone(EMPTY_THREAD_STATE),
-        clientMessageIds: [],
-        turnStatus: "streaming",
+});
+
+test("chatThread updates its title and model", async (c) => {
+  const { chat } = await setupChat(c);
+
+  await expect(chat.setTitle("Renamed thread")).resolves.toBe("Renamed thread");
+  await expect(chat.setModel("anthropic/test")).resolves.toBe("anthropic/test");
+  await expect(chat.getThreadState()).resolves.toMatchObject({
+    title: "Renamed thread",
+    model: "anthropic/test",
+    threadState: {
+      title: "Renamed thread",
+      model: "anthropic/test",
+    },
+  });
+});
+
+test("org actor grants and reports credits", async (c) => {
+  const { client } = await setupTest(c, registry);
+  const orgId = `org-${crypto.randomUUID()}`;
+  const org = client.org.getOrCreate(orgId, {
+    createWithInput: {
+      orgId,
+      creditCents: 100,
+    },
+  });
+
+  await expect(org.getCredits()).resolves.toBe(100);
+  await expect(org.grantCredits(250)).resolves.toBe(350);
+  await expect(org.getCredits()).resolves.toBe(350);
+});
+
+test("workspace actor registers and lists unique threads", async (c) => {
+  const { client } = await setupTest(c, registry);
+  const suffix = crypto.randomUUID();
+  const workspaceId = `workspace-${suffix}`;
+  const workspace = client.workspace.getOrCreate(workspaceId, {
+    createWithInput: {
+      workspaceId,
+      orgId: `org-${suffix}`,
+    },
+  });
+
+  await expect(workspace.listThreads()).resolves.toEqual([]);
+  await expect(workspace.registerThread("thread-1")).resolves.toEqual([
+    "thread-1",
+  ]);
+  await workspace.registerThread("thread-2");
+  await workspace.registerThread("thread-1");
+  await expect(workspace.listThreads()).resolves.toEqual([
+    "thread-1",
+    "thread-2",
+  ]);
+});
+
+test("chatThread handles allowlisted slash commands without the runtime", async (c) => {
+  const { chat } = await setupChat(c);
+
+  await expect(chat.sendMessage("/compact", "client-compact")).resolves.toEqual({
+    status: "completed",
+    messageId: "assistant:client-compact",
+  });
+  const messages = await chat.getMessages();
+  expect(messages[1]).toMatchObject({
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        text: "Context compacted (stub).",
+        state: "done",
       },
-    } as unknown as Parameters<typeof sendMessageAction>[0],
-    "second response",
-    "client-busy",
-  );
-  expect(busyResult).toEqual({ status: "busy" });
+    ],
+  });
+});
+
+test("chatThread rejects unknown slash commands with an assistant error", async (c) => {
+  const { chat } = await setupChat(c);
+  const error = "Unknown slash command: /not-allowed";
+
+  await expect(
+    chat.sendMessage("/not-allowed", "client-unknown"),
+  ).resolves.toEqual({
+    status: "error",
+    messageId: "assistant:client-unknown",
+    error,
+  });
+  const messages = await chat.getMessages();
+  expect(messages[1]).toMatchObject({
+    role: "assistant",
+    parts: [{ type: "data-error", data: { error } }],
+  });
+  await expect(chat.getThreadState()).resolves.toMatchObject({
+    turnStatus: "error",
+    threadState: { lastError: { error } },
+  });
 });

--- a/agentos-platform/tests/chat-thread.test.ts
+++ b/agentos-platform/tests/chat-thread.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "vitest";
+import { setupTest } from "rivetkit/test";
+import { EMPTY_THREAD_STATE } from "../src/shared/index.ts";
+import { chatThread } from "../src/server/actors/chat-thread.ts";
+import { registry } from "../src/server/registry.ts";
+
+test("chatThread sends, deduplicates, reports busy, and records tools", async (c) => {
+  const { client } = await setupTest(c, registry);
+  const suffix = crypto.randomUUID();
+  const threadId = `thread-${suffix}`;
+  const createWithInput = {
+    threadId,
+    workspaceId: `workspace-${suffix}`,
+    orgId: `org-${suffix}`,
+    projectId: `project-${suffix}`,
+  };
+  const chat = client.chatThread.getOrCreate(threadId, {
+    createWithInput,
+  });
+
+  await expect(chat.sendMessage("hello", "client-1")).resolves.toMatchObject({
+    status: "completed",
+  });
+  await expect(chat.sendMessage("hello", "client-1")).resolves.toEqual({
+    status: "duplicate",
+    messageId: "client-1",
+  });
+
+  let messages = await chat.getMessages();
+  expect(messages).toHaveLength(2);
+  expect(messages.map((message) => message.role)).toEqual([
+    "user",
+    "assistant",
+  ]);
+
+  await expect(
+    chat.sendMessage("please use a tool", "client-tool"),
+  ).resolves.toMatchObject({ status: "completed" });
+  messages = await chat.getMessages();
+  const toolAssistant = messages.find(
+    (message) => message.id === "assistant:client-tool",
+  );
+  expect(toolAssistant?.parts).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "read",
+        state: "output-available",
+      }),
+      expect.objectContaining({
+        type: "tool-result",
+        output: "Mock file contents",
+      }),
+    ]),
+  );
+
+  const sendMessageAction = chatThread.config.actions?.sendMessage;
+  if (typeof sendMessageAction !== "function") {
+    throw new Error("chatThread sendMessage action is unavailable");
+  }
+  const busyResult = await sendMessageAction(
+    {
+      state: {
+        threadId: "busy-thread",
+        workspaceId: "busy-workspace",
+        orgId: "busy-org",
+        projectId: "busy-project",
+        title: "Busy test",
+        model: "mock",
+        messages: [],
+        threadState: structuredClone(EMPTY_THREAD_STATE),
+        clientMessageIds: [],
+        turnStatus: "streaming",
+      },
+    } as unknown as Parameters<typeof sendMessageAction>[0],
+    "second response",
+    "client-busy",
+  );
+  expect(busyResult).toEqual({ status: "busy" });
+});

--- a/agentos-platform/tests/credits-gate.test.ts
+++ b/agentos-platform/tests/credits-gate.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertCanStartHostedTurn,
+  chargeTurn,
+  CreditDeniedError,
+} from "../src/server/chat/credits-gate.ts";
+import { createPlatform } from "../src/server/platform/index.ts";
+
+const tempDirs: string[] = [];
+
+function platformFixture() {
+  const dataDir = mkdtempSync(join(tmpdir(), "agentos-credits-"));
+  tempDirs.push(dataDir);
+  return createPlatform({ dataDir });
+}
+
+afterEach(() => {
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("hosted turn credit gate", () => {
+  it("denies a hosted turn with no credits and permits BYOK", () => {
+    const platform = platformFixture();
+    expect(() =>
+      assertCanStartHostedTurn({
+        billing: platform.billing,
+        orgId: "org-empty",
+      }),
+    ).toThrow(CreditDeniedError);
+    expect(() =>
+      assertCanStartHostedTurn({
+        billing: platform.billing,
+        orgId: "org-empty",
+        bypass: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("charges credits and records the successful turn", () => {
+    const platform = platformFixture();
+    platform.billing.grantCredits("org-funded", 10);
+    assertCanStartHostedTurn({
+      billing: platform.billing,
+      orgId: "org-funded",
+    });
+
+    chargeTurn(
+      platform.billing,
+      platform.usage,
+      {
+        orgId: "org-funded",
+        workspaceId: "workspace-1",
+        threadId: "thread-1",
+        userId: "user-1",
+      },
+      { cents: 3, durationMs: 20, model: "hosted/test" },
+    );
+
+    expect(platform.billing.getCreditBalance("org-funded")).toBe(7);
+    expect(platform.usage.listUsage("org-funded")).toMatchObject([
+      {
+        orgId: "org-funded",
+        kind: "turn",
+        cents: 3,
+        creditChargeable: true,
+        durationMs: 20,
+        model: "hosted/test",
+      },
+    ]);
+    expect(platform.usage.sumChargeableCents("org-funded")).toBe(3);
+  });
+
+  it("meters BYOK turns without consuming credits", () => {
+    const platform = platformFixture();
+    chargeTurn(
+      platform.billing,
+      platform.usage,
+      {
+        orgId: "org-byok",
+        workspaceId: "workspace-1",
+        threadId: "thread-1",
+        bypass: true,
+      },
+      { cents: 4 },
+    );
+
+    expect(platform.billing.getCreditBalance("org-byok")).toBe(0);
+    expect(platform.usage.listUsage("org-byok")[0]).toMatchObject({
+      cents: 4,
+      creditChargeable: false,
+    });
+    expect(platform.usage.sumChargeableCents("org-byok")).toBe(0);
+  });
+});

--- a/agentos-platform/tests/message-adapter.test.ts
+++ b/agentos-platform/tests/message-adapter.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyChatEvent,
+  uiMessageToChatMessage,
+} from "../src/client/message-adapter.ts";
+import type { UiMessage } from "../src/shared/index.ts";
+
+describe("uiMessageToChatMessage", () => {
+  it("maps render parts to durable content blocks", () => {
+    const ui: UiMessage = {
+      id: "message-1",
+      role: "assistant",
+      createdAt: 123,
+      parts: [
+        { type: "reasoning", text: "Checking files", state: "done" },
+        {
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "read_file",
+          input: { path: "README.md" },
+          state: "output-available",
+        },
+        {
+          type: "tool-result",
+          toolCallId: "tool-1",
+          toolName: "read_file",
+          output: { content: "# Project" },
+        },
+        { type: "text", text: "The project is ready.", state: "done" },
+        {
+          type: "data-todos",
+          data: {
+            todos: [
+              {
+                content: "Inspect files",
+                activeForm: "Inspecting files",
+                status: "completed",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(uiMessageToChatMessage(ui, "thread-1")).toEqual({
+      id: "message-1",
+      threadId: "thread-1",
+      role: "assistant",
+      createdAt: 123,
+      isStreaming: false,
+      content: [
+        { type: "thinking", thinking: "Checking files" },
+        {
+          type: "tool_use",
+          id: "tool-1",
+          name: "read_file",
+          input: { path: "README.md" },
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "tool-1",
+          content: '{\n  "content": "# Project"\n}',
+          is_error: undefined,
+        },
+        { type: "text", text: "The project is ready." },
+      ],
+    });
+  });
+});
+
+describe("applyChatEvent", () => {
+  it("upserts durable messages and appends streaming text deltas", () => {
+    const initial = applyChatEvent([], {
+      type: "messageUpsert",
+      message: {
+        id: "assistant-1",
+        threadId: "thread-1",
+        role: "assistant",
+        createdAt: 100,
+        content: [{ type: "text", text: "Hello" }],
+        isStreaming: true,
+      },
+    });
+
+    const next = applyChatEvent(initial, {
+      type: "messageDelta",
+      messageId: "assistant-1",
+      textDelta: ", world",
+    });
+
+    expect(next).not.toBe(initial);
+    expect(next[0]?.parts).toEqual([
+      { type: "text", text: "Hello, world", state: "streaming" },
+    ]);
+  });
+
+  it("replaces keyed tool parts without mutating prior state", () => {
+    const original: UiMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        createdAt: 100,
+        parts: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "write_file",
+            input: {},
+            state: "input-streaming",
+          },
+        ],
+      },
+    ];
+
+    const next = applyChatEvent(original, {
+      type: "messageDelta",
+      messageId: "assistant-1",
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "write_file",
+          input: { path: "src/index.ts" },
+          state: "input-available",
+        },
+      ],
+    });
+
+    expect(next[0]?.parts).toEqual([
+      expect.objectContaining({
+        toolCallId: "tool-1",
+        input: { path: "src/index.ts" },
+        state: "input-available",
+      }),
+    ]);
+    expect(original[0]?.parts[0]).toMatchObject({
+      input: {},
+      state: "input-streaming",
+    });
+  });
+});

--- a/agentos-platform/tests/observability.test.ts
+++ b/agentos-platform/tests/observability.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handlePlatformHttpRequest } from "../src/server/http/metrics.ts";
+import {
+  getObservabilitySnapshot,
+  recordError,
+  recordEvent,
+  resetObservabilityForTests,
+} from "../src/server/observability.ts";
+
+beforeEach(() => {
+  resetObservabilityForTests();
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("structured observability", () => {
+  it("writes JSON lines, increments counters, and redacts sensitive metadata", () => {
+    const event = recordEvent({
+      event: "turns_started",
+      component: "chat-thread",
+      orgId: "org-1",
+      count: 2,
+      meta: { model: "test", apiKey: "must-not-leak" },
+    });
+    recordError({
+      event: "turn_failed",
+      component: "chat-thread",
+      error: new Error("boom"),
+    });
+
+    expect(event.meta).toEqual({
+      model: "test",
+      apiKey: "[REDACTED]",
+    });
+    expect(getObservabilitySnapshot()).toMatchObject({
+      counters: { turns_started: 2 },
+      recentEvents: [
+        { event: "turns_started", severity: "info" },
+        {
+          event: "turn_failed",
+          severity: "error",
+          status: "error",
+          meta: { errorName: "Error", errorMessage: "boom" },
+        },
+      ],
+    });
+    const output = vi.mocked(process.stdout.write).mock.calls[0]?.[0];
+    expect(JSON.parse(String(output).trim())).toMatchObject({
+      event: "turns_started",
+      component: "chat-thread",
+    });
+  });
+
+  it("retains only the latest 500 events", () => {
+    for (let index = 0; index < 501; index += 1) {
+      recordEvent({
+        event: `event-${index}`,
+        component: "test",
+      });
+    }
+    const { recentEvents } = getObservabilitySnapshot();
+    expect(recentEvents).toHaveLength(500);
+    expect(recentEvents[0]?.event).toBe("event-1");
+    expect(recentEvents.at(-1)?.event).toBe("event-500");
+  });
+
+  it("serves health and metrics endpoints", async () => {
+    const health = handlePlatformHttpRequest(
+      new Request("http://localhost/health"),
+    );
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toMatchObject({
+      ok: true,
+      version: expect.any(String),
+    });
+
+    const metrics = handlePlatformHttpRequest(
+      new Request("http://localhost/api/metrics"),
+    );
+    await expect(metrics.json()).resolves.toMatchObject({
+      counters: { http_requests: 2 },
+      recentEvents: expect.any(Array),
+    });
+  });
+});

--- a/agentos-platform/tests/platform.test.ts
+++ b/agentos-platform/tests/platform.test.ts
@@ -1,0 +1,201 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BillingService,
+  IdentityService,
+  ProjectFilesystem,
+  Store,
+  createPlatform,
+} from "../src/server/platform/index.ts";
+
+const tempDirs: string[] = [];
+
+function tempDataDir(prefix = "agentos-platform-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("Store", () => {
+  it("get/set/delete and listByPrefix round-trip through the JSON file", () => {
+    const dataDir = tempDataDir();
+    const store = new Store({ dataDir });
+    store.set("org:a", { id: "a" });
+    store.set("org:b", { id: "b" });
+    store.set("thread:1", { id: "1" });
+
+    expect(store.get("org:a")).toEqual({ id: "a" });
+    expect(store.listByPrefix("org:")).toEqual([
+      { key: "org:a", value: { id: "a" } },
+      { key: "org:b", value: { id: "b" } },
+    ]);
+    expect(store.delete("org:b")).toBe(true);
+    expect(store.get("org:b")).toBeUndefined();
+
+    const reloaded = new Store({ dataDir });
+    expect(reloaded.get("org:a")).toEqual({ id: "a" });
+    expect(reloaded.get("org:b")).toBeUndefined();
+    expect(reloaded.listByPrefix("thread:")).toHaveLength(1);
+  });
+
+  it("rejects empty keys", () => {
+    const store = new Store({ dataDir: tempDataDir() });
+    expect(() => store.get("")).toThrow(/non-empty/);
+    expect(() => store.set("", 1)).toThrow(/non-empty/);
+  });
+});
+
+describe("IdentityService", () => {
+  it("creates org, workspace, thread and lists threads", () => {
+    const identity = new IdentityService(new Store({ dataDir: tempDataDir() }));
+    const org = identity.createOrg({ name: "Acme" });
+    const workspace = identity.createWorkspace({
+      orgId: org.id,
+      name: "Main",
+    });
+    const thread = identity.createThread({
+      workspaceId: workspace.id,
+      title: "Hello",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+
+    expect(thread.orgId).toBe(org.id);
+    expect(thread.workspaceId).toBe(workspace.id);
+    expect(identity.getThread(thread.id)?.title).toBe("Hello");
+    expect(identity.listThreads(workspace.id)).toEqual([thread]);
+  });
+
+  it("ensureDemoTenant is idempotent", () => {
+    const identity = new IdentityService(new Store({ dataDir: tempDataDir() }));
+    const first = identity.ensureDemoTenant();
+    const second = identity.ensureDemoTenant();
+    expect(second).toEqual(first);
+    expect(first.org.id).toBe("org_demo");
+    expect(first.workspace.id).toBe("ws_demo");
+    expect(first.user.email).toBe("demo@localhost");
+  });
+
+  it("refuses threads for missing workspaces", () => {
+    const identity = new IdentityService(new Store({ dataDir: tempDataDir() }));
+    expect(() => identity.createThread({ workspaceId: "missing" })).toThrow(
+      /workspace not found/,
+    );
+  });
+});
+
+describe("ProjectFilesystem", () => {
+  it("reads, writes, edits, lists, and deletes under the project root", () => {
+    const dataDir = tempDataDir();
+    const fs = new ProjectFilesystem({
+      dataDir,
+      workspaceId: "ws1",
+      projectId: "proj1",
+    });
+
+    fs.mkdir("src");
+    fs.write("src/index.ts", "export const n = 1;\n");
+    expect(fs.read("src/index.ts")).toContain("n = 1");
+    expect(fs.exists("src/index.ts")).toBe(true);
+
+    const edited = fs.edit("src/index.ts", "n = 1", "n = 2");
+    expect(edited.replacements).toBe(1);
+    expect(fs.read("src/index.ts")).toContain("n = 2");
+
+    const entries = fs.ls("src");
+    expect(entries).toEqual([
+      expect.objectContaining({
+        name: "index.ts",
+        path: "src/index.ts",
+        type: "file",
+      }),
+    ]);
+
+    fs.delete("src/index.ts");
+    expect(fs.exists("src/index.ts")).toBe(false);
+    expect(fs.root).toBe(join(dataDir, "projects", "ws1", "proj1"));
+  });
+
+  it("blocks path traversal", () => {
+    const fs = new ProjectFilesystem({
+      dataDir: tempDataDir(),
+      workspaceId: "ws1",
+      projectId: "proj1",
+    });
+    expect(() => fs.read("../secret")).toThrow(/escapes project root/);
+    expect(() => fs.write("../../etc/passwd", "x")).toThrow(/escapes project root/);
+    expect(() => fs.ls("..")).toThrow(/escapes project root/);
+  });
+
+  it("fails edit when oldText is missing or ambiguous", () => {
+    const fs = new ProjectFilesystem({
+      dataDir: tempDataDir(),
+      workspaceId: "ws1",
+      projectId: "proj1",
+    });
+    fs.write("a.txt", "one two one");
+    expect(() => fs.edit("a.txt", "missing", "x")).toThrow(/not found/);
+    expect(() => fs.edit("a.txt", "one", "ONE")).toThrow(/matched 2 times/);
+    expect(fs.edit("a.txt", "one", "ONE", { replaceAll: true }).replacements).toBe(
+      2,
+    );
+  });
+});
+
+describe("BillingService", () => {
+  it("grants, checks hosted access, and consumes credits", () => {
+    const billing = new BillingService(new Store({ dataDir: tempDataDir() }));
+    expect(billing.canUseHostedModel("org1")).toBe(false);
+    billing.grantCredits("org1", 500);
+    expect(billing.getCreditBalance("org1")).toBe(500);
+    expect(billing.canUseHostedModel("org1")).toBe(true);
+    billing.consumeCredits("org1", 200);
+    expect(billing.getCreditBalance("org1")).toBe(300);
+    expect(() => billing.consumeCredits("org1", 999)).toThrow(/insufficient/);
+  });
+
+  it("persists balances across Store reloads", () => {
+    const dataDir = tempDataDir();
+    new BillingService(new Store({ dataDir })).grantCredits("org1", 100);
+    const reloaded = new BillingService(new Store({ dataDir }));
+    expect(reloaded.getCreditBalance("org1")).toBe(100);
+  });
+});
+
+describe("createPlatform", () => {
+  it("wires shared services and can seed a demo tenant", () => {
+    const dataDir = tempDataDir();
+    const platform = createPlatform({
+      dataDir,
+      ensureDemoTenant: true,
+      demoCreditCents: 250,
+    });
+
+    const demo = platform.identity.ensureDemoTenant();
+    expect(platform.billing.getCreditBalance(demo.org.id)).toBe(250);
+
+    const thread = platform.identity.createThread({
+      workspaceId: demo.workspace.id,
+      title: "First",
+    });
+    expect(platform.identity.listThreads(demo.workspace.id)[0]?.id).toBe(
+      thread.id,
+    );
+
+    const project = platform.projectFilesystem(demo.workspace.id, "app");
+    project.write("README.md", "# hi\n");
+    expect(project.read("README.md")).toBe("# hi\n");
+    expect(platform.store).toBeInstanceOf(Store);
+    expect(platform.dataDir).toBe(dataDir);
+  });
+});

--- a/agentos-platform/tests/stripe-webhook.test.ts
+++ b/agentos-platform/tests/stripe-webhook.test.ts
@@ -1,0 +1,266 @@
+import { createHmac } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  STRIPE_API_VERSION,
+  StripeBillingClient,
+  handleWebhookEvent,
+  type StripeWebhookEvent,
+} from "../src/server/billing/stripe.ts";
+import { createApiHandler } from "../src/server/http/api.ts";
+import { BillingService } from "../src/server/platform/billing.ts";
+import { Store } from "../src/server/platform/store.ts";
+
+const tempDirs: string[] = [];
+const webhookSecret = "whsec_unit_test";
+const nowSeconds = 1_800_000_000;
+
+function createBilling(): BillingService {
+  const dataDir = mkdtempSync(join(tmpdir(), "agentos-stripe-"));
+  tempDirs.push(dataDir);
+  return new BillingService(new Store({ dataDir }));
+}
+
+function sign(payload: string, timestamp = nowSeconds): string {
+  const signature = createHmac("sha256", webhookSecret)
+    .update(`${timestamp}.${payload}`)
+    .digest("hex");
+  return `t=${timestamp},v1=${signature}`;
+}
+
+function client(options: ConstructorParameters<typeof StripeBillingClient>[0] = {}) {
+  return new StripeBillingClient({
+    webhookSecret,
+    now: () => nowSeconds * 1000,
+    ...options,
+  });
+}
+
+function event(
+  type: string,
+  object: Record<string, unknown>,
+): StripeWebhookEvent {
+  return {
+    id: `evt_${type}`,
+    type,
+    data: { object },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Stripe webhook signatures", () => {
+  it("verifies the raw payload before parsing the event", () => {
+    const payload = JSON.stringify(
+      event("checkout.session.completed", { id: "cs_1" }),
+    );
+    expect(client().constructEvent(payload, sign(payload))).toEqual(
+      JSON.parse(payload),
+    );
+    expect(() =>
+      client().constructEvent(`${payload} `, sign(payload)),
+    ).toThrow(/Invalid Stripe signature/);
+  });
+
+  it("rejects missing, malformed, and stale signatures", () => {
+    const payload = JSON.stringify(event("ignored", {}));
+    expect(() => client().constructEvent(payload, null)).toThrow(
+      /Invalid Stripe signature/,
+    );
+    expect(() => client().constructEvent(payload, "t=bad,v1=nope")).toThrow(
+      /Invalid Stripe signature/,
+    );
+    expect(() =>
+      client().constructEvent(payload, sign(payload, nowSeconds - 301)),
+    ).toThrow(/outside tolerance/);
+  });
+});
+
+describe("Stripe webhook billing", () => {
+  it("grants completed credit checkouts exactly once", () => {
+    const billing = createBilling();
+    const completed = event("checkout.session.completed", {
+      id: "cs_credits",
+      mode: "payment",
+      amount_total: 2500,
+      customer: "cus_1",
+      metadata: {
+        type: "credits",
+        orgId: "org-1",
+        amountCents: "2500",
+      },
+    });
+
+    handleWebhookEvent(completed, billing);
+    handleWebhookEvent(completed, billing);
+    expect(billing.getCreditBalance("org-1")).toBe(2500);
+    expect(billing.getAccount("org-1").stripeCustomerId).toBe("cus_1");
+  });
+
+  it("syncs subscriptions and grants each paid invoice once", () => {
+    const billing = createBilling();
+    handleWebhookEvent(
+      event("customer.subscription.updated", {
+        id: "sub_1",
+        customer: "cus_1",
+        status: "active",
+        metadata: {
+          org_id: "org-1",
+          billing_plan: "team",
+          seat_count: "4",
+        },
+      }),
+      billing,
+    );
+    expect(billing.getAccount("org-1")).toMatchObject({
+      plan: "team",
+      billingStatus: "active",
+      seatCount: 4,
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_1",
+    });
+
+    const invoice = event("invoice.payment_succeeded", {
+      id: "in_1",
+      parent: {
+        subscription_details: {
+          metadata: {
+            org_id: "org-1",
+            billing_plan: "team",
+            seat_count: "4",
+          },
+        },
+      },
+    });
+    handleWebhookEvent(invoice, billing);
+    handleWebhookEvent(invoice, billing);
+    expect(billing.getAccount("org-1").includedCreditCents).toBe(20_000);
+    expect(billing.getAccount("org-1").lastIncludedCreditInvoiceId).toBe(
+      "in_1",
+    );
+  });
+});
+
+describe("Stripe Checkout client", () => {
+  it("creates dynamic-payment Checkout Sessions on the latest API version", async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        Response.json({
+          id: "cs_new",
+          url: "https://checkout.stripe.test/cs_new",
+        }),
+    );
+    const stripe = client({
+      secretKey: "sk_test_example",
+      mode: "test",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await stripe.createCheckoutSessionForSubscription({
+      orgId: "org-1",
+      plan: "team",
+      seatCount: 4,
+      successUrl: "https://camelai.test/success",
+      cancelUrl: "https://camelai.test/cancel",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://api.stripe.com/v1/checkout/sessions");
+    expect(init?.headers).toMatchObject({
+      "Stripe-Version": STRIPE_API_VERSION,
+    });
+    const body = init?.body as URLSearchParams;
+    expect(body.get("mode")).toBe("subscription");
+    expect(body.get("line_items[0][quantity]")).toBe("4");
+    expect([...body.keys()].some((key) => key.includes("payment_method_types"))).toBe(
+      false,
+    );
+  });
+
+  it("fails closed when Stripe is absent or the key mode mismatches", async () => {
+    await expect(
+      client({ secretKey: "", mode: "test" }).createCheckoutSessionForCredits({
+        orgId: "org-1",
+        amountCents: 500,
+        successUrl: "https://camelai.test/success",
+        cancelUrl: "https://camelai.test/cancel",
+      }),
+    ).rejects.toThrow("Stripe not configured");
+
+    await expect(
+      client({
+        secretKey: "sk_live_example",
+        mode: "test",
+      }).createCheckoutSessionForCredits({
+        orgId: "org-1",
+        amountCents: 500,
+        successUrl: "https://camelai.test/success",
+        cancelUrl: "https://camelai.test/cancel",
+      }),
+    ).rejects.toThrow(/key mode mismatch/);
+  });
+});
+
+describe("billing HTTP routes", () => {
+  it("mounts protected account and Checkout endpoints on the API handler", async () => {
+    const billing = createBilling();
+    billing.grantCredits("org-1", 300);
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        Response.json({
+          id: "cs_http",
+          url: "https://checkout.stripe.test/cs_http",
+        }),
+    );
+    const handler = createApiHandler({
+      billingService: billing,
+      stripeClient: client({
+        secretKey: "sk_test_example",
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+      allowTestOrgHeader: true,
+    });
+
+    const unauthorized = await handler(
+      new Request("http://localhost/api/billing/account?orgId=org-1"),
+    );
+    expect(unauthorized.status).toBe(401);
+
+    const account = await handler(
+      new Request("http://localhost/api/billing/account?orgId=org-1", {
+        headers: { "x-org-id": "org-1" },
+      }),
+    );
+    expect(account.status).toBe(200);
+    expect(await account.json()).toMatchObject({ creditBalanceCents: 300 });
+
+    const checkout = await handler(
+      new Request("http://localhost/api/billing/checkout/credits", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-org-id": "org-1",
+        },
+        body: JSON.stringify({
+          orgId: "org-1",
+          amountCents: 500,
+          successUrl: "https://camelai.test/success",
+          cancelUrl: "https://camelai.test/cancel",
+        }),
+      }),
+    );
+    expect(checkout.status).toBe(201);
+    expect(await checkout.json()).toEqual({
+      id: "cs_http",
+      url: "https://checkout.stripe.test/cs_http",
+    });
+  });
+});

--- a/agentos-platform/tests/tickets.test.ts
+++ b/agentos-platform/tests/tickets.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  mintTicket,
+  type AuthTicketPayload,
+  verifyTicket,
+} from "../src/server/auth/tickets.ts";
+
+const originalSigningSecret = process.env.TOKEN_SIGNING_SECRET;
+
+function payload(overrides: Partial<AuthTicketPayload> = {}): AuthTicketPayload {
+  return {
+    orgId: "org-1",
+    workspaceId: "workspace-1",
+    threadId: "thread-1",
+    userId: "user-1",
+    exp: Math.floor(Date.now() / 1000) + 60,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  if (originalSigningSecret === undefined) {
+    delete process.env.TOKEN_SIGNING_SECRET;
+  } else {
+    process.env.TOKEN_SIGNING_SECRET = originalSigningSecret;
+  }
+});
+
+describe("auth tickets", () => {
+  test("mints and verifies an HMAC ticket", () => {
+    const expected = payload();
+    const ticket = mintTicket(expected, "test-secret");
+
+    expect(ticket.split(".")).toHaveLength(2);
+    expect(verifyTicket(ticket, "test-secret")).toEqual(expected);
+  });
+
+  test("rejects tampered tickets and the wrong secret", () => {
+    const ticket = mintTicket(payload(), "test-secret");
+    const [body, signature] = ticket.split(".");
+    const tamperedBody = `${body?.startsWith("A") ? "B" : "A"}${body?.slice(1)}`;
+
+    expect(verifyTicket(`${tamperedBody}.${signature}`, "test-secret")).toBeNull();
+    expect(verifyTicket(ticket, "other-secret")).toBeNull();
+  });
+
+  test("rejects expired and malformed tickets", () => {
+    const expired = mintTicket(
+      payload({ exp: Math.floor(Date.now() / 1000) - 1 }),
+      "test-secret",
+    );
+
+    expect(verifyTicket(expired, "test-secret")).toBeNull();
+    expect(verifyTicket("not-a-ticket", "test-secret")).toBeNull();
+  });
+
+  test("uses TOKEN_SIGNING_SECRET with a development fallback", () => {
+    process.env.TOKEN_SIGNING_SECRET = "environment-secret";
+    const environmentTicket = mintTicket(payload());
+    expect(verifyTicket(environmentTicket)).not.toBeNull();
+    expect(verifyTicket(environmentTicket, "dev-secret")).toBeNull();
+
+    delete process.env.TOKEN_SIGNING_SECRET;
+    const developmentTicket = mintTicket(payload());
+    expect(verifyTicket(developmentTicket, "dev-secret")).not.toBeNull();
+  });
+});

--- a/agentos-platform/tests/turn.test.ts
+++ b/agentos-platform/tests/turn.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "vitest";
+import type {
+  ChatEvent,
+  ThreadState,
+  TurnStatus,
+  UiMessage,
+} from "../src/shared/index.ts";
+import { EMPTY_THREAD_STATE } from "../src/shared/index.ts";
+import { MockAgentRuntime } from "../src/server/chat/runtime.ts";
+import { runChatTurn } from "../src/server/chat/turn.ts";
+
+describe("runChatTurn", () => {
+  test("streams a deterministic user and assistant exchange", async () => {
+    const messages: UiMessage[] = [];
+    const events: ChatEvent[] = [];
+    let status: TurnStatus = "idle";
+    let threadState: ThreadState = structuredClone(EMPTY_THREAD_STATE);
+
+    const result = await runChatTurn({
+      messages,
+      broadcast: (event) => {
+        events.push(event);
+      },
+      updateState: (patch) => {
+        threadState = { ...threadState, ...patch };
+      },
+      updateTurnStatus: (next) => {
+        status = next;
+      },
+      turnStatus: () => status,
+      runtime: new MockAgentRuntime(),
+      content: "hello",
+      clientMessageId: "client-1",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      id: "client-1",
+      role: "user",
+    });
+    expect(messages[1]).toMatchObject({
+      id: "assistant:client-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "text",
+          text: "Mock reply: hello",
+          state: "done",
+        },
+      ],
+    });
+    expect(status).toBe("idle");
+    expect(threadState.lastError).toBeNull();
+    expect(events.some((event) => event.type === "messageDelta")).toBe(true);
+    expect(
+      events.some(
+        (event) => event.type === "turnStatus" && event.status === "streaming",
+      ),
+    ).toBe(true);
+  });
+
+  test("records tool calls, tool results, and pending questions", async () => {
+    const messages: UiMessage[] = [];
+    let status: TurnStatus = "idle";
+    let threadState: ThreadState = structuredClone(EMPTY_THREAD_STATE);
+
+    await runChatTurn({
+      messages,
+      broadcast: () => {},
+      updateState: (patch) => {
+        threadState = { ...threadState, ...patch };
+      },
+      updateTurnStatus: (next) => {
+        status = next;
+      },
+      turnStatus: () => status,
+      runtime: new MockAgentRuntime(),
+      content: "use a tool then ask: Which option?",
+      clientMessageId: "client-tool",
+    });
+
+    const assistant = messages[1];
+    expect(assistant?.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "tool-call",
+          toolCallId: "mock-tool-1",
+          toolName: "read",
+          state: "output-available",
+        }),
+        expect.objectContaining({
+          type: "tool-result",
+          toolCallId: "mock-tool-1",
+          output: "Mock file contents",
+        }),
+      ]),
+    );
+    expect(threadState.pendingQuestion).toMatchObject({
+      questionId: "mock-question-1",
+      questions: [{ question: "Which option?" }],
+    });
+  });
+
+  test("rejects duplicate and busy sends before mutating messages", async () => {
+    const messages: UiMessage[] = [
+      {
+        id: "existing",
+        role: "user",
+        parts: [{ type: "text", text: "already sent" }],
+        createdAt: 1,
+      },
+    ];
+    const base = {
+      messages,
+      broadcast: () => {},
+      updateState: () => {},
+      runtime: new MockAgentRuntime(),
+      content: "hello",
+    };
+
+    await expect(
+      runChatTurn({ ...base, clientMessageId: "existing" }),
+    ).resolves.toEqual({ status: "duplicate", messageId: "existing" });
+    await expect(
+      runChatTurn({
+        ...base,
+        clientMessageId: "new",
+        turnStatus: "streaming",
+      }),
+    ).resolves.toEqual({ status: "busy" });
+    expect(messages).toHaveLength(1);
+  });
+});

--- a/agentos-platform/tests/usage.test.ts
+++ b/agentos-platform/tests/usage.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { Store, UsageService } from "../src/server/platform/index.ts";
+
+const tempDirs: string[] = [];
+
+function createUsage(): UsageService {
+  const dataDir = mkdtempSync(join(tmpdir(), "agentos-usage-"));
+  tempDirs.push(dataDir);
+  return new UsageService(new Store({ dataDir }));
+}
+
+afterEach(() => {
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("UsageService", () => {
+  it("records, filters, limits, and sums chargeable usage", () => {
+    const usage = createUsage();
+    usage.recordUsage({
+      id: "old",
+      orgId: "org-1",
+      workspaceId: "workspace-1",
+      threadId: "thread-1",
+      kind: "inference",
+      model: "hosted/test",
+      cents: 2,
+      creditChargeable: true,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    usage.recordUsage({
+      id: "new",
+      orgId: "org-1",
+      workspaceId: "workspace-1",
+      threadId: "thread-1",
+      userId: "user-1",
+      kind: "turn",
+      cents: 7,
+      creditChargeable: false,
+      durationMs: 25,
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    usage.recordUsage({
+      id: "other-org",
+      orgId: "org-2",
+      workspaceId: "workspace-2",
+      threadId: "thread-2",
+      kind: "tool",
+      cents: 100,
+      creditChargeable: true,
+      createdAt: "2026-01-03T00:00:00.000Z",
+    });
+
+    expect(usage.listUsage("org-1").map((event) => event.id)).toEqual([
+      "new",
+      "old",
+    ]);
+    expect(
+      usage.listUsage("org-1", {
+        since: "2026-01-02T00:00:00.000Z",
+        limit: 1,
+      }),
+    ).toMatchObject([{ id: "new" }]);
+    expect(usage.sumChargeableCents("org-1")).toBe(2);
+  });
+
+  it("validates malformed usage events", () => {
+    const usage = createUsage();
+    expect(() =>
+      usage.recordUsage({
+        id: "bad",
+        orgId: "org-1",
+        workspaceId: "workspace-1",
+        threadId: "thread-1",
+        kind: "turn",
+        cents: -1,
+        creditChargeable: true,
+        createdAt: new Date().toISOString(),
+      }),
+    ).toThrow(/non-negative integer/);
+    expect(() => usage.listUsage("org-1", { since: "not-a-date" })).toThrow(
+      /valid timestamp/,
+    );
+  });
+});

--- a/agentos-platform/tests/use-rivet-chat-memory.test.ts
+++ b/agentos-platform/tests/use-rivet-chat-memory.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMemoryChatTransport,
+  type ChatConnectionStatus,
+} from "../src/client/use-rivet-chat.ts";
+import { applyChatEvent } from "../src/client/message-adapter.ts";
+import type { ChatEvent, UiMessage } from "../src/shared/index.ts";
+
+describe("createMemoryChatTransport", () => {
+  it("sends a message, broadcasts events, and persists the applied transcript", async () => {
+    const transport = createMemoryChatTransport();
+    const events: ChatEvent[] = [];
+    const statuses: ChatConnectionStatus[] = [];
+    let rendered: UiMessage[] = [];
+
+    const session = await transport.connect(
+      {
+        threadId: "thread-memory",
+        workspaceId: "ws-1",
+        orgId: "org-1",
+        initialTitle: "Memory test",
+      },
+      {
+        onEvent(event) {
+          events.push(event);
+          rendered = applyChatEvent(rendered, event);
+        },
+        onStatus(status) {
+          statuses.push(status);
+        },
+        onError: vi.fn(),
+      },
+    );
+
+    await session.sendMessage({
+      content: "Build a dashboard",
+      clientMessageId: "client-1",
+    });
+
+    expect(statuses).toEqual(["connecting", "connected"]);
+    expect(events.map((event) => event.type)).toEqual([
+      "messageUpsert",
+      "turnStatus",
+      "messageUpsert",
+      "messageDelta",
+      "messageUpsert",
+      "turnStatus",
+    ]);
+    expect(rendered).toHaveLength(2);
+    expect(rendered[0]).toMatchObject({
+      id: "client-1",
+      role: "user",
+      parts: [{ type: "text", text: "Build a dashboard", state: "done" }],
+    });
+    expect(rendered[1]?.parts).toEqual([
+      {
+        type: "text",
+        text: "Memory mode received: Build a dashboard",
+        state: "done",
+      },
+    ]);
+
+    const snapshot = await session.refresh();
+    expect(snapshot.messages).toEqual(rendered);
+    expect(snapshot.threadState.title).toBe("Memory test");
+    expect(snapshot.turnStatus).toBe("idle");
+
+    await session.dispose();
+    expect(statuses.at(-1)).toBe("disconnected");
+  });
+
+  it("accepts injected events for deterministic UI tests", async () => {
+    const transport = createMemoryChatTransport();
+    const onEvent = vi.fn();
+    await transport.connect(
+      {
+        threadId: "thread-events",
+        workspaceId: "ws-1",
+        orgId: "org-1",
+      },
+      {
+        onEvent,
+        onStatus: vi.fn(),
+        onError: vi.fn(),
+      },
+    );
+
+    transport.emit("thread-events", {
+      type: "state",
+      state: { previewUrl: "https://preview.example" },
+    });
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "state",
+      state: { previewUrl: "https://preview.example" },
+    });
+    expect(transport.getSnapshot("thread-events")?.threadState.previewUrl).toBe(
+      "https://preview.example",
+    );
+  });
+});

--- a/agentos-platform/tsconfig.json
+++ b/agentos-platform/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["bun-types"],
+    "rootDir": ".",
+    "baseUrl": "."
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", ".data"]
+}

--- a/agentos-platform/tsconfig.json
+++ b/agentos-platform/tsconfig.json
@@ -1,18 +1,29 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
+    "jsx": "react-jsx",
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["bun-types"],
+    "types": ["bun-types", "vite/client"],
     "rootDir": ".",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["src/shared/*"],
+      "@client/*": ["src/client/*"]
+    }
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "include": [
+    "src/**/*.ts",
+    "web/**/*.ts",
+    "web/**/*.tsx",
+    "tests/**/*.ts",
+    "vitest.config.ts"
+  ],
   "exclude": ["node_modules", ".data"]
 }

--- a/agentos-platform/vitest.config.ts
+++ b/agentos-platform/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+    testTimeout: 15_000,
+  },
+});

--- a/agentos-platform/web/index.html
+++ b/agentos-platform/web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#111315" />
+    <title>camelAI agentOS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/agentos-platform/web/src/App.tsx
+++ b/agentos-platform/web/src/App.tsx
@@ -1,0 +1,165 @@
+import { useMemo } from "react";
+import {
+  createMemoryChatTransport,
+  useRivetChat,
+} from "@client/use-rivet-chat";
+import { ChatPanel } from "./components/ChatPanel";
+
+const endpoint =
+  import.meta.env.VITE_RIVET_ENDPOINT ?? "http://localhost:6420";
+const useMemory = import.meta.env.VITE_CHAT_MODE === "memory";
+
+export function App() {
+  const transport = useMemo(
+    () => (useMemory ? createMemoryChatTransport() : undefined),
+    [],
+  );
+  const chat = useRivetChat({
+    endpoint,
+    transport,
+    threadId: "thread_demo",
+    workspaceId: "ws_demo",
+    orgId: "org_demo",
+    projectId: "app",
+    initialTitle: "Build the next feature",
+  });
+
+  return (
+    <div className="app-shell">
+      <aside className="workspace-rail" aria-label="Workspace navigation">
+        <div className="brand">
+          <span className="brand-mark">c</span>
+          <span>camelAI</span>
+        </div>
+
+        <nav className="rail-nav">
+          <button className="rail-item active" type="button">
+            <span className="rail-icon" aria-hidden="true">
+              ◫
+            </span>
+            Agent
+          </button>
+          <button className="rail-item" type="button">
+            <span className="rail-icon" aria-hidden="true">
+              ⌘
+            </span>
+            Files
+          </button>
+          <button className="rail-item" type="button">
+            <span className="rail-icon" aria-hidden="true">
+              ⎇
+            </span>
+            Deploys
+          </button>
+        </nav>
+
+        <div className="workspace-switcher">
+          <span className="eyebrow">Workspace</span>
+          <strong>Demo workspace</strong>
+          <span className="muted">app / main</span>
+        </div>
+      </aside>
+
+      <main className="workbench">
+        <header className="topbar">
+          <div>
+            <span className="eyebrow">Agent session</span>
+            <h1>{chat.threadState.title ?? "Untitled thread"}</h1>
+          </div>
+          <div className="topbar-actions">
+            <span className={`status-pill status-${chat.connStatus}`}>
+              <span className="status-dot" />
+              {chat.connStatus}
+            </span>
+            <button
+              className="button secondary"
+              type="button"
+              onClick={() => void chat.refresh()}
+              disabled={chat.connStatus !== "connected"}
+            >
+              Refresh
+            </button>
+          </div>
+        </header>
+
+        <div className="workbench-body">
+          <ChatPanel chat={chat} />
+
+          <aside className="context-panel" aria-label="Session context">
+            <section className="context-section">
+              <div className="section-heading">
+                <span>Session</span>
+                <span className="section-count">{chat.turnStatus}</span>
+              </div>
+              <dl className="metadata-list">
+                <div>
+                  <dt>Model</dt>
+                  <dd>{chat.threadState.model ?? "Default"}</dd>
+                </div>
+                <div>
+                  <dt>Context</dt>
+                  <dd>
+                    {chat.threadState.contextUsedPercent === null
+                      ? "—"
+                      : `${chat.threadState.contextUsedPercent}%`}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Endpoint</dt>
+                  <dd title={endpoint}>
+                    {useMemory ? "In-memory demo" : endpoint}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="context-section context-grow">
+              <div className="section-heading">
+                <span>Plan</span>
+                <span className="section-count">
+                  {chat.threadState.currentTodos.length}
+                </span>
+              </div>
+              {chat.threadState.currentTodos.length === 0 ? (
+                <p className="empty-copy">
+                  Agent todos will appear here during a turn.
+                </p>
+              ) : (
+                <ul className="todo-list">
+                  {chat.threadState.currentTodos.map((todo, index) => (
+                    <li key={`${todo.content}-${index}`}>
+                      <span className={`todo-state ${todo.status}`} />
+                      <span>
+                        {todo.status === "in_progress"
+                          ? todo.activeForm
+                          : todo.content}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <section className="context-section">
+              <div className="section-heading">
+                <span>Preview</span>
+              </div>
+              {chat.threadState.previewUrl ? (
+                <a
+                  className="preview-link"
+                  href={chat.threadState.previewUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Open current preview ↗
+                </a>
+              ) : (
+                <p className="empty-copy">No preview is active.</p>
+              )}
+            </section>
+          </aside>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/agentos-platform/web/src/components/ChatPanel.tsx
+++ b/agentos-platform/web/src/components/ChatPanel.tsx
@@ -1,0 +1,235 @@
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useRivetChat } from "@client/use-rivet-chat";
+import type { AskUserQuestionItem } from "@shared/index";
+import { MessageBubble } from "./MessageBubble";
+
+type ChatPanelProps = {
+  chat: ReturnType<typeof useRivetChat>;
+};
+
+function selectedValues(value: string | undefined): string[] {
+  return value ? value.split("\n").filter(Boolean) : [];
+}
+
+export function ChatPanel({ chat }: ChatPanelProps) {
+  const [draft, setDraft] = useState("");
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const messageEndRef = useRef<HTMLDivElement>(null);
+  const pendingQuestion = chat.threadState.pendingQuestion;
+  const isRunning =
+    chat.turnStatus === "streaming" || chat.turnStatus === "recovering";
+
+  useEffect(() => {
+    messageEndRef.current?.scrollIntoView({ block: "end" });
+  }, [chat.messages]);
+
+  useEffect(() => {
+    setAnswers({});
+  }, [pendingQuestion?.questionId]);
+
+  async function submitMessage(event?: FormEvent) {
+    event?.preventDefault();
+    const content = draft.trim();
+    if (!content || chat.connStatus !== "connected") return;
+    setDraft("");
+    try {
+      await chat.sendMessage(content);
+    } catch {
+      setDraft(content);
+    }
+  }
+
+  function onComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void submitMessage();
+    }
+  }
+
+  function toggleOption(question: AskUserQuestionItem, label: string) {
+    setAnswers((current) => {
+      if (!question.multiSelect) {
+        return { ...current, [question.question]: label };
+      }
+      const selected = selectedValues(current[question.question]);
+      const next = selected.includes(label)
+        ? selected.filter((value) => value !== label)
+        : [...selected, label];
+      return { ...current, [question.question]: next.join("\n") };
+    });
+  }
+
+  async function submitAnswers(event: FormEvent) {
+    event.preventDefault();
+    if (!pendingQuestion) return;
+    await chat.answerQuestion(pendingQuestion.questionId, answers);
+  }
+
+  return (
+    <section className="chat-panel" aria-label="Agent conversation">
+      <div className="message-list" aria-live="polite">
+        {chat.messages.length === 0 ? (
+          <div className="empty-chat">
+            <span className="empty-chat-mark">c</span>
+            <h2>What should camelAI work on?</h2>
+            <p>
+              Describe a feature, bug, or investigation. The agent can inspect
+              and modify this workspace.
+            </p>
+            {chat.connStatus === "connected" && (
+              <div className="prompt-examples">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setDraft("Inspect the project and summarize its architecture.")
+                  }
+                >
+                  Summarize the architecture
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setDraft("Find the highest-impact issue and propose a fix.")
+                  }
+                >
+                  Find a high-impact issue
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          chat.messages.map((message) => (
+            <MessageBubble key={message.id} message={message} />
+          ))
+        )}
+        <div ref={messageEndRef} />
+      </div>
+
+      {pendingQuestion && (
+        <form className="question-card" onSubmit={submitAnswers}>
+          <div className="question-card-header">
+            <span className="agent-avatar">c</span>
+            <div>
+              <strong>Agent needs input</strong>
+              <span>Choose an option to continue the turn.</span>
+            </div>
+          </div>
+
+          {pendingQuestion.questions.map((question) => (
+            <fieldset key={question.question}>
+              <legend>
+                <span>{question.header}</span>
+                {question.question}
+              </legend>
+              <div className="question-options">
+                {question.options.map((option) => {
+                  const isSelected = selectedValues(
+                    answers[question.question],
+                  ).includes(option.label);
+                  return (
+                    <button
+                      key={option.label}
+                      className={isSelected ? "selected" : ""}
+                      type="button"
+                      aria-pressed={isSelected}
+                      onClick={() => toggleOption(question, option.label)}
+                    >
+                      <strong>{option.label}</strong>
+                      {option.description && <span>{option.description}</span>}
+                    </button>
+                  );
+                })}
+              </div>
+              {question.allowOther !== false && (
+                <input
+                  className="question-other"
+                  value={
+                    question.options.some((option) =>
+                      selectedValues(answers[question.question]).includes(
+                        option.label,
+                      ),
+                    )
+                      ? ""
+                      : (answers[question.question] ?? "")
+                  }
+                  onChange={(event) =>
+                    setAnswers((current) => ({
+                      ...current,
+                      [question.question]: event.target.value,
+                    }))
+                  }
+                  placeholder="Or type a custom answer"
+                />
+              )}
+            </fieldset>
+          ))}
+
+          <div className="question-actions">
+            <button
+              className="button primary"
+              type="submit"
+              disabled={pendingQuestion.questions.some(
+                (question) => !answers[question.question]?.trim(),
+              )}
+            >
+              Continue
+            </button>
+          </div>
+        </form>
+      )}
+
+      {chat.error && (
+        <div className="error-banner" role="alert">
+          <strong>Chat error</strong>
+          <span>{chat.error.message}</span>
+        </div>
+      )}
+
+      <form className="composer" onSubmit={submitMessage}>
+        <textarea
+          aria-label="Message camelAI"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={onComposerKeyDown}
+          placeholder={
+            chat.connStatus === "connected"
+              ? "Ask camelAI to build, debug, or explain…"
+              : "Connecting to agentOS…"
+          }
+          rows={3}
+          disabled={chat.connStatus !== "connected" || !!pendingQuestion}
+        />
+        <div className="composer-footer">
+          <span>
+            Enter to send <kbd>Shift</kbd> + <kbd>Enter</kbd> for newline
+          </span>
+          {isRunning ? (
+            <button
+              className="button stop"
+              type="button"
+              onClick={() => void chat.requestStop()}
+            >
+              <span className="stop-square" />
+              Stop
+            </button>
+          ) : (
+            <button
+              className="button primary"
+              type="submit"
+              disabled={!draft.trim() || chat.connStatus !== "connected"}
+            >
+              Send
+              <span aria-hidden="true">↵</span>
+            </button>
+          )}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/agentos-platform/web/src/components/MessageBubble.tsx
+++ b/agentos-platform/web/src/components/MessageBubble.tsx
@@ -1,0 +1,129 @@
+import type { UiMessage, UiPart } from "@shared/index";
+
+type MessageBubbleProps = {
+  message: UiMessage;
+};
+
+function displayValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function MessagePart({ part }: { part: UiPart }) {
+  switch (part.type) {
+    case "text":
+      return (
+        <div className="message-text">
+          {part.text}
+          {part.state === "streaming" && (
+            <span className="streaming-cursor" aria-label="Streaming" />
+          )}
+        </div>
+      );
+    case "reasoning":
+      return (
+        <details className="reasoning-block">
+          <summary>Thinking</summary>
+          <div>{part.text}</div>
+        </details>
+      );
+    case "tool-call":
+      return (
+        <details className="tool-block" open={part.state === "input-streaming"}>
+          <summary>
+            <span className="tool-icon" aria-hidden="true">
+              ⌁
+            </span>
+            <span>{part.toolName}</span>
+            <span className="tool-state">
+              {part.state === "input-streaming" ? "preparing" : "called"}
+            </span>
+          </summary>
+          <pre>{displayValue(part.input)}</pre>
+        </details>
+      );
+    case "tool-result":
+      return (
+        <details className={`tool-block ${part.isError ? "tool-error" : ""}`}>
+          <summary>
+            <span className="tool-icon" aria-hidden="true">
+              {part.isError ? "!" : "✓"}
+            </span>
+            <span>{part.toolName ?? "Tool result"}</span>
+            <span className="tool-state">
+              {part.isError ? "failed" : "complete"}
+            </span>
+          </summary>
+          <pre>{displayValue(part.output)}</pre>
+        </details>
+      );
+    case "data-error":
+      return (
+        <div className="message-error" role="alert">
+          <strong>{part.data.title ?? "Agent error"}</strong>
+          <span>{part.data.error}</span>
+        </div>
+      );
+    case "data-todos":
+      return (
+        <div className="inline-todos">
+          {part.data.explanation && <p>{part.data.explanation}</p>}
+          <ul>
+            {part.data.todos.map((todo, index) => (
+              <li key={`${todo.content}-${index}`}>
+                <span className={`todo-state ${todo.status}`} />
+                {todo.status === "in_progress"
+                  ? todo.activeForm
+                  : todo.content}
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+    case "data-tool-stream":
+      return (
+        <pre className="tool-stream" data-sequence={part.data.seq}>
+          {part.data.text}
+        </pre>
+      );
+  }
+}
+
+export function MessageBubble({ message }: MessageBubbleProps) {
+  const isUser = message.role === "user";
+
+  return (
+    <article className={`message-row ${isUser ? "message-user" : ""}`}>
+      <div className={`message-avatar ${isUser ? "user-avatar" : ""}`}>
+        {isUser ? "Y" : "c"}
+      </div>
+      <div className="message-content">
+        <div className="message-meta">
+          <strong>{isUser ? "You" : "camelAI"}</strong>
+          <time dateTime={new Date(message.createdAt).toISOString()}>
+            {new Date(message.createdAt).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </time>
+        </div>
+        <div className="message-parts">
+          {message.parts.map((part, index) => (
+            <MessagePart
+              key={
+                "toolCallId" in part
+                  ? `${part.type}-${part.toolCallId}`
+                  : `${part.type}-${index}`
+              }
+              part={part}
+            />
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/agentos-platform/web/src/main.tsx
+++ b/agentos-platform/web/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Missing #root element");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/agentos-platform/web/src/styles.css
+++ b/agentos-platform/web/src/styles.css
@@ -1,0 +1,854 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-synthesis: none;
+  --bg: #111315;
+  --panel: #16191c;
+  --panel-raised: #1c2024;
+  --panel-muted: #141719;
+  --border: #2a2f34;
+  --border-strong: #3a4147;
+  --text: #f0f1f2;
+  --text-muted: #959da5;
+  --text-dim: #6f7880;
+  --accent: #d7ff64;
+  --accent-ink: #182000;
+  --danger: #ff7a7a;
+  --warning: #e8bb63;
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  min-width: 320px;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+}
+
+button,
+textarea,
+input {
+  font: inherit;
+}
+
+button {
+  color: inherit;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 216px minmax(0, 1fr);
+  height: 100%;
+  overflow: hidden;
+}
+
+.workspace-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-height: 0;
+  padding: 18px 14px 14px;
+  background: #0d0f10;
+  border-right: 1px solid var(--border);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 7px;
+  font-weight: 720;
+  letter-spacing: -0.02em;
+}
+
+.brand-mark,
+.empty-chat-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 25px;
+  height: 25px;
+  border-radius: 7px;
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-weight: 850;
+}
+
+.rail-nav {
+  display: grid;
+  gap: 3px;
+}
+
+.rail-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 9px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  text-align: left;
+  cursor: pointer;
+}
+
+.rail-item:hover {
+  color: var(--text);
+  background: #171a1d;
+}
+
+.rail-item.active {
+  color: var(--text);
+  background: #1c2023;
+  border-color: #252a2e;
+}
+
+.rail-icon {
+  width: 18px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+.workspace-switcher {
+  display: grid;
+  gap: 4px;
+  margin-top: auto;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: #131618;
+  font-size: 12px;
+}
+
+.eyebrow {
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.workbench {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 62px;
+  padding: 9px 16px 9px 20px;
+  border-bottom: 1px solid var(--border);
+  background: #121517;
+}
+
+.topbar h1 {
+  max-width: 60vw;
+  margin: 3px 0 0;
+  overflow: hidden;
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+
+.status-connected .status-dot {
+  background: #7bd88f;
+  box-shadow: 0 0 0 2px rgb(123 216 143 / 12%);
+}
+
+.status-connecting .status-dot {
+  background: var(--warning);
+}
+
+.workbench-body {
+  display: grid;
+  grid-template-columns: minmax(420px, 1fr) 260px;
+  min-height: 0;
+  flex: 1;
+}
+
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--panel);
+}
+
+.message-list {
+  min-height: 0;
+  padding: 8px max(24px, calc((100% - 820px) / 2));
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-color: #394047 transparent;
+}
+
+.empty-chat {
+  display: grid;
+  justify-items: center;
+  max-width: 500px;
+  margin: 18vh auto 0;
+  text-align: center;
+}
+
+.empty-chat-mark {
+  width: 34px;
+  height: 34px;
+  margin-bottom: 14px;
+  border-radius: 9px;
+}
+
+.empty-chat h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.025em;
+}
+
+.empty-chat p {
+  max-width: 440px;
+  margin: 8px 0 18px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.prompt-examples {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.prompt-examples button {
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-raised);
+  color: #c9ced2;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.prompt-examples button:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.message-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 10px;
+  padding: 18px 4px;
+  border-bottom: 1px solid rgb(42 47 52 / 70%);
+}
+
+.message-avatar,
+.agent-avatar {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.message-avatar.user-avatar {
+  background: #343a40;
+  color: #d9dde0;
+}
+
+.message-content {
+  min-width: 0;
+}
+
+.message-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 3px 0 8px;
+  font-size: 12px;
+}
+
+.message-meta time {
+  color: var(--text-dim);
+  font-size: 10px;
+}
+
+.message-parts {
+  display: grid;
+  gap: 8px;
+}
+
+.message-text {
+  color: #d9dcde;
+  font-size: 13px;
+  line-height: 1.62;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.message-user .message-text {
+  color: var(--text);
+}
+
+.streaming-cursor {
+  display: inline-block;
+  width: 6px;
+  height: 14px;
+  margin-left: 3px;
+  background: var(--accent);
+  vertical-align: -2px;
+  animation: blink 1s steps(2, start) infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+.reasoning-block,
+.tool-block {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-muted);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.reasoning-block summary,
+.tool-block summary {
+  padding: 7px 9px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.reasoning-block > div {
+  padding: 0 9px 9px;
+  color: #aeb4b9;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.tool-block summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  list-style: none;
+}
+
+.tool-block summary::-webkit-details-marker {
+  display: none;
+}
+
+.tool-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: #252a2e;
+  color: #b4bbc0;
+}
+
+.tool-state {
+  margin-left: auto;
+  color: var(--text-dim);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.tool-block pre,
+.tool-stream {
+  max-height: 260px;
+  margin: 0;
+  padding: 9px;
+  overflow: auto;
+  border-top: 1px solid var(--border);
+  color: #bfc5c9;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 10px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.tool-block.tool-error {
+  border-color: rgb(255 122 122 / 35%);
+}
+
+.message-error,
+.error-banner {
+  display: grid;
+  gap: 3px;
+  padding: 8px 10px;
+  border: 1px solid rgb(255 122 122 / 35%);
+  border-radius: 6px;
+  background: rgb(255 122 122 / 6%);
+  color: #ffb0b0;
+  font-size: 11px;
+}
+
+.inline-todos {
+  padding: 8px 10px;
+  border-left: 2px solid var(--border-strong);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.inline-todos p {
+  margin: 0 0 6px;
+}
+
+.inline-todos ul,
+.todo-list {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.inline-todos li,
+.todo-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+}
+
+.todo-state {
+  width: 8px;
+  height: 8px;
+  margin-top: 3px;
+  flex: 0 0 auto;
+  border: 1px solid #596168;
+  border-radius: 50%;
+}
+
+.todo-state.in_progress {
+  border-color: var(--warning);
+  background: var(--warning);
+}
+
+.todo-state.completed {
+  border-color: #70bf82;
+  background: #70bf82;
+}
+
+.question-card,
+.composer,
+.error-banner {
+  width: min(820px, calc(100% - 48px));
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.question-card {
+  max-height: 48%;
+  margin-bottom: 8px;
+  padding: 12px;
+  overflow-y: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--panel-raised);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 20%);
+}
+
+.question-card-header {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 12px;
+}
+
+.question-card-header > div {
+  display: grid;
+  gap: 2px;
+  font-size: 12px;
+}
+
+.question-card-header span:last-child {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.question-card fieldset {
+  display: grid;
+  gap: 8px;
+  margin: 0 0 12px;
+  padding: 0;
+  border: 0;
+}
+
+.question-card legend {
+  display: grid;
+  gap: 3px;
+  margin-bottom: 7px;
+  color: #cbd0d4;
+  font-size: 12px;
+}
+
+.question-card legend span {
+  color: var(--text-dim);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.question-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 6px;
+}
+
+.question-options button {
+  display: grid;
+  gap: 2px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: #171a1d;
+  color: #cdd1d4;
+  text-align: left;
+  cursor: pointer;
+}
+
+.question-options button:hover,
+.question-options button.selected {
+  border-color: #66703f;
+  background: #20251a;
+}
+
+.question-options button span {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.question-other {
+  width: 100%;
+  padding: 8px 9px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  outline: 0;
+  background: #121517;
+  color: var(--text);
+  font-size: 11px;
+}
+
+.question-other:focus {
+  border-color: #66703f;
+}
+
+.question-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.error-banner {
+  margin-bottom: 8px;
+}
+
+.composer {
+  margin-bottom: 16px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: #111416;
+  box-shadow: 0 10px 30px rgb(0 0 0 / 18%);
+}
+
+.composer:focus-within {
+  border-color: #5a633a;
+}
+
+.composer textarea {
+  display: block;
+  width: 100%;
+  min-height: 70px;
+  max-height: 180px;
+  padding: 11px 12px 6px;
+  resize: vertical;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.composer textarea::placeholder {
+  color: var(--text-dim);
+}
+
+.composer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 7px 7px 12px;
+  color: var(--text-dim);
+  font-size: 9px;
+}
+
+kbd {
+  padding: 1px 3px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: #1c2023;
+  font-size: 8px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 5px 10px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.button.primary {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.button.secondary {
+  border-color: var(--border);
+  background: #191d20;
+  color: #c1c7cb;
+}
+
+.button.stop {
+  border-color: rgb(255 122 122 / 25%);
+  background: rgb(255 122 122 / 8%);
+  color: #ffabab;
+}
+
+.stop-square {
+  width: 8px;
+  height: 8px;
+  border-radius: 1px;
+  background: currentColor;
+}
+
+.context-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  border-left: 1px solid var(--border);
+  background: #121517;
+}
+
+.context-section {
+  padding: 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.context-grow {
+  flex: 1;
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  color: #cbd0d3;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.section-count {
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: #202428;
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.metadata-list {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+}
+
+.metadata-list div {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr);
+  gap: 7px;
+  font-size: 10px;
+}
+
+.metadata-list dt {
+  color: var(--text-dim);
+}
+
+.metadata-list dd {
+  margin: 0;
+  overflow: hidden;
+  color: #b9bfc3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.empty-copy {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.todo-list {
+  color: #aeb5ba;
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.preview-link {
+  color: #c9db87;
+  font-size: 10px;
+  text-decoration: none;
+}
+
+.preview-link:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    grid-template-columns: 56px minmax(0, 1fr);
+  }
+
+  .workspace-rail {
+    align-items: center;
+    padding: 15px 8px;
+  }
+
+  .brand > span:last-child,
+  .rail-item:not(.active),
+  .rail-item.active {
+    font-size: 0;
+  }
+
+  .rail-item {
+    justify-content: center;
+    padding: 8px;
+  }
+
+  .rail-icon {
+    font-size: 14px;
+  }
+
+  .workspace-switcher {
+    display: none;
+  }
+
+  .workbench-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .context-panel {
+    display: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .app-shell {
+    display: block;
+  }
+
+  .workspace-rail {
+    display: none;
+  }
+
+  .topbar {
+    padding-left: 13px;
+  }
+
+  .status-pill,
+  .button.secondary {
+    display: none;
+  }
+
+  .message-list {
+    padding-right: 12px;
+    padding-left: 12px;
+  }
+
+  .question-card,
+  .composer,
+  .error-banner {
+    width: calc(100% - 20px);
+  }
+
+  .composer-footer > span {
+    display: none;
+  }
+
+  .composer-footer {
+    justify-content: flex-end;
+  }
+}

--- a/agentos-platform/web/vite.config.ts
+++ b/agentos-platform/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
+  server: {
+    port: 5173,
+  },
+  resolve: {
+    alias: {
+      "@shared": fileURLToPath(new URL("../src/shared", import.meta.url)),
+      "@client": fileURLToPath(new URL("../src/client", import.meta.url)),
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -96,7 +96,10 @@
 		"test:e2e:ui": "playwright test --ui",
 		"test:e2e:staging-billing": "node scripts/run-staging-billing-e2e.mjs",
 		"publish:e2e:staging-billing": "E2E_REPORT_DIR=playwright-report-staging-billing node scripts/publish-e2e-report.mjs",
-		"build:renderer": "node scripts/build-notebook-renderer.mjs"
+		"build:renderer": "node scripts/build-notebook-renderer.mjs",
+		"dev:agentos": "bun --cwd agentos-platform run dev",
+		"test:agentos": "bun --cwd agentos-platform run test",
+		"typecheck:agentos": "bun --cwd agentos-platform run typecheck"
 	},
 	"dependencies": {
 		"@ai-sdk/react": "^3.0.204",

--- a/plans/agentos-full-rewrite.md
+++ b/plans/agentos-full-rewrite.md
@@ -47,33 +47,38 @@ Rivetkit **embedded mode** — engine in-process, no separate `rivet-engine` ser
 
 ## Phases
 
-### Phase 0 — Scaffold (current)
+### Phase 0 — Scaffold
 
 - [x] `agentos-platform/` package with shared chat types
 - [x] Platform services: `Store`, `IdentityService`, `BillingService`, `ProjectFilesystem`
 - [x] Vitest + typecheck
 - [x] Docker / Compose VPS layout, `.env.example`, smoke script
-- [ ] `src/server/index.ts` — Bun HTTP + Rivetkit registry bootstrap
-- [ ] `web/` — minimal chat UI
+- [x] `src/server/index.ts` — Bun + Rivetkit registry bootstrap
+- [x] `web/` — dense chat SPA (`useRivetChat`, memory transport for offline UI)
 
 ### Phase 1 — Chat actor MVP
 
-- [ ] `chatThread` Rivet actor: websocket, `sendMessage`, turn status
-- [ ] `AGENT_RUNTIME=mock` — deterministic fake turns for UI dev
-- [ ] `ChatEvent` encoder mirroring `src/lib/pi-chunk-encoder.ts` semantics
-- [ ] Thread state patches (`StateEvent`) aligned with `src/shared/thread-state.ts`
-- [ ] Demo tenant bootstrap (`ensureDemoTenant`)
+- [x] `chatThread` Rivet actor: `sendMessage`, turn status, `chatEvent` broadcast
+- [x] `AGENT_RUNTIME=mock` — deterministic fake turns for UI/tests
+- [x] `ChatEvent` bus (`messageUpsert` / `messageDelta` / tool stream / state)
+- [x] Thread state patches aligned with `src/shared/thread-state.ts`
+- [x] Demo tenant bootstrap (`ensureDemoTenant`)
+- [x] org / workspace actors, HMAC tickets, slash commands
+- [x] React client replaces Agents SDK (`useRivetChat`)
 
 ### Phase 2 — Real agentOS / Pi
 
-- [ ] `AGENT_RUNTIME=agentos` — wire `@rivet-dev/agentos` Pi software
-- [ ] File tools backed by `ProjectFilesystem`
-- [ ] Tool permission gates + `AskUserQuestion`
-- [ ] `c.keepAwake` around full turn lifecycle
-- [ ] Context compaction + slash commands
+- [x] `chatThreadAgentOs` actor via `@rivet-dev/agentos` + Pi software package
+- [x] Camel host bindings → `ProjectFilesystem` / deploy stub / ask_user / credits
+- [x] ACP → `ChatEvent` mapper (+ unit tests)
+- [x] `c.keepAwake` around mock turn lifecycle
+- [x] Slash command stubs (`/compact`, `/context`, …)
+- [ ] Live Pi session e2e with API keys on a VPS (manual / smoke flag)
+- [ ] Full permission UI parity + turn resume across actor migrate
 
 ### Phase 3 — Platform hardening
 
+- [x] HMAC turn tickets (foundation); full session auth still TODO
 - [ ] Session auth (password + OAuth); optional proxy-auth providers
 - [ ] Stripe billing parity with `src/lib/billing-plans.ts`
 - [ ] Usage metering and credit enforcement on inference path

--- a/plans/agentos-full-rewrite.md
+++ b/plans/agentos-full-rewrite.md
@@ -78,11 +78,11 @@ Rivetkit **embedded mode** — engine in-process, no separate `rivet-engine` ser
 
 ### Phase 3 — Platform hardening
 
-- [x] HMAC turn tickets (foundation); full session auth still TODO
-- [ ] Session auth (password + OAuth); optional proxy-auth providers
-- [ ] Stripe billing parity with `src/lib/billing-plans.ts`
-- [ ] Usage metering and credit enforcement on inference path
-- [ ] Structured logging / metrics (replace Analytics Engine)
+- [x] HMAC turn tickets (foundation)
+- [x] Session auth (password + OAuth start/callback + proxy-auth CF Access/Pomerium)
+- [x] Stripe billing parity (`billing-plans`, Checkout, webhook HMAC, idempotent grants)
+- [x] Usage metering + credit enforcement on `chatThread` turns (BYOK bypass)
+- [x] Structured JSON observability + `/health` + `/api/metrics` ring buffer
 
 ### Phase 4 — Production adjacency
 

--- a/plans/agentos-full-rewrite.md
+++ b/plans/agentos-full-rewrite.md
@@ -1,0 +1,156 @@
+# agentOS full rewrite plan
+
+Cross-cutting architecture plan for replacing camelAI's Cloudflare Workers chat plane with a **Rivet Actors + agentOS** stack on a VPS. Implementation lives in [`agentos-platform/README.md`](../agentos-platform/README.md).
+
+## Goals
+
+1. **Self-hosted chat runtime** — one (or few) VPS instances instead of per-thread Durable Objects for agent turns.
+2. **agentOS harness** — run Pi (and future agent software) via `@rivet-dev/agentos` with native sidecars, not CF sandbox containers.
+3. **Graceful deploys** — version-tagged Rivet actors, dual runners, `keepAwake` on in-flight turns.
+4. **Incremental port** — shared types and platform services first; wire production auth/billing/dispatcher later.
+
+## Non-goals (phase 1)
+
+- Feature parity with production billing, SSO, admin MCP, email/Slack ingress.
+- Workers for Platforms user-app dispatcher.
+- Cloudflare R2 / D1 / Analytics Engine bindings.
+
+## Target architecture
+
+```text
+                    +------------------+
+                    |  Reverse proxy   |
+                    | (TLS, routing)   |
+                    +--------+---------+
+                             |
+              +--------------+--------------+
+              |                             |
+       +------v------+               +------v------+
+       |  web (SPA)  |               | app runner  |
+       | nginx/vite  |               | Bun+Rivetkit|
+       +-------------+               +------+------+
+                                            |
+                                     +------v------+
+                                     | chatThread  |
+                                     |   actors    |
+                                     +------+------+
+                                            |
+                              +-------------+-------------+
+                              |                           |
+                       +------v------+             +------v------+
+                       |  agentOS    |             | DATA_DIR    |
+                       |  Pi harness |             | store+proj  |
+                       +-------------+             +-------------+
+```
+
+Rivetkit **embedded mode** — engine in-process, no separate `rivet-engine` service. Optional second runner (`app-canary`) for drain testing; both mount the same `DATA_DIR` volume.
+
+## Phases
+
+### Phase 0 — Scaffold (current)
+
+- [x] `agentos-platform/` package with shared chat types
+- [x] Platform services: `Store`, `IdentityService`, `BillingService`, `ProjectFilesystem`
+- [x] Vitest + typecheck
+- [x] Docker / Compose VPS layout, `.env.example`, smoke script
+- [ ] `src/server/index.ts` — Bun HTTP + Rivetkit registry bootstrap
+- [ ] `web/` — minimal chat UI
+
+### Phase 1 — Chat actor MVP
+
+- [ ] `chatThread` Rivet actor: websocket, `sendMessage`, turn status
+- [ ] `AGENT_RUNTIME=mock` — deterministic fake turns for UI dev
+- [ ] `ChatEvent` encoder mirroring `src/lib/pi-chunk-encoder.ts` semantics
+- [ ] Thread state patches (`StateEvent`) aligned with `src/shared/thread-state.ts`
+- [ ] Demo tenant bootstrap (`ensureDemoTenant`)
+
+### Phase 2 — Real agentOS / Pi
+
+- [ ] `AGENT_RUNTIME=agentos` — wire `@rivet-dev/agentos` Pi software
+- [ ] File tools backed by `ProjectFilesystem`
+- [ ] Tool permission gates + `AskUserQuestion`
+- [ ] `c.keepAwake` around full turn lifecycle
+- [ ] Context compaction + slash commands
+
+### Phase 3 — Platform hardening
+
+- [ ] Session auth (password + OAuth); optional proxy-auth providers
+- [ ] Stripe billing parity with `src/lib/billing-plans.ts`
+- [ ] Usage metering and credit enforcement on inference path
+- [ ] Structured logging / metrics (replace Analytics Engine)
+
+### Phase 4 — Production adjacency
+
+- [ ] Project build + deploy (replace `ProjectBuildSandbox` or hybrid)
+- [ ] Notebook analysis runner
+- [ ] SQL / data proxy path (relay or embedded runner)
+- [ ] Import/migration tooling from production DO exports
+- [ ] Dual-run or cutover strategy vs existing Workers plane
+
+## Graceful deploy design
+
+Rivet actor versioning uses `RIVET_ENVOY_VERSION` (integer, monotonic per release). See [Rivet docs — actor versions](https://rivet.dev/docs/actors/versions).
+
+### Build
+
+- Pass `RIVET_ENVOY_VERSION` as Docker `ARG` / `ENV` (see `agentos-platform/Dockerfile`).
+- Each production image gets a new version number.
+
+### Runtime
+
+| Mechanism | Purpose |
+| --- | --- |
+| `RIVET_ENVOY_VERSION` | Tags new actor placements on the updated runner |
+| Old runner | Stops accepting new actors; existing actors drain |
+| `c.keepAwake(promise)` | Blocks actor sleep/finalize until turn completes |
+| Shared `DATA_DIR` | Project files + JSON store visible to both runners during transition |
+
+### Rolling procedure
+
+1. Build image with `RIVET_ENVOY_VERSION=N+1`.
+2. Start `app-canary` (or scale second replica) on the new version.
+3. Configure proxy / Rivet pool routing so **new** `chatThread` actors land on `N+1`.
+4. Wait for version `N` actors to finalize (monitor actor counts / logs).
+5. Stop version `N` runner; promote canary to primary if needed.
+6. Increment stored version for the next release.
+
+`docker-compose.yml` includes `app` + `app-canary` (`--profile canary`) on ports `6420` / `6421` for local drain drills.
+
+## Key migration surfaces
+
+| Production | Rewrite target |
+| --- | --- |
+| `workers/main/src/chat-thread-do.ts` | `chatThread` actor module |
+| `workers/main/src/chat-thread/*` | Actor collaborators (recovery, tools, preview) |
+| `src/lib/pi-chunk-encoder.ts` | Server-side `ChatEvent` emission |
+| `src/lib/ui-message-adapter.ts` | Web client adapter |
+| `WorkspaceFilesystemDO` | `ProjectFilesystem` |
+| `UserDO` / `OrgDO` | Identity actors or expanded `IdentityService` |
+
+Detailed row-by-row map: [`agentos-platform/README.md`](../agentos-platform/README.md#migration-map-chatthreaddo--chatthread-actor).
+
+## Verification
+
+```bash
+# From repo root
+bun run test:agentos
+bun run typecheck:agentos
+agentos-platform/scripts/smoke.sh
+
+# VPS integration (when server exists)
+docker compose -f agentos-platform/docker-compose.yml up --build -d
+curl -f http://localhost:6420/health
+```
+
+## Open questions
+
+- **Object storage** — local disk only vs S3/R2 for uploads and artifacts.
+- **Multi-tenant isolation** — single VPS vs sharded runners per org.
+- **Build/deploy for user apps** — retain CF dispatcher or embed in agentOS runtime.
+- **Cutover** — blue/green at DNS vs gradual thread migration export.
+
+## Links
+
+- Implementation README: [`agentos-platform/README.md`](../agentos-platform/README.md)
+- Production agent guide: [`AGENTS.md`](../AGENTS.md)
+- Chat transcript invariants (reference): `docs/chat-transcript-simplification.md`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Starts the full rewrite of camelAI’s chat/agent plane off Cloudflare Workers + Agents SDK onto **Rivet Actors + agentOS** for VPS hosting — through **Phase 3 (platform hardening)**.

New package: `agentos-platform/` (production CF stack is untouched).

### Phases 0–2 (runtime)

- Rivet actors: `chatThread` (mock), `chatThreadAgentOs` (Pi via `@rivet-dev/agentos`), `org`, `workspace`
- Platform services: identity, ledger billing, project filesystem, usage
- Camel host bindings + ACP → `ChatEvent` mapper
- React SPA + `useRivetChat` (no Agents SDK)
- HMAC tickets, slash commands
- VPS Docker / dual-runner drain (`RIVET_ENVOY_VERSION`)

### Phase 3 (this update)

- **Session auth:** password (scrypt), GitHub/Google OAuth, CF Access / Pomerium proxy headers; cookie sessions on `AUTH_HTTP_PORT` (default `:6422`)
- **Stripe billing:** plan limits parity, Checkout (subscription + credits), webhook HMAC, idempotent included/purchased grants, `STRIPE_MODE` key prefix checks
- **Metering / credits:** `UsageService`, hosted-turn gate on `chatThread`, BYOK bypass (`AGENT_BYOK` / `byok:` model)
- **Observability:** structured JSON stdout events, counters, ring buffer, `GET /health`, `GET /api/metrics`

### Verification

```bash
bun run test:agentos          # 82 tests
bun run typecheck:agentos
bun --cwd agentos-platform run smoke
bun --cwd agentos-platform run test:live-smoke
```

### Still TODO (Phase 4+)

Dispatcher / user-app deploys, builds/notebooks/SQL runners, R2/uploads, admin MCP, production data migration, live Pi e2e with API keys on a VPS.

See `agentos-platform/README.md` and `plans/agentos-full-rewrite.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb588-94bc-7383-9124-6c2d3da18610?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb588-94bc-7383-9124-6c2d3da18610&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

