### PR TITLE
Right-size Cloudflare sandbox containers to cut bill

### DIFF
--- a/tests/container-sizing.test.ts
+++ b/tests/container-sizing.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  ANALYSIS_INSTANCE_TYPE,
+  ANALYSIS_SLEEP_AFTER,
+  DB_QUERY_INSTANCE_TYPE,
+  DB_QUERY_SLEEP_AFTER,
+  EVAL_INSTANCE_TYPE,
+  PROJECT_BUILD_INSTANCE_TYPE,
+  PROJECT_BUILD_SLEEP_AFTER,
+} from "../workers/main/src/container-sizing.ts";
+
+/**
+ * Strip // and /* *\/ comments plus trailing commas so wrangler JSONC can be
+ * JSON.parse'd. Good enough for our containers blocks (no // inside strings).
+ */
+function loadJsonc(path: string): { containers?: Array<{ class_name: string; instance_type: string }> } {
+  const raw = readFileSync(path, "utf8");
+  const stripped = raw
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "")
+    .replace(/,\s*([\]}])/g, "$1");
+  return JSON.parse(stripped);
+}
+
+function instanceTypesByClass(path: string): Record<string, string> {
+  const config = loadJsonc(resolve(process.cwd(), path));
+  const out: Record<string, string> = {};
+  for (const entry of config.containers ?? []) {
+    out[entry.class_name] = entry.instance_type;
+  }
+  return out;
+}
+
+const EXPECTED = {
+  ProjectBuildSandbox: PROJECT_BUILD_INSTANCE_TYPE,
+  AnalysisSandbox: ANALYSIS_INSTANCE_TYPE,
+  DbQuerySandbox: DB_QUERY_INSTANCE_TYPE,
+  EvalSandbox: EVAL_INSTANCE_TYPE,
+} as const;
+
+describe("container right-sizing", () => {
+  it("keeps idle sleep shorter than the SDK 10m default for provisioned billing", () => {
+    expect(PROJECT_BUILD_SLEEP_AFTER).toBe("2m");
+    expect(ANALYSIS_SLEEP_AFTER).toBe("5m");
+    expect(DB_QUERY_SLEEP_AFTER).toBe("2m");
+  });
+
+  it.each([
+    ["wrangler.prod.jsonc", ["ProjectBuildSandbox", "AnalysisSandbox", "DbQuerySandbox"]],
+    ["wrangler.staging.jsonc", ["ProjectBuildSandbox", "AnalysisSandbox", "DbQuerySandbox"]],
+    ["wrangler.jsonc", ["ProjectBuildSandbox", "AnalysisSandbox", "DbQuerySandbox"]],
+    ["wrangler.test.jsonc", ["EvalSandbox", "ProjectBuildSandbox", "AnalysisSandbox"]],
+    ["wrangler.dev-miguel.jsonc", ["ProjectBuildSandbox", "DbQuerySandbox"]],
+    ["wrangler.dev-illiana.jsonc", ["ProjectBuildSandbox", "DbQuerySandbox"]],
+  ] as const)("%s instance_type matches container-sizing.ts", (path, classes) => {
+    const types = instanceTypesByClass(path);
+    for (const className of classes) {
+      expect(types[className], `${path} ${className}`).toBe(EXPECTED[className]);
+    }
+  });
+});

--- a/workers/main/src/analysis-sandbox.ts
+++ b/workers/main/src/analysis-sandbox.ts
@@ -1,5 +1,6 @@
 import { InvalidMountConfigError, S3FSMountError, Sandbox } from "@cloudflare/sandbox";
 
+import { ANALYSIS_SLEEP_AFTER } from "./container-sizing.js";
 import { handleAuthenticatedConnectionsRpc } from "./routes/connections-rpc.js";
 import type { Env } from "./types.js";
 
@@ -123,6 +124,9 @@ export class AnalysisSandbox extends Sandbox<Env> {
   // so the baked container-server trusts the interception CA for spawned
   // processes. connections.internal is plain HTTP and unaffected.
   interceptHttps = true;
+  // Memory/disk bill while awake; 5m is enough for interactive notebooks
+  // without the SDK's 10m default idle burn (see container-sizing.ts).
+  sleepAfter = ANALYSIS_SLEEP_AFTER;
 
   // Mount paths already established in this container, and a per-path single-flight
   // gate coalescing concurrent mount attempts of the SAME path. Both are tied to

--- a/workers/main/src/container-sizing.ts
+++ b/workers/main/src/container-sizing.ts
@@ -1,0 +1,42 @@
+/**
+ * Cloudflare container right-sizing.
+ *
+ * Memory and disk are billed on *provisioned* resources for every second a
+ * container is awake; CPU is active-usage only. Prefer the smallest instance
+ * type that fits the workload, and sleep bursty sandboxes quickly.
+ *
+ * Instance types (Cloudflare predefined):
+ *   lite        1/16 vCPU · 256 MiB · 2 GB
+ *   basic       1/4  vCPU · 1 GiB   · 4 GB
+ *   standard-1  1/2  vCPU · 4 GiB   · 8 GB
+ *   standard-2  1    vCPU · 6 GiB   · 12 GB
+ *   standard-3  2    vCPU · 8 GiB   · 16 GB
+ *   standard-4  4    vCPU · 12 GiB  · 20 GB
+ *
+ * Keep wrangler `instance_type` values in sync with these constants
+ * (tests/container-sizing.test.ts).
+ */
+
+/** Per-org `bun install && bun run build` with a prewarmed bun cache. */
+export const PROJECT_BUILD_INSTANCE_TYPE = "standard-2";
+
+/**
+ * Notebooks + DuckDB over mounted Parquet. Needs headroom above a Vite build,
+ * but not the absolute max (standard-4) — most analysis fits in 8 GiB.
+ */
+export const ANALYSIS_INSTANCE_TYPE = "standard-3";
+
+/** Trusted node SQL/export runner; no user code, bounded result buffers. */
+export const DB_QUERY_INSTANCE_TYPE = "standard-1";
+
+/** Eval harness only — tiny control plane, no real build/analysis load. */
+export const EVAL_INSTANCE_TYPE = "lite";
+
+/** Builds finish in seconds; no reason to bill 10m of idle memory/disk. */
+export const PROJECT_BUILD_SLEEP_AFTER = "2m";
+
+/** Interactive notebooks; shorter than the SDK 10m default, still warm enough. */
+export const ANALYSIS_SLEEP_AFTER = "5m";
+
+/** Single-shot queries/exports; sleep promptly when the workspace goes quiet. */
+export const DB_QUERY_SLEEP_AFTER = "2m";

--- a/workers/main/src/container-sizing.ts
+++ b/workers/main/src/container-sizing.ts
@@ -17,8 +17,11 @@
  * (tests/container-sizing.test.ts).
  */
 
-/** Per-org `bun install && bun run build` with a prewarmed bun cache. */
-export const PROJECT_BUILD_INSTANCE_TYPE = "standard-2";
+/**
+ * Per-org `bun install && bun run build` with a prewarmed bun cache.
+ * standard-3 (2 vCPU) keeps Vite/esbuild parallelism without standard-4 memory.
+ */
+export const PROJECT_BUILD_INSTANCE_TYPE = "standard-3";
 
 /**
  * Notebooks + DuckDB over mounted Parquet. Needs headroom above a Vite build,

--- a/workers/main/src/db-query-sandbox.ts
+++ b/workers/main/src/db-query-sandbox.ts
@@ -1,6 +1,7 @@
 import { Sandbox } from "@cloudflare/sandbox";
 
 import { createSingleFlight, isMountAlreadyPresent } from "./analysis-sandbox.js";
+import { DB_QUERY_SLEEP_AFTER } from "./container-sizing.js";
 import type { Env } from "./types.js";
 
 /** R2 binding name the export mount resolves against (credential-less mount). */
@@ -46,6 +47,8 @@ export class DbQuerySandbox extends Sandbox<Env> {
   // HTTPS interception governs the relay's cloudflared WSS and the R2 export
   // mount — kept on regardless of the internet switch.
   interceptHttps = true;
+  // Queries/exports are short-lived; sleep promptly to cut provisioned memory/disk.
+  sleepAfter = DB_QUERY_SLEEP_AFTER;
 
   // Mount paths already established in this container + a per-path single-flight
   // gate (same pattern as AnalysisSandbox.ensureMounted). Instance state on a

--- a/workers/main/src/project-build-sandbox.ts
+++ b/workers/main/src/project-build-sandbox.ts
@@ -1,12 +1,17 @@
 import { Sandbox } from "@cloudflare/sandbox";
 
+import { PROJECT_BUILD_SLEEP_AFTER } from "./container-sizing.js";
 import type { Env } from "./types.js";
 
 /**
  * Warm per-org build container for DO+R2-backed projects.
  *
- * This is intentionally separate from WarehouseSandbox: builds execute arbitrary
- * package install/build code and need npm registry egress, while warehouse code
- * is sealed. Callers still run only fixed platform-issued commands here.
+ * This is intentionally separate from AnalysisSandbox: builds execute arbitrary
+ * package install/build code and need npm registry egress, while analysis
+ * egress is allowlisted. Callers still run only fixed platform-issued commands
+ * here. Sized as standard-2 (see container-sizing.ts) — Vite/bun builds do not
+ * need standard-4 memory/disk, which are billed while the container is awake.
  */
-export class ProjectBuildSandbox extends Sandbox<Env> {}
+export class ProjectBuildSandbox extends Sandbox<Env> {
+  sleepAfter = PROJECT_BUILD_SLEEP_AFTER;
+}

--- a/workers/main/src/project-build-sandbox.ts
+++ b/workers/main/src/project-build-sandbox.ts
@@ -9,8 +9,8 @@ import type { Env } from "./types.js";
  * This is intentionally separate from AnalysisSandbox: builds execute arbitrary
  * package install/build code and need npm registry egress, while analysis
  * egress is allowlisted. Callers still run only fixed platform-issued commands
- * here. Sized as standard-2 (see container-sizing.ts) — Vite/bun builds do not
- * need standard-4 memory/disk, which are billed while the container is awake.
+ * here. Sized as standard-3 (see container-sizing.ts) — enough vCPU for
+ * Vite/esbuild parallelism without standard-4's provisioned memory/disk.
  */
 export class ProjectBuildSandbox extends Sandbox<Env> {
   sleepAfter = PROJECT_BUILD_SLEEP_AFTER;

--- a/wrangler.dev-illiana.jsonc
+++ b/wrangler.dev-illiana.jsonc
@@ -48,7 +48,7 @@
 		{
 			"class_name": "ProjectBuildSandbox",
 			"image": "./workers/main/project-build-sandbox.Dockerfile",
-			"instance_type": "standard-2",
+			"instance_type": "standard-3",
 			"max_instances": 10
 		},
 		{

--- a/wrangler.dev-illiana.jsonc
+++ b/wrangler.dev-illiana.jsonc
@@ -48,7 +48,7 @@
 		{
 			"class_name": "ProjectBuildSandbox",
 			"image": "./workers/main/project-build-sandbox.Dockerfile",
-			"instance_type": "standard-4",
+			"instance_type": "standard-2",
 			"max_instances": 10
 		},
 		{

--- a/wrangler.dev-miguel.jsonc
+++ b/wrangler.dev-miguel.jsonc
@@ -52,7 +52,7 @@
 		{
 			"class_name": "ProjectBuildSandbox",
 			"image": "./workers/main/project-build-sandbox.Dockerfile",
-			"instance_type": "standard-4",
+			"instance_type": "standard-2",
 			"max_instances": 10
 		},
 		{

--- a/wrangler.dev-miguel.jsonc
+++ b/wrangler.dev-miguel.jsonc
@@ -52,7 +52,7 @@
 		{
 			"class_name": "ProjectBuildSandbox",
 			"image": "./workers/main/project-build-sandbox.Dockerfile",
-			"instance_type": "standard-2",
+			"instance_type": "standard-3",
 			"max_instances": 10
 		},
 		{

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -55,13 +55,13 @@
 		{
 			"class_name": "ProjectBuildSandbox",
 			"image": "./workers/main/project-build-sandbox.Dockerfile",
-			"instance_type": "standard-4",
+			"instance_type": "standard-2",
 			"max_instances": 10
 		},
 		{
 			"class_name": "AnalysisSandbox",
 			"image": "./workers/main/analysis-sandbox.Dockerfile",
-			"instance_type": "standard-4",
+			"instance_type": "standard-3",
 			"max_instances": 2
 		},
 		{

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -55,7 +55,7 @@
 		{
 			"class_name": "ProjectBuildSandbox",
 			"image": "./workers/main/project-build-sandbox.Dockerfile",
-			"instance_type": "standard-2",
+			"instance_type": "standard-3",
 			"max_instances": 10
 		},
 		{

--- a/wrangler.prod.jsonc
+++ b/wrangler.prod.jsonc
@@ -66,22 +66,25 @@
   "worker_loaders": [{ "binding": "CODE_MODE_LOADER" }],
   "containers": [
     {
+      // Per-org Vite/bun builds with a prewarmed bun cache. standard-2 (1 vCPU /
+      // 6 GiB / 12 GB) is enough — memory/disk are provisioned-billed while awake
+      // (see workers/main/src/container-sizing.ts).
       "class_name": "ProjectBuildSandbox",
       "image": "./workers/main/project-build-sandbox.Dockerfile",
-      "instance_type": "standard-4",
+      "instance_type": "standard-2",
       "max_instances": 100,
     },
     {
       // Unified analysis container (notebooks + shell + DuckDB) — successor to
-      // the warehouse tier. Largest instance type (4 vCPU / 12 GiB / 20 GB disk)
-      // for data-intensive DuckDB. The account-wide vCPU quota is shared across
-      // all environments and application creation/scale-up is rejected if the
-      // requested max_instances would exceed it; the 2026-07-10 orphan-app
-      // cleanup freed ~600 vCPU, so 100 × 4 = 400 vCPU fits with headroom.
-      // Ceiling is demand-driven, not reserved; scale-to-zero when idle.
+      // the warehouse tier. standard-3 (2 vCPU / 8 GiB / 16 GB) covers typical
+      // DuckDB/notebook work without standard-4's provisioned memory/disk cost.
+      // The account-wide vCPU quota is shared across all environments and
+      // application creation/scale-up is rejected if the requested max_instances
+      // would exceed it; 100 × 2 = 200 vCPU fits with headroom. Ceiling is
+      // demand-driven, not reserved; scale-to-zero when idle.
       "class_name": "AnalysisSandbox",
       "image": "./workers/main/analysis-sandbox.Dockerfile",
-      "instance_type": "standard-4",
+      "instance_type": "standard-3",
       "max_instances": 100,
     },
     {
@@ -90,7 +93,7 @@
       // THE SQL query/export path (connection MCP, DATA_PROXY user-app binding,
       // sandbox routes) — one warm container per active workspace, scale-to-zero
       // when idle, so the cap bounds concurrently-querying workspaces
-      // (25 × standard-1 = 25 vCPU, well under the account container budget).
+      // (25 × standard-1 = 12.5 vCPU, well under the account container budget).
       "class_name": "DbQuerySandbox",
       "image": "./workers/main/db-query-sandbox.Dockerfile",
       "instance_type": "standard-1",

--- a/wrangler.prod.jsonc
+++ b/wrangler.prod.jsonc
@@ -66,12 +66,12 @@
   "worker_loaders": [{ "binding": "CODE_MODE_LOADER" }],
   "containers": [
     {
-      // Per-org Vite/bun builds with a prewarmed bun cache. standard-2 (1 vCPU /
-      // 6 GiB / 12 GB) is enough — memory/disk are provisioned-billed while awake
-      // (see workers/main/src/container-sizing.ts).
+      // Per-org Vite/bun builds with a prewarmed bun cache. standard-3 (2 vCPU /
+      // 8 GiB / 16 GB) keeps compile parallelism without standard-4 memory/disk
+      // (provisioned-billed while awake; see workers/main/src/container-sizing.ts).
       "class_name": "ProjectBuildSandbox",
       "image": "./workers/main/project-build-sandbox.Dockerfile",
-      "instance_type": "standard-2",
+      "instance_type": "standard-3",
       "max_instances": 100,
     },
     {

--- a/wrangler.staging.jsonc
+++ b/wrangler.staging.jsonc
@@ -68,7 +68,7 @@
     {
       "class_name": "ProjectBuildSandbox",
       "image": "./workers/main/project-build-sandbox.Dockerfile",
-      "instance_type": "standard-4",
+      "instance_type": "standard-2",
       "max_instances": 25,
     },
     {
@@ -76,7 +76,7 @@
       // instance type so staging tests are representative.
       "class_name": "AnalysisSandbox",
       "image": "./workers/main/analysis-sandbox.Dockerfile",
-      "instance_type": "standard-4",
+      "instance_type": "standard-3",
       "max_instances": 10,
     },
     {

--- a/wrangler.staging.jsonc
+++ b/wrangler.staging.jsonc
@@ -68,7 +68,7 @@
     {
       "class_name": "ProjectBuildSandbox",
       "image": "./workers/main/project-build-sandbox.Dockerfile",
-      "instance_type": "standard-2",
+      "instance_type": "standard-3",
       "max_instances": 25,
     },
     {

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -21,13 +21,13 @@
 		{
 			"class_name": "ProjectBuildSandbox",
 			"image": "./workers/main/project-build-sandbox.Dockerfile",
-			"instance_type": "standard-4",
+			"instance_type": "standard-2",
 			"max_instances": 1
 		},
 		{
 			"class_name": "AnalysisSandbox",
 			"image": "./workers/main/analysis-sandbox.Dockerfile",
-			"instance_type": "standard-4",
+			"instance_type": "standard-3",
 			"max_instances": 1
 		}
 	],

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -21,7 +21,7 @@
 		{
 			"class_name": "ProjectBuildSandbox",
 			"image": "./workers/main/project-build-sandbox.Dockerfile",
-			"instance_type": "standard-2",
+			"instance_type": "standard-3",
 			"max_instances": 1
 		},
 		{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloudflare bills container **memory and disk on provisioned size** for every second a container is awake (CPU is active-usage only). Build and analysis sandboxes were both on `standard-4` (4 vCPU / 12 GiB / 20 GB) — the largest tier — so idle warm time was needlessly expensive.

| Sandbox | Before | After | Rationale |
| --- | --- | --- | --- |
| `ProjectBuildSandbox` | `standard-4` | `standard-3` (2 vCPU / 8 GiB / 16 GB) | Keeps Vite/esbuild parallelism; cuts provisioned memory ~33% vs standard-4 |
| `AnalysisSandbox` | `standard-4` | `standard-3` (2 vCPU / 8 GiB / 16 GB) | Notebooks + DuckDB still get headroom; drops provisioned memory ~33% |
| `DbQuerySandbox` | `standard-1` | `standard-1` (unchanged) | Already sized for the node SQL/export runner |

Also shortens idle `sleepAfter` below the SDK 10m default (builds/queries `2m`, analysis `5m`) so bursty workspaces stop billing memory/disk sooner.

Sizing constants live in `workers/main/src/container-sizing.ts`; `tests/container-sizing.test.ts` keeps every wrangler env in sync.

## Test plan

- [x] `bun run test:run -- tests/container-sizing.test.ts`
- [ ] Deploy to staging and spot-check a project build + notebook run
- [ ] Watch for OOM / disk pressure on analysis (raise only if needed)
- [ ] Confirm container spend trend after deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb625-24aa-77d2-906c-b43f73b5457b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb625-24aa-77d2-906c-b43f73b5457b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

