### PR TITLE
Move superuser bootstrap allowlist to env config

### DIFF
--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -30,6 +30,8 @@ export interface AuthEnv {
   TOKEN_SIGNING_SECRET: string;
   CF_ACCOUNT_ID?: string;
   CF_DISPATCH_NAMESPACE?: string;
+  /** Comma/whitespace-separated bootstrap superuser emails (optional secret). */
+  SUPERUSER_EMAILS?: string;
 }
 
 /**
@@ -48,6 +50,7 @@ export function getAuthEnv(env: CloudflareEnv): AuthEnv {
     TOKEN_SIGNING_SECRET: env.TOKEN_SIGNING_SECRET,
     CF_ACCOUNT_ID: env.CF_ACCOUNT_ID,
     CF_DISPATCH_NAMESPACE: env.CF_DISPATCH_NAMESPACE,
+    SUPERUSER_EMAILS: env.SUPERUSER_EMAILS,
   };
 }
 

--- a/src/lib/auth.server.ts
+++ b/src/lib/auth.server.ts
@@ -885,7 +885,8 @@ export function canUseSuperuserAccess(
 ): boolean {
   return Boolean(
     context.user.is_superuser &&
-    context.session.auth_source !== ENTERPRISE_OIDC_AUTH_SOURCE,
+      context.user.email_verified_at != null &&
+      context.session.auth_source !== ENTERPRISE_OIDC_AUTH_SOURCE,
   );
 }
 

--- a/src/lib/cloudflare.server.ts
+++ b/src/lib/cloudflare.server.ts
@@ -120,6 +120,8 @@ export interface CloudflareEnv {
   LOCAL_AUTH_BYPASS_HOSTS?: string;
   LOCAL_AUTH_USER_EMAIL?: string;
   LOCAL_AUTH_USER_NAME?: string;
+  /** Comma/whitespace-separated bootstrap superuser emails (prefer wrangler secret). */
+  SUPERUSER_EMAILS?: string;
 }
 
 /**

--- a/src/lib/org-sso.server.ts
+++ b/src/lib/org-sso.server.ts
@@ -507,7 +507,7 @@ export async function resolveOrgSsoUser(input: {
       input.connectionId &&
       input.issuer &&
       input.orgStub.claimSsoInvitedIdentity &&
-      !isSuperuserEmail(identity.email)
+      !isSuperuserEmail(identity.email, authEnv.SUPERUSER_EMAILS)
     ) {
       invitedIdentity = await input.orgStub.claimSsoInvitedIdentity(
         input.connectionId,
@@ -540,7 +540,7 @@ export async function resolveOrgSsoUser(input: {
         ) {
           return null;
         }
-        if (isSuperuserEmail(identity.email)) {
+        if (isSuperuserEmail(identity.email, authEnv.SUPERUSER_EMAILS)) {
           throw new Response("Superuser identities cannot use enterprise SSO", {
             status: 403,
           });
@@ -579,7 +579,7 @@ export async function resolveOrgSsoUser(input: {
     account = null;
   }
 
-  if (isSuperuserEmail(identity.email)) {
+  if (isSuperuserEmail(identity.email, authEnv.SUPERUSER_EMAILS)) {
     throw new Response("Superuser identities cannot use enterprise SSO", {
       status: 403,
     });

--- a/src/routes/api/workspaces.utils.ts
+++ b/src/routes/api/workspaces.utils.ts
@@ -109,7 +109,9 @@ export async function requireWorkspaceAccess(
     const userProfile = await authEnv.USER
       .get(authEnv.USER.idFromName(sessionContext.session.user_id))
       .getProfile();
-    superuser = Boolean(userProfile?.is_superuser);
+    superuser = Boolean(
+      userProfile?.is_superuser && userProfile.email_verified_at != null,
+    );
     return superuser;
   };
 

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -9,6 +9,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  isSuperuserEmail,
+  parseSuperuserEmails,
+} from '../workers/main/src/identity/superuser';
 
 // Types matching the actual implementation
 interface SessionData {
@@ -194,42 +198,30 @@ describe('requireSuperuser', () => {
 });
 
 describe('Superuser email allowlist', () => {
-  // Tests the email allowlist logic from worker/auth.ts
-  const SUPERUSER_EMAILS = new Set([
-    'admin-one@example.com',
-    'admin-two@example.com',
-  ]);
-
-  function isSuperuserEmail(email: string | null): boolean {
-    if (!email) return false;
-    return SUPERUSER_EMAILS.has(email.toLowerCase());
-  }
-
-  it('should return true for allowlisted emails', () => {
-    expect(isSuperuserEmail('admin-one@example.com')).toBe(true);
-    expect(isSuperuserEmail('admin-two@example.com')).toBe(true);
-  });
-
-  it('should be case-insensitive', () => {
-    expect(isSuperuserEmail('ADMIN-ONE@EXAMPLE.COM')).toBe(true);
-    expect(isSuperuserEmail('Admin-Two@Example.com')).toBe(true);
-  });
-
-  it('should return false for non-allowlisted emails', () => {
-    expect(isSuperuserEmail('other@example.com')).toBe(false);
+  it('should return false for every email when no allowlist is configured', () => {
+    expect(isSuperuserEmail('admin-one@example.com')).toBe(false);
+    expect(isSuperuserEmail('admin-two@example.com')).toBe(false);
     expect(isSuperuserEmail('admin@example.com')).toBe(false);
-    expect(isSuperuserEmail('illiana@otherdomain.com')).toBe(false);
+  });
+
+  it('should honor an explicit allowlist and be case-insensitive', () => {
+    const allowlist = parseSuperuserEmails('ops@camelai.test,other@camelai.test');
+    expect(isSuperuserEmail('ops@camelai.test', allowlist)).toBe(true);
+    expect(isSuperuserEmail('OPS@CamelAI.test', 'ops@camelai.test')).toBe(true);
+    expect(isSuperuserEmail('other@example.com', allowlist)).toBe(false);
   });
 
   it('should return false for null or empty email', () => {
-    expect(isSuperuserEmail(null)).toBe(false);
-    expect(isSuperuserEmail('')).toBe(false);
+    expect(isSuperuserEmail(null, 'ops@camelai.test')).toBe(false);
+    expect(isSuperuserEmail('', 'ops@camelai.test')).toBe(false);
   });
 
   it('should handle edge cases', () => {
-    // Email with extra spaces should fail (not trimmed)
-    expect(isSuperuserEmail(' admin@example.com ')).toBe(false);
-    // Partial match should fail
-    expect(isSuperuserEmail('admin@example.com.evil.com')).toBe(false);
+    expect(isSuperuserEmail(' ops@camelai.test ', 'ops@camelai.test')).toBe(
+      false,
+    );
+    expect(
+      isSuperuserEmail('ops@camelai.test.evil.com', 'ops@camelai.test'),
+    ).toBe(false);
   });
 });

--- a/tests/org-sso-auto-link.test.ts
+++ b/tests/org-sso-auto-link.test.ts
@@ -403,16 +403,17 @@ describe("enterprise SSO first-login linking", () => {
     expect(emailDelete).not.toHaveBeenCalled();
   });
 
-  it("rejects reserved superuser emails before claiming a tenant identity", async () => {
+  it("rejects configured bootstrap superuser emails before claiming a tenant identity", async () => {
     const claimSsoJitIdentity = vi.fn();
     const superuserIdentity = {
       ...googleIdentity,
-      email: "admin-one@example.com",
+      email: "ops@camelai.test",
     };
     try {
       await resolveOrgSsoUser({
         authEnv: {
           ...authEnv(user()),
+          SUPERUSER_EMAILS: "ops@camelai.test",
           EMAIL_TO_USER: {
             get: vi.fn().mockResolvedValue(null),
           },

--- a/tests/org-sso.test.ts
+++ b/tests/org-sso.test.ts
@@ -137,9 +137,15 @@ describe("organization OIDC SSO", () => {
   });
 
   it("never grants global superuser privileges to an enterprise SSO session", () => {
-    const user = { is_superuser: true } as never;
+    const user = { is_superuser: true, email_verified_at: Date.now() } as never;
     expect(canUseSuperuserAccess({ user, session: { auth_source: "enterprise_oidc" } as never })).toBe(false);
     expect(canUseSuperuserAccess({ user, session: { auth_source: null } as never })).toBe(true);
+    expect(
+      canUseSuperuserAccess({
+        user: { is_superuser: true, email_verified_at: null } as never,
+        session: { auth_source: null } as never,
+      }),
+    ).toBe(false);
   });
 
   it("rejects an enterprise SSO session targeting another org", async () => {

--- a/tests/workspaces-access-superuser.test.ts
+++ b/tests/workspaces-access-superuser.test.ts
@@ -75,6 +75,7 @@ describe('requireWorkspaceAccess superuser override', () => {
     getProfileMock.mockResolvedValue({
       id: 'user_123',
       is_superuser: true,
+      email_verified_at: Date.now(),
     });
 
     const result = await requireWorkspaceAccess(
@@ -100,6 +101,7 @@ describe('requireWorkspaceAccess superuser override', () => {
     getProfileMock.mockResolvedValue({
       id: 'user_123',
       is_superuser: true,
+      email_verified_at: Date.now(),
     });
 
     await expect(
@@ -145,6 +147,7 @@ describe('requireWorkspaceAccess superuser override', () => {
     getProfileMock.mockResolvedValue({
       id: 'user_123',
       is_superuser: true,
+      email_verified_at: Date.now(),
     });
 
     const result = await requireWorkspaceAccess(
@@ -170,6 +173,7 @@ describe('requireWorkspaceAccess superuser override', () => {
     getProfileMock.mockResolvedValue({
       id: 'user_123',
       is_superuser: true,
+      email_verified_at: Date.now(),
     });
 
     await expect(

--- a/workers/main/src/identity/superuser.ts
+++ b/workers/main/src/identity/superuser.ts
@@ -1,9 +1,33 @@
-const SUPERUSER_EMAILS = new Set([
-  "admin-one@example.com",
-  "admin-two@example.com",
-]);
+/**
+ * Superuser bootstrap allowlist.
+ *
+ * Configure via the `SUPERUSER_EMAILS` Worker secret (comma or whitespace
+ * separated). Explicit admin grants via the admin panel remain the normal path;
+ * the env list is only for first-admin bootstrap.
+ */
 
-export function isSuperuserEmail(email: string | null): boolean {
+export function parseSuperuserEmails(
+  raw: string | null | undefined,
+): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(/[,\s]+/)
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+export function isSuperuserEmail(
+  email: string | null,
+  allowlist: Set<string> | string | null | undefined = undefined,
+): boolean {
   if (!email) return false;
-  return SUPERUSER_EMAILS.has(email.toLowerCase());
+  const set =
+    allowlist instanceof Set
+      ? allowlist
+      : parseSuperuserEmails(
+          typeof allowlist === "string" ? allowlist : undefined,
+        );
+  return set.has(email.toLowerCase());
 }

--- a/workers/main/src/identity/user-do.ts
+++ b/workers/main/src/identity/user-do.ts
@@ -30,7 +30,7 @@ import type {
 } from "../../../../src/types";
 import { dispatchAdminEvent } from "./admin-events";
 import { getDefaultOnboardingPreferences, sanitizeOnboardingPreferences, toOnboardingPreferences } from "./onboarding";
-import { isSuperuserEmail } from "./superuser";
+import { isSuperuserEmail, parseSuperuserEmails } from "./superuser";
 import { recordObservabilityEvent } from "../observability";
 
 // Re-export for consumers that import from this module
@@ -91,8 +91,13 @@ export interface UserOAuthProvider {
   linked_at: number;
 }
 
-export function canCreateEnterpriseSsoUser(email: string): boolean {
-  return !isSuperuserEmail(email);
+export function canCreateEnterpriseSsoUser(
+  email: string,
+  allowlist?: Set<string> | string | null,
+): boolean {
+  // With an empty/missing allowlist, enterprise SSO may create the user as a
+  // normal member. Only configured bootstrap superuser emails are refused.
+  return !isSuperuserEmail(email, allowlist);
 }
 
 export interface OrgMember {
@@ -457,7 +462,10 @@ export class UserDO extends DurableObject<DOEnv> {
         const profile = JSON.parse(
           (rows[0] as { value: string }).value,
         ) as User;
-        const shouldBeSuperuser = isSuperuserEmail(profile.email);
+        const shouldBeSuperuser = isSuperuserEmail(
+          profile.email,
+          this.superuserAllowlist(),
+        );
         if (profile.is_superuser !== shouldBeSuperuser) {
           profile.is_superuser = shouldBeSuperuser;
           this.sql.exec(
@@ -742,6 +750,12 @@ export class UserDO extends DurableObject<DOEnv> {
     }
   }
 
+  private superuserAllowlist(): Set<string> {
+    return parseSuperuserEmails(
+      (this.env as { SUPERUSER_EMAILS?: string }).SUPERUSER_EMAILS,
+    );
+  }
+
   // Profile methods
   async getProfile(): Promise<User | null> {
     const rows = this.sql
@@ -752,7 +766,10 @@ export class UserDO extends DurableObject<DOEnv> {
     let changed = false;
 
     if (typeof profile.is_superuser !== "boolean") {
-      profile.is_superuser = isSuperuserEmail(profile.email);
+      profile.is_superuser = isSuperuserEmail(
+        profile.email,
+        this.superuserAllowlist(),
+      );
       changed = true;
     }
     if (!profile.avatar) {
@@ -922,13 +939,14 @@ export class UserDO extends DurableObject<DOEnv> {
 
     const now = Date.now();
     const avatar = generateDefaultAvatar(name || email);
+    const allowlist = this.superuserAllowlist();
     const profile: User = {
       id,
       email,
       email_verified_at: null,
       name,
       created_at: now,
-      is_superuser: isSuperuserEmail(email),
+      is_superuser: isSuperuserEmail(email, allowlist),
       avatar,
       is_orphaned: false,
       orphaned_at: null,
@@ -2101,7 +2119,7 @@ export class UserDO extends DurableObject<DOEnv> {
     email: string,
     name: string | null,
   ): Promise<User> {
-    if (!canCreateEnterpriseSsoUser(email)) {
+    if (!canCreateEnterpriseSsoUser(email, this.superuserAllowlist())) {
       throw new Error("enterprise_sso_superuser_forbidden");
     }
     const existing = await this.getProfile();
@@ -2147,13 +2165,14 @@ export class UserDO extends DurableObject<DOEnv> {
   ): Promise<User> {
     const now = Date.now();
     const avatar = generateDefaultAvatar(name || email);
+    const allowlist = this.superuserAllowlist();
     const profile: User = {
       id,
       email,
       email_verified_at: now,
       name,
       created_at: now,
-      is_superuser: isSuperuserEmail(email),
+      is_superuser: isSuperuserEmail(email, allowlist),
       avatar,
       is_orphaned: false,
       orphaned_at: null,

--- a/workers/main/src/routes/admin-mcp.ts
+++ b/workers/main/src/routes/admin-mcp.ts
@@ -181,7 +181,7 @@ async function verifyAdminMcpAuth(
   }
 
   const user = await env.USER.get(env.USER.idFromName(grant.user_id)).getProfile();
-  if (!user?.is_superuser) {
+  if (!user?.is_superuser || user.email_verified_at == null) {
     return Response.json(
       { error: "Forbidden", details: "Admin access required" },
       { status: 403, headers: JSON_HEADERS },

--- a/workers/main/src/types.ts
+++ b/workers/main/src/types.ts
@@ -174,6 +174,9 @@ export interface Env
   SLACK_TEAM_REGISTRY?: DurableObjectNamespace<SlackTeamRegistryDO>;
   // Admin CLI API key (set via wrangler secret)
   ADMIN_API_KEY?: string;
+  // Optional comma/whitespace-separated bootstrap superuser emails.
+  // Prefer `wrangler secret put SUPERUSER_EMAILS`.
+  SUPERUSER_EMAILS?: string;
   // Derived global admin/index read model. Tenant-owned state remains authoritative in DOs.
   APP_DB?: D1Database;
   // Optional static OAuth client id for the remote admin MCP server.

--- a/workers/main/tests/org-sso.test.ts
+++ b/workers/main/tests/org-sso.test.ts
@@ -64,8 +64,11 @@ describe("OrgDO enterprise SSO state", () => {
   });
 
   it("refuses to create a superuser identity through enterprise SSO", () => {
-    expect(canCreateEnterpriseSsoUser("admin-one@example.com")).toBe(false);
+    expect(
+      canCreateEnterpriseSsoUser("ops@camelai.test", "ops@camelai.test"),
+    ).toBe(false);
     expect(canCreateEnterpriseSsoUser("member@example.com")).toBe(true);
+    expect(canCreateEnterpriseSsoUser("admin-one@example.com")).toBe(true);
   });
 
   it("atomically consumes a login transaction once", async () => {

--- a/workers/main/tests/superuser-allowlist-hardening.test.ts
+++ b/workers/main/tests/superuser-allowlist-hardening.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import {
+  createUser,
+  getUserById,
+  updateUserProfile,
+  type TestEnv,
+} from "./test-helpers";
+import {
+  isSuperuserEmail,
+  parseSuperuserEmails,
+} from "../src/identity/superuser";
+import { canCreateEnterpriseSsoUser } from "../src/identity/user-do";
+
+const testEnv = env as unknown as TestEnv;
+
+describe("superuser allowlist hardening", () => {
+  it("does not treat any email as superuser without an explicit allowlist", () => {
+    expect(isSuperuserEmail("admin@example.com")).toBe(false);
+    expect(isSuperuserEmail("admin-one@example.com")).toBe(false);
+    expect(isSuperuserEmail("admin@camelai.com")).toBe(false);
+    expect(isSuperuserEmail("ops@camelai.test", undefined)).toBe(false);
+    expect(isSuperuserEmail("ops@camelai.test", "")).toBe(false);
+  });
+
+  it("honors only the configured SUPERUSER_EMAILS allowlist", () => {
+    const allowlist = parseSuperuserEmails(
+      "ops@camelai.test, other@camelai.test",
+    );
+    expect(isSuperuserEmail("ops@camelai.test", allowlist)).toBe(true);
+    expect(isSuperuserEmail("OPS@CamelAI.test", "ops@camelai.test")).toBe(
+      true,
+    );
+    expect(isSuperuserEmail("admin-one@example.com", allowlist)).toBe(false);
+  });
+
+  it("does not auto-grant superuser on signup when SUPERUSER_EMAILS is unset", async () => {
+    for (const email of [
+      `user-${crypto.randomUUID()}@example.com`,
+      `admin-${crypto.randomUUID()}@example.com`,
+    ]) {
+      const { userId, user } = await createUser(
+        testEnv,
+        email,
+        "password123",
+        "User",
+      );
+      expect(user.is_superuser).toBe(false);
+      expect((await getUserById(testEnv, userId))?.is_superuser).toBe(false);
+    }
+  });
+
+  it("still allows explicit admin grants", async () => {
+    const email = `grant-${crypto.randomUUID()}@example.com`;
+    const { userId } = await createUser(testEnv, email, "password123", "User");
+    await updateUserProfile(testEnv, userId, { is_superuser: true });
+    expect((await getUserById(testEnv, userId))?.is_superuser).toBe(true);
+  });
+
+  it("allows enterprise SSO user creation when no allowlist is configured", () => {
+    expect(canCreateEnterpriseSsoUser("admin-one@example.com")).toBe(true);
+    expect(
+      canCreateEnterpriseSsoUser("ops@camelai.test", "ops@camelai.test"),
+    ).toBe(false);
+  });
+});

--- a/workers/main/tests/test-helpers.ts
+++ b/workers/main/tests/test-helpers.ts
@@ -111,7 +111,12 @@ export async function updateUserProfile(
   updates: { name?: string | null; avatar?: { color?: string; content?: string }; is_superuser?: boolean }
 ): Promise<User | null> {
   const userStub = env.USER.get(env.USER.idFromName(userId));
-  return userStub.updateProfile(updates);
+  const profile = await userStub.updateProfile(updates);
+  if (updates.is_superuser === true) {
+    await userStub.markEmailVerified();
+    return userStub.getProfile();
+  }
+  return profile;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Load bootstrap superuser emails from the `SUPERUSER_EMAILS` Worker secret instead of a source constant. Superuser-gated surfaces also require a verified email.

## Deploy notes

1. Deploy this change
2. Optionally set bootstrap emails with `wrangler secret put SUPERUSER_EMAILS` (comma/whitespace separated)
3. Explicit admin grants via the admin panel remain supported

## Test plan

- [x] `bun run test:run -- tests/admin-auth.test.ts tests/org-sso.test.ts tests/workspaces-access-superuser.test.ts`
- [x] `bun run test:workers -- superuser-allowlist-hardening superuser-persistence admin-mcp-oauth user-do-chat-groups`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fba01-81d3-7643-916c-755be4ee6521?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fba01-81d3-7643-916c-755be4ee6521&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

