### PR TITLE
Set up Cursor Cloud dev environment for camelAI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,3 +365,17 @@ Tailscale host IPs are staging `100.115.221.105` and prod `100.112.135.2`. Publi
 - When adding a major subsystem, add a short map entry and the canonical test command.
 - When removing or renaming a subsystem, update this file in the same change.
 - If a detail is likely to drift quickly, document where to verify it instead of freezing it here.
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for running this repo inside a Cursor Cloud VM (no Cloudflare account/credentials available). Standard commands live in the `README.md` / `package.json` tables above — this section only captures the gotchas.
+
+- **Run fully offline with `E2E_LOCAL=1`.** The default `bun run dev` marks several bindings `remote: true` (`AI`, `R2_BUCKET`, `R2_OUTPUTS_BUCKET`, `ARTIFACTS`, `BROWSER`, `send_email`) and expects a Cloudflare login. Setting `E2E_LOCAL=1` forces every binding into local Miniflare and disables sandbox containers (see `vite.config.ts`), so no Cloudflare creds and no Docker are needed for the web app. Use `E2E_LOCAL=1 bun run dev:local-auth` (auto-seeds a `Local Dev` user/org/workspace and auto-logs-in; localhost-only) → app on `http://localhost:3001`.
+- **`.dev.vars` is required to boot** and must contain non-empty `TOKEN_SIGNING_SECRET` and `INTEGRATION_SECRET_KEY` (random values are fine — copy `.dev.vars.example`). It is gitignored; the setup step already created one in the snapshot, so it normally persists across sessions. Recreate it if missing.
+- **Exercising a real chat turn offline (no model creds):** run the deterministic fake LLM `node scripts/fake-llm.mjs` (port `8788`) and start the dev server with `TEST_LLM_REPLAY_URL=http://localhost:8788` so `resolvePiModel` routes model calls to it. The fake echoes text after `Reply with:` (prefixed `[fake-llm] `). Full hello-world command:
+  ```bash
+  TEST_LLM_REPLAY_URL=http://localhost:8788 E2E_LOCAL=1 bun run dev:local-auth
+  ```
+- **Local Playwright E2E:** `E2E_LOCAL=1 bun run test:e2e` reuses an already-running `:3001` dev server (and `:8788` fake LLM) via `reuseExistingServer`; if you want Playwright to own both, stop your manual servers first. Chromium + system deps are already installed in the snapshot (`bunx playwright install --with-deps chromium` to refresh). The two `connections-local` specs can flake against a live Vite dev server (dialog open timing); the app page itself loads fine.
+- **CI does not gate `typecheck` or `lint`** (`.github/workflows/ci.yml` runs only `test:run`, `test:workers`, and self-host checks). As a result `bun run typecheck` and `bun run lint` currently report pre-existing failures on `main` (e.g. `tests/container-sizing.test.ts` TS5097; a `no-unused-vars` warning in `chat-thread-do.ts`) that are unrelated to environment setup — do not treat them as regressions you introduced.
+- **Bun** is installed at `~/.bun/bin/bun` and symlinked to `/usr/local/bin/bun` so it resolves in non-login shells (the update script's `bun install --frozen-lockfile` depends on this).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the camelAI development environment inside a Cursor Cloud VM (no Cloudflare account/credentials available) and documents the non-obvious startup path for future agents.

The only code change is an additive `## Cursor Cloud specific instructions` section in `AGENTS.md`; no application code was modified.

## What was set up

- Installed **Bun** (`~/.bun/bin/bun`, symlinked to `/usr/local/bin/bun` for non-login shells) and ran `bun install --frozen-lockfile`.
- Created `.dev.vars` (gitignored) with random `TOKEN_SIGNING_SECRET` + `INTEGRATION_SECRET_KEY`.
- Ran the app fully offline via `E2E_LOCAL=1` (forces local Miniflare bindings, disables sandbox containers) with the deterministic fake LLM (`scripts/fake-llm.mjs`) wired through `TEST_LLM_REPLAY_URL`.
- Installed Playwright Chromium for E2E.

## Validation (all CI-gated suites pass)

| Check | Command | Result |
| --- | --- | --- |
| Build | `bun run build` | pass |
| Unit tests | `bun run test:run` | 2513 passed, 6 skipped |
| Worker tests | `bun run test:workers` | 1786 passed, 41 skipped |
| Dev server | `E2E_LOCAL=1 bun run dev:local-auth` | up on `:3001`, auto-logged-in as Local Dev |
| Hello-world | chat turn via UI + fake LLM | assistant streamed `[fake-llm] Hello from camelAI local dev environment!` |

`bun run typecheck` and `bun run lint` report pre-existing failures on `main` (`tests/container-sizing.test.ts` TS5097; a `no-unused-vars` warning in `chat-thread-do.ts`). These are **not** gated by CI (`.github/workflows/ci.yml` runs only the test suites + self-host checks) and are unrelated to environment setup.

## Hello-world demo

[camelai_chat_hello_world.mp4](https://cursor.com/agents/bc-f28aad3f-cf02-4068-b2ee-b5fde43a7de4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcamelai_chat_hello_world.mp4)

[Chat exchange with fake LLM response](https://cursor.com/agents/bc-f28aad3f-cf02-4068-b2ee-b5fde43a7de4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcamelai_chat_hello_world.webp)

## Update script

`bun install --frozen-lockfile`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f28aad3f-cf02-4068-b2ee-b5fde43a7de4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f28aad3f-cf02-4068-b2ee-b5fde43a7de4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

