### PR TITLE
Finish Discord channel production rollout

### DIFF
--- a/workers/discord-bridge/wrangler.jsonc
+++ b/workers/discord-bridge/wrangler.jsonc
@@ -36,7 +36,7 @@
       "vars": {
         "DISCORD_APPLICATION_ID": "1531378050447704264",
         "DISCORD_MESSAGE_CONTENT_MODE": "full",
-        "DISCORD_INGRESS_ENABLED": "false",
+        "DISCORD_INGRESS_ENABLED": "true",
         "DISCORD_OUTBOUND_ENABLED": "true"
       },
       "durable_objects": {

--- a/workers/discord-bridge/wrangler.jsonc
+++ b/workers/discord-bridge/wrangler.jsonc
@@ -61,7 +61,7 @@
       "vars": {
         "DISCORD_APPLICATION_ID": "1531387078808436787",
         "DISCORD_MESSAGE_CONTENT_MODE": "full",
-        "DISCORD_INGRESS_ENABLED": "false",
+        "DISCORD_INGRESS_ENABLED": "true",
         "DISCORD_OUTBOUND_ENABLED": "true"
       },
       "durable_objects": {

--- a/wrangler.prod.jsonc
+++ b/wrangler.prod.jsonc
@@ -43,7 +43,7 @@
     "WORKER_BASE_URL": "https://camelai.dev",
     "EMAIL_FROM_ADDRESS": "no-reply@mail.camelai.com",
     "WORKSPACE_EMAIL_DOMAIN": "camelai.dev",
-    "DISCORD_CHANNEL_ENABLED": "false",
+    "DISCORD_CHANNEL_ENABLED": "true",
     "DISCORD_CLIENT_ID": "1531387078808436787",
     "STRIPE_MODE": "live",
     "STRIPE_SUBSCRIPTION_PRICE_ID": "price_1TtCX7GvliMKf4vHRVJ6LKLl",

--- a/wrangler.staging.jsonc
+++ b/wrangler.staging.jsonc
@@ -42,7 +42,7 @@
     "WORKER_BASE_URL": "https://staging.camelai.dev",
     "EMAIL_FROM_ADDRESS": "agent-staging@camelai.dev",
     "WORKSPACE_EMAIL_DOMAIN": "camelai.dev",
-    "DISCORD_CHANNEL_ENABLED": "false",
+    "DISCORD_CHANNEL_ENABLED": "true",
     "DISCORD_CLIENT_ID": "1531378050447704264",
     "STRIPE_MODE": "test",
     "STRIPE_SUBSCRIPTION_PRICE_ID": "price_1TtBYWGvliMKf4vH0F0649xi",


### PR DESCRIPTION
## Summary

- keep the Discord channel catalog and bridge ingress enabled in staging
- enable the Discord channel catalog and bridge ingress in production
- persist the flags already verified in the live staging and production environments

## Impact

This completes the post-merge rollout for the Discord channel integration from #11. Eligible customers can install the public production bot, bind a Discord channel to a workspace, and exchange messages with Camel.

## Validation

- `bun run typecheck`
- `bun run test:discord-bridge` — 36 tests passed
- focused connection UI tests — 66 tests passed
- focused Discord Worker tests — 15 tests passed
- live production bridge reports the correct bot identity, a healthy Gateway heartbeat, ingress/outbound enabled, zero pending deliveries, and readiness `ready`
