### PR TITLE
Derive settled chat UI from pi_core on read

### DIFF
--- a/src/lib/chat-render-history.ts
+++ b/src/lib/chat-render-history.ts
@@ -3,10 +3,96 @@ import type { UIMessage } from "ai";
 export const CHAT_RENDER_WINDOW_MAX_MESSAGES = 50;
 export const CHAT_RENDER_WINDOW_MAX_BYTES = 4 * 1024 * 1024;
 
+/** Opaque older-page cursor for derive-on-read history (`d:<endExclusiveIndex>`). */
+export const DERIVED_RENDER_HISTORY_CURSOR_PREFIX = "d:";
+
 export interface ChatRenderHistoryPage {
   messages: UIMessage[];
   nextCursor: string | null;
   hasMore: boolean;
+}
+
+export function estimateUiMessageBytes(message: UIMessage): number {
+  try {
+    return JSON.stringify(message).length;
+  } catch {
+    return 1024;
+  }
+}
+
+export function encodeDerivedRenderHistoryCursor(endExclusiveIndex: number): string {
+  return `${DERIVED_RENDER_HISTORY_CURSOR_PREFIX}${Math.max(0, Math.floor(endExclusiveIndex))}`;
+}
+
+/** SQLite/ai-chat chronology string from epoch ms (`YYYY-MM-DD HH:MM:SS.mmm`). */
+export function formatAiChatCreatedAt(ms: number): string {
+  return new Date(ms).toISOString().replace("T", " ").replace("Z", "");
+}
+
+export function parseDerivedRenderHistoryCursor(
+  cursor: string,
+): number | null {
+  if (!cursor.startsWith(DERIVED_RENDER_HISTORY_CURSOR_PREFIX)) return null;
+  const raw = cursor.slice(DERIVED_RENDER_HISTORY_CURSOR_PREFIX.length);
+  if (!/^\d+$/.test(raw)) return null;
+  const index = Number(raw);
+  if (!Number.isFinite(index) || index < 0) return null;
+  return Math.floor(index);
+}
+
+/**
+ * Page a chronologically-ordered derived transcript newest-first (same window
+ * semantics as ai-chat's renderHistoryWindow), with an opaque `d:` cursor.
+ */
+export function pageDerivedUiMessages(
+  messages: readonly UIMessage[],
+  options: {
+    beforeCursor?: string | null;
+    maxMessages?: number;
+    maxBytes?: number;
+  } = {},
+): ChatRenderHistoryPage {
+  const maxMessages = Math.max(
+    1,
+    Math.floor(options.maxMessages ?? CHAT_RENDER_WINDOW_MAX_MESSAGES),
+  );
+  const maxBytes = Math.max(
+    1,
+    Math.floor(options.maxBytes ?? CHAT_RENDER_WINDOW_MAX_BYTES),
+  );
+
+  let endExclusive = messages.length;
+  if (options.beforeCursor != null && options.beforeCursor !== "") {
+    const parsed = parseDerivedRenderHistoryCursor(String(options.beforeCursor));
+    if (parsed === null) {
+      throw new Error("A valid derived render-history cursor is required");
+    }
+    endExclusive = Math.min(parsed, messages.length);
+  }
+
+  const selectedReversed: UIMessage[] = [];
+  let bytes = 0;
+  for (let index = endExclusive - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    const messageBytes = Math.max(1, estimateUiMessageBytes(message));
+    if (
+      selectedReversed.length > 0 &&
+      (selectedReversed.length >= maxMessages || bytes + messageBytes > maxBytes)
+    ) {
+      break;
+    }
+    selectedReversed.push(message);
+    bytes += messageBytes;
+  }
+
+  const selected = selectedReversed.reverse();
+  const startIndex = endExclusive - selected.length;
+  const hasMore = startIndex > 0;
+  return {
+    messages: selected,
+    nextCursor: hasMore ? encodeDerivedRenderHistoryCursor(startIndex) : null,
+    hasMore,
+  };
 }
 
 export type ResidentRenderHistoryUpdate =

--- a/src/lib/derive-ui-messages-from-pi-core.ts
+++ b/src/lib/derive-ui-messages-from-pi-core.ts
@@ -1,0 +1,337 @@
+import type { UIMessage } from "ai";
+
+import {
+  PI_STEER_MARKER_PART,
+  piSteerMarkerPartId,
+} from "@/lib/pi-chunk-encoder";
+import { parseMessageAuthor } from "@/lib/message-author";
+import {
+  messageToUiMessage,
+  uiMessageCreatedAtMs,
+} from "@/lib/ui-message-adapter";
+import type { ContentBlock, Message } from "@/types";
+
+/**
+ * Minimal pi_core → render row shape. Compatible with AgentEvalParsedMessage
+ * (extra fields like thread_id are ignored).
+ */
+export interface PiParsedRenderMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: unknown;
+  created_at: number;
+  forkEntryId: string;
+  /** Render-history message id this row streams into (uiMetadata stamp). */
+  renderMessageId?: string;
+  sentDuringStreaming?: boolean;
+  /** Compaction summary rows are model-facing only; omit from UI derive. */
+  isCompactSummary?: boolean;
+}
+
+/**
+ * Derive settled UIMessages from parsed pi_core rows.
+ *
+ * Pure transform: fold multi-SDK-turn assistants sharing a renderMessageId,
+ * insert steer markers for interposed user rows, prefer stamped user skeleton
+ * ids, and order strictly by pi_core sequence. No SQL, no high-water mark, no
+ * chronology rewrite — this is the Phase C read path.
+ */
+export function deriveUiMessagesFromParsedPiCore(
+  parsed: readonly PiParsedRenderMessage[],
+): UIMessage[] {
+  // Drop compaction summaries before indexing so steer fold positions stay
+  // aligned with the visible transcript.
+  const visible = parsed.filter((row) => row.isCompactSummary !== true);
+  if (visible.length === 0) return [];
+
+  const convertedByIndex = new Map<number, UIMessage>();
+  const convertAt = (index: number): UIMessage => {
+    const cached = convertedByIndex.get(index);
+    if (cached) return cached;
+    const row = visible[index];
+    let converted = messageToUiMessage(toAdapterMessage(row));
+    if (
+      row.role === "user" &&
+      typeof row.renderMessageId === "string" &&
+      row.renderMessageId
+    ) {
+      converted = { ...converted, id: row.renderMessageId } as UIMessage;
+    }
+    convertedByIndex.set(index, converted);
+    return converted;
+  };
+
+  const resolvedUserIdAt = (index: number): string => {
+    const row = visible[index];
+    if (typeof row.renderMessageId === "string" && row.renderMessageId) {
+      return row.renderMessageId;
+    }
+    return convertAt(index).id;
+  };
+
+  const assistantIndexesByStamp = new Map<string, number[]>();
+  for (let index = 0; index < visible.length; index += 1) {
+    const row = visible[index];
+    if (
+      row.role !== "assistant" ||
+      typeof row.renderMessageId !== "string" ||
+      !row.renderMessageId
+    ) {
+      continue;
+    }
+    const indexes = assistantIndexesByStamp.get(row.renderMessageId) ?? [];
+    indexes.push(index);
+    assistantIndexesByStamp.set(row.renderMessageId, indexes);
+  }
+
+  const stampedAssistantIndexes = new Set<number>();
+  const foldedAssistantByFirstIndex = new Map<number, UIMessage>();
+  for (const [renderMessageId, indexes] of assistantIndexesByStamp) {
+    for (const index of indexes) stampedAssistantIndexes.add(index);
+
+    const firstIndex = indexes[0];
+    const parts: UIMessage["parts"] = [];
+    let previousAssistantIndex = firstIndex;
+    for (let offset = 0; offset < indexes.length; offset += 1) {
+      const assistantIndex = indexes[offset];
+      if (offset > 0) {
+        for (
+          let between = previousAssistantIndex + 1;
+          between < assistantIndex;
+          between += 1
+        ) {
+          const interposed = visible[between];
+          if (interposed.role !== "user") continue;
+          const steerMessageId = resolvedUserIdAt(between);
+          const acceptedAtMs =
+            typeof interposed.created_at === "number" &&
+            Number.isFinite(interposed.created_at)
+              ? interposed.created_at
+              : 0;
+          parts.push({
+            type: PI_STEER_MARKER_PART,
+            id: piSteerMarkerPartId(steerMessageId),
+            data: { steerMessageId, acceptedAtMs },
+          } as UIMessage["parts"][number]);
+        }
+      }
+      parts.push(...convertAt(assistantIndex).parts);
+      previousAssistantIndex = assistantIndex;
+    }
+
+    const rows = indexes.map((index) => visible[index]);
+    const forkEntryIds = rows
+      .map((row) => row.forkEntryId)
+      .filter((id): id is string => typeof id === "string" && !!id);
+    const pi: Record<string, unknown> =
+      forkEntryIds.length > 0
+        ? {
+            forkEntryId: forkEntryIds[forkEntryIds.length - 1],
+            forkEntryIds,
+          }
+        : {};
+    const firstCreatedAt = (
+      convertAt(firstIndex).metadata as
+        | { pi?: { createdAtMs?: unknown } }
+        | undefined
+    )?.pi?.createdAtMs;
+    if (typeof firstCreatedAt === "number") pi.createdAtMs = firstCreatedAt;
+    foldedAssistantByFirstIndex.set(firstIndex, {
+      id: renderMessageId,
+      role: "assistant",
+      parts,
+      metadata: { pi },
+    } as UIMessage);
+  }
+
+  const uiMessages: UIMessage[] = [];
+  for (let index = 0; index < visible.length; index += 1) {
+    if (stampedAssistantIndexes.has(index)) {
+      const folded = foldedAssistantByFirstIndex.get(index);
+      if (!folded) continue;
+      uiMessages.push(folded);
+      continue;
+    }
+    uiMessages.push(convertAt(index));
+  }
+  return uiMessages;
+}
+
+/**
+ * Overlay the live ai-chat resident rows onto derived settled history.
+ *
+ * - Open turn id → live row wins.
+ * - Live user skeleton with `piCoreMessageKey` or matching `createdAtMs`
+ *   replaces the derived `pi_user_*` bubble (same-content-same-id; also keeps
+ *   stable archive ids after compaction renumbers pi_core indexes).
+ * - Live assistant whose `metadata.pi.forkEntryId(s)` match a derived
+ *   assistant's fork entry replaces that derived row (legacy unstamped /
+ *   live-minted turn ids).
+ * - Remaining live-only rows (just-sent user, in-flight assistant not yet in
+ *   pi_core) append at the end — skipped when role+createdAtMs already settled.
+ */
+export function overlayLiveUiMessages(
+  settled: UIMessage[],
+  live: readonly UIMessage[],
+  options: { activeTurnId: string | null },
+): UIMessage[] {
+  if (live.length === 0) return settled;
+
+  const liveById = new Map<string, UIMessage>();
+  const liveUserByPiKey = new Map<string, UIMessage>();
+  const liveUserByCreatedAt = new Map<number, UIMessage>();
+  const liveAssistantByForkEntryId = new Map<string, UIMessage>();
+  for (const message of live) {
+    if (typeof message?.id !== "string" || !message.id) continue;
+    liveById.set(message.id, message);
+    const metadata = (message.metadata ?? {}) as Record<string, unknown>;
+    if (message.role === "user") {
+      const key = metadata.piCoreMessageKey;
+      if (typeof key === "string" && key) liveUserByPiKey.set(key, message);
+      const createdAt = uiMessageCreatedAtMs(message);
+      if (createdAt !== undefined) liveUserByCreatedAt.set(createdAt, message);
+    } else if (message.role === "assistant") {
+      const pi =
+        metadata.pi && typeof metadata.pi === "object"
+          ? (metadata.pi as Record<string, unknown>)
+          : null;
+      const forkEntryId = pi?.forkEntryId;
+      if (typeof forkEntryId === "string" && forkEntryId) {
+        liveAssistantByForkEntryId.set(forkEntryId, message);
+      }
+      if (Array.isArray(pi?.forkEntryIds)) {
+        for (const id of pi.forkEntryIds) {
+          if (typeof id === "string" && id) {
+            liveAssistantByForkEntryId.set(id, message);
+          }
+        }
+      }
+    }
+  }
+
+  const consumedLiveIds = new Set<string>();
+  const result = settled.map((message) => {
+    if (options.activeTurnId && message.id === options.activeTurnId) {
+      const liveMsg = liveById.get(message.id);
+      if (liveMsg) {
+        consumedLiveIds.add(liveMsg.id);
+        return liveMsg;
+      }
+    }
+
+    if (message.role === "user") {
+      const createdAt = uiMessageCreatedAtMs(message);
+      const liveUser =
+        (createdAt !== undefined
+          ? liveUserByPiKey.get(String(createdAt))
+          : undefined) ??
+        (createdAt !== undefined
+          ? liveUserByCreatedAt.get(createdAt)
+          : undefined) ??
+        liveById.get(message.id);
+      if (liveUser) {
+        consumedLiveIds.add(liveUser.id);
+        return liveUser;
+      }
+    }
+
+    if (message.role === "assistant") {
+      const liveAssistant = findLiveAssistantForSettled(
+        message,
+        liveAssistantByForkEntryId,
+        liveById,
+      );
+      if (liveAssistant) {
+        consumedLiveIds.add(liveAssistant.id);
+        return liveAssistant;
+      }
+    }
+
+    return message;
+  });
+
+  const settledIds = new Set(result.map((message) => message.id));
+  const settledDedupeKeys = new Set(
+    result.map((message) => renderOverlayDedupeKey(message)),
+  );
+  for (const message of live) {
+    if (!message?.id || consumedLiveIds.has(message.id) || settledIds.has(message.id)) {
+      continue;
+    }
+    const dedupeKey = renderOverlayDedupeKey(message);
+    if (settledDedupeKeys.has(dedupeKey)) {
+      continue;
+    }
+    settledIds.add(message.id);
+    settledDedupeKeys.add(dedupeKey);
+    result.push(message);
+  }
+  return result;
+}
+
+function renderOverlayDedupeKey(message: UIMessage): string {
+  const createdAt = uiMessageCreatedAtMs(message);
+  if (createdAt !== undefined) return `${message.role}:${createdAt}`;
+  return `${message.role}:${message.id}`;
+}
+
+function findLiveAssistantForSettled(
+  settled: UIMessage,
+  liveAssistantByForkEntryId: Map<string, UIMessage>,
+  liveById: Map<string, UIMessage>,
+): UIMessage | undefined {
+  const metadata = (settled.metadata ?? {}) as Record<string, unknown>;
+  const pi =
+    metadata.pi && typeof metadata.pi === "object"
+      ? (metadata.pi as Record<string, unknown>)
+      : null;
+  if (typeof pi?.forkEntryId === "string" && pi.forkEntryId) {
+    const match = liveAssistantByForkEntryId.get(pi.forkEntryId);
+    if (match) return match;
+  }
+  if (Array.isArray(pi?.forkEntryIds)) {
+    for (const id of pi.forkEntryIds) {
+      if (typeof id !== "string" || !id) continue;
+      const match = liveAssistantByForkEntryId.get(id);
+      if (match) return match;
+    }
+  }
+  // Unstamped derive uses forkEntryId as the UIMessage id.
+  const byForkAsId = liveAssistantByForkEntryId.get(settled.id);
+  if (byForkAsId) return byForkAsId;
+  return liveById.get(settled.id);
+}
+
+function toAdapterMessage(row: PiParsedRenderMessage): Message {
+  let content: string | ContentBlock[] =
+    typeof row.content === "string"
+      ? row.content
+      : Array.isArray(row.content)
+        ? (row.content as ContentBlock[])
+        : "";
+  let authorDisplayName: string | undefined;
+  let messageSource: string | undefined;
+
+  if (row.role === "user") {
+    const parsedAuthor = parseMessageAuthor(content);
+    content = parsedAuthor.content;
+    if (parsedAuthor.author?.displayName) {
+      authorDisplayName = parsedAuthor.author.displayName;
+    }
+    if (parsedAuthor.source) {
+      messageSource = parsedAuthor.source;
+    }
+  }
+
+  return {
+    id: row.id,
+    thread_id: "",
+    role: row.role,
+    content,
+    created_at: row.created_at,
+    forkEntryId: row.forkEntryId,
+    ...(row.sentDuringStreaming ? { sentDuringStreaming: true } : {}),
+    ...(authorDisplayName ? { authorDisplayName } : {}),
+    ...(messageSource ? { messageSource } : {}),
+  };
+}

--- a/tests/chat-render-history.test.ts
+++ b/tests/chat-render-history.test.ts
@@ -4,8 +4,11 @@ import { describe, expect, it } from "vitest";
 import {
   appendEvictedRenderMessages,
   classifyResidentRenderHistoryUpdate,
+  encodeDerivedRenderHistoryCursor,
   findEvictedRenderMessages,
   isCurrentRenderHistoryGeneration,
+  pageDerivedUiMessages,
+  parseDerivedRenderHistoryCursor,
   prependOlderRenderMessages,
   shouldHydrateRenderHistoryCursor,
 } from "@/lib/chat-render-history";
@@ -113,5 +116,41 @@ describe("resident render-history rollover", () => {
     ).toBe(false);
     expect(isCurrentRenderHistoryGeneration(0, 1)).toBe(false);
     expect(isCurrentRenderHistoryGeneration(1, 1)).toBe(true);
+  });
+});
+
+describe("pageDerivedUiMessages", () => {
+  it("returns the newest window with a d: cursor for older pages", () => {
+    const messages = Array.from({ length: 5 }, (_, index) =>
+      uiMessage(`m${index}`),
+    );
+    const first = pageDerivedUiMessages(messages, { maxMessages: 2 });
+    expect(first.messages.map((message) => message.id)).toEqual(["m3", "m4"]);
+    expect(first.hasMore).toBe(true);
+    expect(first.nextCursor).toBe(encodeDerivedRenderHistoryCursor(3));
+    expect(parseDerivedRenderHistoryCursor(first.nextCursor!)).toBe(3);
+
+    const older = pageDerivedUiMessages(messages, {
+      beforeCursor: first.nextCursor,
+      maxMessages: 2,
+    });
+    expect(older.messages.map((message) => message.id)).toEqual(["m1", "m2"]);
+    expect(older.nextCursor).toBe(encodeDerivedRenderHistoryCursor(1));
+
+    const oldest = pageDerivedUiMessages(messages, {
+      beforeCursor: older.nextCursor,
+      maxMessages: 2,
+    });
+    expect(oldest.messages.map((message) => message.id)).toEqual(["m0"]);
+    expect(oldest.hasMore).toBe(false);
+    expect(oldest.nextCursor).toBeNull();
+  });
+
+  it("rejects non-derived cursors", () => {
+    expect(() =>
+      pageDerivedUiMessages([uiMessage("m0")], {
+        beforeCursor: "i:not-derived",
+      }),
+    ).toThrow(/derived render-history cursor/);
   });
 });

--- a/tests/derive-ui-messages-from-pi-core.test.ts
+++ b/tests/derive-ui-messages-from-pi-core.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveUiMessagesFromParsedPiCore,
+  overlayLiveUiMessages,
+  type PiParsedRenderMessage,
+} from "@/lib/derive-ui-messages-from-pi-core";
+import { PI_STEER_MARKER_PART } from "@/lib/pi-chunk-encoder";
+import type { UIMessage } from "ai";
+
+function user(
+  overrides: Partial<PiParsedRenderMessage> &
+    Pick<PiParsedRenderMessage, "id" | "created_at" | "content">,
+): PiParsedRenderMessage {
+  return {
+    role: "user",
+    forkEntryId: overrides.id,
+    ...overrides,
+  };
+}
+
+function assistant(
+  overrides: Partial<PiParsedRenderMessage> &
+    Pick<PiParsedRenderMessage, "id" | "created_at" | "content">,
+): PiParsedRenderMessage {
+  return {
+    role: "assistant",
+    forkEntryId: overrides.id,
+    ...overrides,
+  };
+}
+
+describe("deriveUiMessagesFromParsedPiCore", () => {
+  it("orders by pi_core sequence and prefers stamped user skeleton ids", () => {
+    const derived = deriveUiMessagesFromParsedPiCore([
+      user({
+        id: "pi_user_1_0",
+        created_at: 1,
+        content: "[web message from Illiana Reed (illiana@camelai.com)]: June",
+        renderMessageId: "client_june",
+      }),
+      user({
+        id: "pi_user_2_1",
+        created_at: 2,
+        content: "[web message from Illiana Reed (illiana@camelai.com)]: timeout",
+        renderMessageId: "client_timeout",
+      }),
+      assistant({
+        id: "resp-a",
+        created_at: 3,
+        content: [{ type: "text", text: "lazy loading done" }],
+        renderMessageId: "turn-1",
+      }),
+    ]);
+
+    expect(derived.map((message) => message.id)).toEqual([
+      "client_june",
+      "client_timeout",
+      "turn-1",
+    ]);
+    expect(
+      (derived[0].parts[0] as { text?: string }).text,
+    ).toBe("June");
+    expect(
+      (derived[0].metadata as { authorDisplayName?: string }).authorDisplayName,
+    ).toBe("Illiana Reed");
+  });
+
+  it("folds multi-SDK-turn assistants and inserts steer markers", () => {
+    const derived = deriveUiMessagesFromParsedPiCore([
+      user({
+        id: "pi_user_1_0",
+        created_at: 1,
+        content: "start",
+        renderMessageId: "client_start",
+      }),
+      assistant({
+        id: "resp-1",
+        created_at: 2,
+        content: [{ type: "text", text: "pre-steer" }],
+        renderMessageId: "turn-1",
+      }),
+      user({
+        id: "pi_user_3_2",
+        created_at: 3,
+        content: "steer me",
+        renderMessageId: "client_steer",
+      }),
+      assistant({
+        id: "resp-2",
+        created_at: 4,
+        content: [{ type: "text", text: "post-steer" }],
+        renderMessageId: "turn-1",
+      }),
+    ]);
+
+    expect(derived.map((message) => message.id)).toEqual([
+      "client_start",
+      "turn-1",
+      "client_steer",
+    ]);
+    const folded = derived[1];
+    expect(folded.parts.map((part) => part.type)).toEqual([
+      "text",
+      PI_STEER_MARKER_PART,
+      "text",
+    ]);
+    expect(
+      (folded.parts[1] as { data?: { steerMessageId?: string } }).data
+        ?.steerMessageId,
+    ).toBe("client_steer");
+  });
+
+  it("omits compaction summary rows from the visible derive", () => {
+    const derived = deriveUiMessagesFromParsedPiCore([
+      user({
+        id: "pi_user_summary",
+        created_at: 1,
+        content: "summary of earlier work",
+        isCompactSummary: true,
+      }),
+      user({
+        id: "pi_user_tail",
+        created_at: 2,
+        content: "tail",
+        renderMessageId: "client_tail",
+      }),
+    ]);
+    expect(derived.map((message) => message.id)).toEqual(["client_tail"]);
+  });
+});
+
+describe("overlayLiveUiMessages", () => {
+  it("lets the live open-turn row win and appends live-only skeletons", () => {
+    const settled = [
+      {
+        id: "u1",
+        role: "user",
+        parts: [{ type: "text", text: "hi", state: "done" }],
+        metadata: { pi: { createdAtMs: 1 } },
+      },
+      {
+        id: "turn-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "partial", state: "done" }],
+      },
+    ] as UIMessage[];
+    const live = [
+      {
+        id: "turn-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "live", state: "streaming" }],
+      },
+      {
+        id: "u2",
+        role: "user",
+        parts: [{ type: "text", text: "just sent", state: "done" }],
+      },
+    ] as UIMessage[];
+
+    const overlaid = overlayLiveUiMessages(settled, live, {
+      activeTurnId: "turn-1",
+    });
+    expect(overlaid.map((message) => message.id)).toEqual([
+      "u1",
+      "turn-1",
+      "u2",
+    ]);
+    expect((overlaid[1].parts[0] as { text?: string }).text).toBe("live");
+  });
+
+  it("prefers live skeletons matched by piCoreMessageKey / forkEntryId", () => {
+    const settled = [
+      {
+        id: "pi_user_1000_0",
+        role: "user",
+        parts: [{ type: "text", text: "q", state: "done" }],
+        metadata: { pi: { createdAtMs: 1000 } },
+      },
+      {
+        id: "resp-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "a", state: "done" }],
+      },
+    ] as UIMessage[];
+    const live = [
+      {
+        id: "client-user-1",
+        role: "user",
+        parts: [{ type: "text", text: "q", state: "done" }],
+        metadata: { piCoreMessageKey: "1000" },
+      },
+      {
+        id: "turn-mint-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "a", state: "done" }],
+        metadata: { pi: { forkEntryId: "resp-1" } },
+      },
+    ] as UIMessage[];
+
+    expect(
+      overlayLiveUiMessages(settled, live, { activeTurnId: null }).map(
+        (message) => message.id,
+      ),
+    ).toEqual(["client-user-1", "turn-mint-1"]);
+  });
+
+  it("keeps archive ids when compaction renumbers pi_user_* indexes", () => {
+    const settled = [
+      {
+        id: "pi_user_1000_0",
+        role: "user",
+        parts: [{ type: "text", text: "old", state: "done" }],
+        metadata: { pi: { createdAtMs: 1000 } },
+      },
+      {
+        id: "resp-old",
+        role: "assistant",
+        parts: [{ type: "text", text: "old a", state: "done" }],
+        metadata: { pi: { forkEntryId: "resp-old", createdAtMs: 1100 } },
+      },
+      {
+        id: "pi_user_2000_1",
+        role: "user",
+        parts: [{ type: "text", text: "new", state: "done" }],
+        metadata: { pi: { createdAtMs: 2000 } },
+      },
+      {
+        id: "resp-new",
+        role: "assistant",
+        parts: [{ type: "text", text: "new a", state: "done" }],
+        metadata: { pi: { forkEntryId: "resp-new", createdAtMs: 2100 } },
+      },
+    ] as UIMessage[];
+    const live = [
+      {
+        id: "pi_user_1000_0",
+        role: "user",
+        parts: [{ type: "text", text: "old", state: "done" }],
+        metadata: { pi: { createdAtMs: 1000 } },
+      },
+      {
+        id: "resp-old",
+        role: "assistant",
+        parts: [{ type: "text", text: "old a", state: "done" }],
+        metadata: { pi: { forkEntryId: "resp-old", createdAtMs: 1100 } },
+      },
+      {
+        id: "pi_user_2000_2",
+        role: "user",
+        parts: [{ type: "text", text: "new", state: "done" }],
+        metadata: { pi: { createdAtMs: 2000 } },
+      },
+      {
+        id: "resp-new",
+        role: "assistant",
+        parts: [{ type: "text", text: "new a", state: "done" }],
+        metadata: { pi: { forkEntryId: "resp-new", createdAtMs: 2100 } },
+      },
+    ] as UIMessage[];
+
+    expect(
+      overlayLiveUiMessages(settled, live, { activeTurnId: null }).map(
+        (message) => message.id,
+      ),
+    ).toEqual(["pi_user_1000_0", "resp-old", "pi_user_2000_2", "resp-new"]);
+  });
+});

--- a/workers/main/src/chat-thread-do.ts
+++ b/workers/main/src/chat-thread-do.ts
@@ -53,14 +53,21 @@ import type { UIMessage, UIMessageStreamWriter } from 'ai';
 import {
   CHAT_RENDER_WINDOW_MAX_BYTES,
   CHAT_RENDER_WINDOW_MAX_MESSAGES,
+  formatAiChatCreatedAt,
+  pageDerivedUiMessages,
   type ChatRenderHistoryPage,
 } from '../../../src/lib/chat-render-history';
+import {
+  deriveUiMessagesFromParsedPiCore,
+  overlayLiveUiMessages,
+} from '../../../src/lib/derive-ui-messages-from-pi-core';
 import {
   PiChunkEncoder,
   PI_ERROR_PART_ID,
   type PiRuntimeEvent,
   type PiUiMessageChunk,
 } from '../../../src/lib/pi-chunk-encoder';
+import { uiMessageCreatedAtMs } from '../../../src/lib/ui-message-adapter';
 import { normalizePiUiMetadata, type PiUiMetadata, type RuntimeCallArtifact } from '../../../src/lib/runtime-artifacts';
 import type {
   LlmModel,
@@ -277,11 +284,7 @@ import {
 
 // pi_core → ai-chat render-mirror machinery (ChatThreadUiMirror): the top-up
 // backfill, legacy time heal, user render skeleton, and wipe-and-rebuild resync.
-import {
-  ChatThreadUiMirror,
-  UI_MESSAGES_PI_CORE_HIGH_WATER_KEY,
-  UI_MESSAGES_PI_CORE_REVISION_KEY,
-} from "./chat-thread/ui-mirror";
+import { ChatThreadUiMirror } from "./chat-thread/ui-mirror";
 
 // Thread metadata generation (ChatThreadMetadata): per-user-message org
 // metadata updates, title generation, chat group avatar/emoji generation, and
@@ -569,9 +572,6 @@ const HEADER_AUTH_DEGRADED = "X-Chiridion-Auth-Degraded";
 // The codeModeArtifacts: KV key prefix lives in
 // ./chat-thread/code-mode-artifacts with the methods that use it.
 
-// The UI_MESSAGES_* KV keys for the pi_core → ai-chat render mirror live in
-// ./chat-thread/ui-mirror (UI_MESSAGES_PI_CORE_HIGH_WATER_KEY is re-imported
-// above for replacePiCoreMessages' re-pin path).
 // Drop-oldest cap for the pre-attach chunk buffer so a turn that never attaches
 // a writer (e.g. saveMessages skipped) cannot grow memory without bound.
 const PI_STREAM_PRE_ATTACH_CHUNK_CAP = 5000;
@@ -633,7 +633,11 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
   private automationRunInstance?: ChatThreadAutomationRun;
   private uiMirrorInstance?: ChatThreadUiMirror;
   private legacyUiMessageHealingPromise: Promise<void> | null = null;
-  private renderHistoryReconciliationPromise: Promise<void> | null = null;
+  /** Revision-keyed cache of derive-on-read settled UIMessages (+ compaction archive). */
+  private derivedUiMessagesCache: {
+    token: string;
+    messages: UIMessage[];
+  } | null = null;
   private piTurnJournalInstance?: PiTurnJournal;
   private chatAccessInstance?: ChatThreadAccess;
   private channelToolsInstance?: ChannelTools;
@@ -1393,12 +1397,36 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     }
   }
 
-  private sendRenderHistoryToConnection(connection: Connection): void {
-    if (this.messages.length === 0) return;
+  /**
+   * Handshake-only: push the in-memory resident window synchronously so
+   * onConnect stays bounded (no pi_core derive, no SQL page). Background
+   * reconcile follows with derive-on-read.
+   */
+  private sendResidentRenderHistoryToConnection(connection: Connection): void {
     try {
+      const messages = this.messages as UIMessage[];
+      if (!Array.isArray(messages) || messages.length === 0) return;
       connection.send(
         JSON.stringify({
-          messages: this.messages,
+          messages,
+          type: CHAT_MESSAGE_TYPES.CHAT_MESSAGES,
+        }),
+      );
+    } catch (error) {
+      console.error(
+        "[ChatThreadDO] failed to send resident render history on connect",
+        error,
+      );
+    }
+  }
+
+  private async sendRenderHistoryToConnection(connection: Connection): Promise<void> {
+    try {
+      const page = await this.getDerivedUiMessagePage();
+      if (page.messages.length === 0) return;
+      connection.send(
+        JSON.stringify({
+          messages: page.messages,
           type: CHAT_MESSAGE_TYPES.CHAT_MESSAGES,
         }),
       );
@@ -1411,10 +1439,9 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
   private async reconcileConnectedClient(connection: Connection): Promise<void> {
     const startedAt = Date.now();
     try {
-      // None of these repairs belongs on the HTTP 101 critical path. Run them in
-      // order because the mirror top-up must precede legacy metadata healing.
+      // Settled history is derive-on-read from pi_core; only sweep a stranded
+      // active-turn marker before shipping the resident derived page.
       await this.sweepOrphanedActiveTurnMarker();
-      await this.reconcileRenderHistory();
       // Repair path for the lake export: catches rows whose post-commit sync was
       // lost to an eviction or a stream failure, and backfills threads whose
       // history predates the export entirely.
@@ -1426,7 +1453,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       } else {
         this.syncAgentState();
       }
-      this.sendRenderHistoryToConnection(connection);
+      await this.sendRenderHistoryToConnection(connection);
       this.recordChatThreadObservabilityEvent("chat_ws_connect_background_repair", {
         operation: "reconcile_connected_client",
         status: "completed",
@@ -1443,7 +1470,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       // Still deliver the best state/history currently available. A later
       // connection or getUiMessages read retries idempotent repairs.
       this.syncAgentState();
-      this.sendRenderHistoryToConnection(connection);
+      await this.sendRenderHistoryToConnection(connection);
     }
   }
 
@@ -1481,9 +1508,10 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     this.captureChatContextFromRequest(url, ctx.request, connection);
 
     // Keep the handshake path synchronous and bounded: publish the currently
-    // available state/history, then reconcile durable truth after the 101.
+    // resident ai-chat window, then derive-on-read after the 101 (and after any
+    // orphaned active-turn sweep) so settled order comes from pi_core.
     this.syncAgentState();
-    this.sendRenderHistoryToConnection(connection);
+    this.sendResidentRenderHistoryToConnection(connection);
     this.ctx.waitUntil(
       Promise.resolve()
         .then(() => this.reconcileConnectedClient(connection))
@@ -3043,6 +3071,11 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     options: { uiRender: "preserve" | "rebuild" },
   ): Promise<void> {
     this.ensurePiCoreTables();
+    // Before pi_core shrinks, snapshot the current visible derive into the
+    // ai-chat table so post-compaction reads can prepend those rows as archive.
+    if (options.uiRender === "preserve") {
+      await this.materializeSettledRenderArchiveFromPiCore();
+    }
     // Serialize first (this can await R2/image work); swap the table contents
     // with no await between DELETE and the INSERTs so an eviction or a
     // concurrent reader never observes a half-written history.
@@ -3062,19 +3095,39 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       );
     }
     this.piCoreStore.markPiCoreChanged(payloads.length);
+    // Invalidate derive-on-read cache; markPiCoreChanged already bumped generation.
+    this.derivedUiMessagesCache = null;
     if (options.uiRender === "rebuild") {
+      // Admin/fork rewrites: refresh the live/archive render table too so
+      // compaction-archive hybrid and any residual mirror consumers converge.
       await this.rebuildUiMessagesFromPiCore();
-    } else {
-      const parsed = await this.getPiCoreParsedMessages(
-        this.chatContext?.threadId ?? "",
-      );
-      this.ctx.storage.kv.put(UI_MESSAGES_PI_CORE_HIGH_WATER_KEY, parsed.length);
-      const revision = this.piCoreStore.getPiCoreRevision();
-      this.ctx.storage.kv.put(
-        UI_MESSAGES_PI_CORE_REVISION_KEY,
-        `${revision.generation}:${revision.count}`,
+    }
+    // uiRender: "preserve" keeps cf_ai_chat_agent_messages as the pre-compaction
+    // visible archive; settled reads derive from the new pi_core and prepend
+    // archive rows whose ids are absent from the derive.
+  }
+
+  /**
+   * Write the current pi_core-derived settled transcript into the ai-chat table
+   * (with pi timestamps as chronology) so a following compaction preserve can
+   * keep pre-compaction rows visible via the archive hybrid.
+   */
+  private async materializeSettledRenderArchiveFromPiCore(): Promise<void> {
+    const parsed = await this.getPiCoreParsedMessages(
+      this.chatContext?.threadId ?? "",
+    );
+    const derived = deriveUiMessagesFromParsedPiCore(parsed);
+    if (derived.length === 0) return;
+    await this.persistMessages(derived);
+    for (const message of derived) {
+      const createdAtMs = uiMessageCreatedAtMs(message);
+      if (createdAtMs === undefined) continue;
+      this._setRenderHistoryChronology(
+        message.id,
+        formatAiChatCreatedAt(createdAtMs),
       );
     }
+    this.messages = this.getRenderHistoryPage().messages;
   }
 
   private get uiMirror(): ChatThreadUiMirror {
@@ -7707,37 +7760,24 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
   }
 
   /**
-   * Render history for the live-user chat loader (commit 3b). Returns the
-   * resident window immediately and reconciles pi_core in background.
-   * DO RPC only — intentionally NOT wired to any HTTP route (auth-sensitive; the
-   * loader wiring is commit 4).
+   * Settled render history for the live-user chat loader. Derived from pi_core
+   * on read (Phase C), with the live resident window overlaid for the open turn.
+   * DO RPC only — intentionally NOT wired to any HTTP route (auth-sensitive).
    */
   async getUiMessages(): Promise<UIMessage[]> {
     return this.withChatMemoryPhase("render_rpc_return_full", async () => {
       await this.sweepOrphanedActiveTurnMarker();
-      await this.reconcileRenderHistory();
-      return this.getRenderHistoryPage().messages;
+      return (await this.getDerivedUiMessagePage()).messages;
     });
   }
 
   async getUiMessagePage(): Promise<ChatRenderHistoryPage> {
     return this.withChatMemoryPhase("render_rpc_return", async () => {
-    // The SSR loader is the first page-open touch (before the websocket
-    // connects). Heal a provably-dead turn's stranded marker here so the load
-    // doesn't derive a busy indicator from it.
-    await this.sweepOrphanedActiveTurnMarker();
-    // Pi top-up and legacy metadata repair can both walk a full old transcript.
-    // They are idempotent and websocket reconciliation broadcasts the converged
-    // resident window, so keep all unbounded work outside this first-page RPC.
-    this.ctx.waitUntil(
-      this.reconcileRenderHistory().catch((error) => {
-        console.error(
-          "[ChatThreadDO] background render-history reconciliation failed",
-          error,
-        );
-      }),
-    );
-    return this.getRenderHistoryPage();
+      // The SSR loader is the first page-open touch (before the websocket
+      // connects). Heal a provably-dead turn's stranded marker here so the load
+      // doesn't derive a busy indicator from it.
+      await this.sweepOrphanedActiveTurnMarker();
+      return this.getDerivedUiMessagePage();
     });
   }
 
@@ -7750,64 +7790,144 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       throw new Error("A valid render-history cursor is required");
     }
     return this.withChatMemoryPhase("render_rpc_older_page", async () =>
-      this.getRenderHistoryPage({ beforeCursor }),
+      this.getDerivedUiMessagePage({ beforeCursor }),
     );
   }
 
+  /**
+   * Build the newest (or older) page of settled UI history from pi_core, plus
+   * pre-compaction archive rows still held in the ai-chat table, with the live
+   * stream's open-turn row overlaid.
+   */
+  private async getDerivedUiMessagePage(options?: {
+    beforeCursor?: string | null;
+  }): Promise<ChatRenderHistoryPage> {
+    const settled = await this.getSettledUiMessagesFromPiCore();
+    if (settled.length === 0) {
+      // No pi_core-derived history yet: serve the ai-chat table with its native
+      // chronology cursor (live-only / render-table tests / brand-new threads).
+      return this.getRenderHistoryPage(
+        options?.beforeCursor ? { beforeCursor: options.beforeCursor } : {},
+      );
+    }
+    const activeTurnId =
+      this.activePiStreamTurnId ?? this.readPiActiveTurn()?.turnId ?? null;
+    const overlaid = overlayLiveUiMessages(
+      settled,
+      this.messages as UIMessage[],
+      { activeTurnId },
+    );
+    return pageDerivedUiMessages(overlaid, {
+      beforeCursor: options?.beforeCursor,
+      maxMessages: CHAT_RENDER_WINDOW_MAX_MESSAGES,
+      maxBytes: CHAT_RENDER_WINDOW_MAX_BYTES,
+    });
+  }
+
+  private async getSettledUiMessagesFromPiCore(): Promise<UIMessage[]> {
+    const revision = this.piCoreStore.getPiCoreRevision();
+    const token = `${revision.generation}:${revision.count}`;
+    if (this.derivedUiMessagesCache?.token === token) {
+      return this.derivedUiMessagesCache.messages;
+    }
+
+    const parsed = await this.getPiCoreParsedMessages(
+      this.chatContext?.threadId ?? "",
+    );
+    const derived = deriveUiMessagesFromParsedPiCore(parsed);
+    const archived = await this.collectCompactionRenderArchive(derived);
+    const settled =
+      archived.length === 0 ? derived : [...archived, ...derived];
+    this.derivedUiMessagesCache = { token, messages: settled };
+    return settled;
+  }
+
+  /**
+   * Post-compaction `uiRender: "preserve"` keeps pre-compaction visible rows in
+   * cf_ai_chat_agent_messages after pi_core is rewritten to summary+tail. Pure
+   * derive only sees the tail (plus a model-only summary); prepend archive rows
+   * that are not already represented in the derive. Match by id OR by
+   * role+createdAtMs so index-based `pi_user_*` ids that renumber across
+   * compaction do not duplicate the kept tail.
+   */
+  private async collectCompactionRenderArchive(
+    derived: UIMessage[],
+  ): Promise<UIMessage[]> {
+    if (derived.length === 0) return [];
+
+    const derivedIds = new Set(derived.map((message) => message.id));
+    const derivedKeys = new Set(
+      derived.map((message) => this.renderMessageDedupeKey(message)),
+    );
+    const firstDerivedAt = uiMessageCreatedAtMs(derived[0]) ?? 0;
+    const archived: UIMessage[] = [];
+    const seenIds = new Set<string>();
+    const seenCursors = new Set<string>();
+    let beforeCursor: string | null = null;
+
+    for (;;) {
+      const page = this.getRenderHistoryPage(
+        beforeCursor ? { beforeCursor } : {},
+      );
+      for (const message of page.messages) {
+        if (!message?.id || derivedIds.has(message.id) || seenIds.has(message.id)) {
+          continue;
+        }
+        // Live skeletons without a pi timestamp are not pre-compaction archive.
+        const createdAt = uiMessageCreatedAtMs(message);
+        if (createdAt === undefined) {
+          continue;
+        }
+        if (derivedKeys.has(this.renderMessageDedupeKey(message))) {
+          continue;
+        }
+        // Same-era / newer rows arrive via derive or live overlay.
+        if (createdAt >= firstDerivedAt) {
+          continue;
+        }
+        seenIds.add(message.id);
+        archived.push(message);
+      }
+      if (!page.hasMore || !page.nextCursor) break;
+      if (seenCursors.has(page.nextCursor)) break;
+      seenCursors.add(page.nextCursor);
+      beforeCursor = page.nextCursor;
+    }
+
+    archived.sort(
+      (left, right) =>
+        (uiMessageCreatedAtMs(left) ?? 0) - (uiMessageCreatedAtMs(right) ?? 0),
+    );
+    return archived;
+  }
+
+  private renderMessageDedupeKey(message: UIMessage): string {
+    const createdAt = uiMessageCreatedAtMs(message);
+    if (createdAt !== undefined) return `${message.role}:${createdAt}`;
+    return `${message.role}:${message.id}`;
+  }
+
+  /** @deprecated Kept for focused legacy-heal unit tests; not on the read path. */
   private healLegacyUiMessageTimes(): Promise<void> {
     return this.uiMirror.healLegacyUiMessageTimes();
   }
 
+  /** @deprecated Kept for focused legacy-heal unit tests; not on the read path. */
   private healLegacyUiMessageAuthors(): Promise<void> {
     return this.uiMirror.healLegacyUiMessageAuthors();
   }
 
-  private healLegacyUiMessageMetadata(): Promise<void> {
-    if (this.legacyUiMessageHealingPromise) {
-      return this.legacyUiMessageHealingPromise;
-    }
-    const healing = (async () => {
-      await this.healLegacyUiMessageTimes();
-      await this.healLegacyUiMessageAuthors();
-    })();
-    let guarded: Promise<void>;
-    guarded = healing.finally(() => {
-      if (this.legacyUiMessageHealingPromise === guarded) {
-        this.legacyUiMessageHealingPromise = null;
-      }
-    });
-    this.legacyUiMessageHealingPromise = guarded;
-    return guarded;
-  }
-
-  private reconcileRenderHistory(): Promise<void> {
-    if (this.renderHistoryReconciliationPromise) {
-      return this.renderHistoryReconciliationPromise;
-    }
-    const reconciliation = (async () => {
-      await this.topUpUiMessagesFromPiCore();
-      await this.healLegacyUiMessageMetadata();
-    })();
-    let guarded: Promise<void>;
-    guarded = reconciliation.finally(() => {
-      if (this.renderHistoryReconciliationPromise === guarded) {
-        this.renderHistoryReconciliationPromise = null;
-      }
-    });
-    this.renderHistoryReconciliationPromise = guarded;
-    return guarded;
-  }
-
   /**
-   * Admin repair RPC (commit 3b): rebuild the entire ai-chat render history from
-   * pi_core. Clears the mirror + high-water mark, then re-runs the top-up. For
-   * flows that rewrite pi_core (fork repair, compaction repair) where the append-
-   * only high-water assumption no longer holds.
+   * Admin repair RPC: refresh the ai-chat live/archive table from pi_core and
+   * clear the derive-on-read cache. Settled reads already derive from pi_core;
+   * this keeps the compaction-archive hybrid and residual mirror consumers
+   * aligned after fork/admin rewrites.
    */
   async resyncUiMessagesFromPiCore(): Promise<{
     ok: true;
     messageCount: number;
   }> {
+    this.derivedUiMessagesCache = null;
     await this.rebuildUiMessagesFromPiCore();
     const row = this.ctx.storage.sql
       .exec<{ count: number }>(

--- a/workers/main/src/chat-thread/types.ts
+++ b/workers/main/src/chat-thread/types.ts
@@ -302,6 +302,8 @@ export interface AgentEvalParsedMessage {
   renderMessageId?: string;
   /** User row accepted while its assistant turn was already streaming. */
   sentDuringStreaming?: boolean;
+  /** Compaction summary rows are model-facing only; omitted from UI derive. */
+  isCompactSummary?: boolean;
 }
 
 export interface AgentEvalSessionRequest extends InitialUserMessageRequest {

--- a/workers/main/tests/chat-thread-pi-stream-bridge.test.ts
+++ b/workers/main/tests/chat-thread-pi-stream-bridge.test.ts
@@ -72,31 +72,19 @@ function seedPiCoreRow(instance: any, idx: number, message: AnyRecord): void {
 }
 
 describe('ChatThreadDO bounded render history', () => {
-  it('returns the first page without awaiting full-archive legacy repair', async () => {
+  it('returns the first derived page without background top-up or legacy heal', async () => {
     const fake = Object.create(ChatThreadDO.prototype) as any;
-    let finishTopUp: (() => void) | undefined;
-    const topUp = new Promise<void>((resolve) => {
-      finishTopUp = resolve;
-    });
-    let finishTimeRepair: (() => void) | undefined;
-    const timeRepair = new Promise<void>((resolve) => {
-      finishTimeRepair = resolve;
-    });
-    const background: Promise<unknown>[] = [];
     fake.withChatMemoryPhase = vi.fn(
       async (_operation: string, fn: () => Promise<unknown>) => fn(),
     );
     fake.sweepOrphanedActiveTurnMarker = vi.fn(async () => {});
-    fake.topUpUiMessagesFromPiCore = vi.fn(() => topUp);
-    fake.healLegacyUiMessageTimes = vi.fn(() => timeRepair);
-    fake.healLegacyUiMessageAuthors = vi.fn(async () => {});
-    fake.getRenderHistoryPage = vi.fn(() => ({
+    fake.getDerivedUiMessagePage = vi.fn(async () => ({
       messages: [{ id: 'resident', role: 'user', parts: [] }],
-      nextCursor: 'cursor',
+      nextCursor: 'd:0',
       hasMore: true,
     }));
     fake.ctx = {
-      waitUntil: vi.fn((promise: Promise<unknown>) => background.push(promise)),
+      waitUntil: vi.fn(),
     };
 
     const page = await ChatThreadDO.prototype.getUiMessagePage.call(fake);
@@ -104,17 +92,8 @@ describe('ChatThreadDO bounded render history', () => {
     expect(page.messages.map((message: AnyRecord) => message.id)).toEqual([
       'resident',
     ]);
-    expect(fake.topUpUiMessagesFromPiCore).toHaveBeenCalledTimes(1);
-    expect(fake.healLegacyUiMessageTimes).not.toHaveBeenCalled();
-    expect(fake.healLegacyUiMessageAuthors).not.toHaveBeenCalled();
-    expect(background).toHaveLength(1);
-
-    finishTopUp?.();
-    await Promise.resolve();
-    expect(fake.healLegacyUiMessageTimes).toHaveBeenCalledTimes(1);
-    finishTimeRepair?.();
-    await Promise.all(background);
-    expect(fake.healLegacyUiMessageAuthors).toHaveBeenCalledTimes(1);
+    expect(fake.getDerivedUiMessagePage).toHaveBeenCalledTimes(1);
+    expect(fake.ctx.waitUntil).not.toHaveBeenCalled();
   });
 
   it('keeps only the resident window in memory while retaining and paging every durable row', async () => {
@@ -523,7 +502,7 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
     expect(response).toBeUndefined();
   });
 
-  it('backfills pi_core render history with monotonic created_at and idempotent top-up', async () => {
+  it('derives settled UI messages from pi_core on read in pi order', async () => {
     const stub = await newChatThreadStub('thread-backfill');
     await runInDurableObject(stub, async (instance: any) => {
       instance.chatContext = { threadId: 'thread-backfill' };
@@ -546,36 +525,21 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
         'resp-1',
       ]);
       expect(first.map((m: AnyRecord) => m.role)).toEqual(['user', 'assistant']);
-
-      // Identical pi timestamps must not tie: created_at is strictly increasing.
-      const createdAts = () =>
-        (
-          instance.ctx.storage.sql
-            .exec(
-              'SELECT id, created_at FROM cf_ai_chat_agent_messages ORDER BY created_at',
-            )
-            .toArray() as Array<{ id: string; created_at: string }>
-        );
-      const afterFirst = createdAts();
-      expect(afterFirst.map((row) => row.id)).toEqual([
-        'pi_user_1000_0',
-        'resp-1',
-      ]);
-      expect(afterFirst[0].created_at < afterFirst[1].created_at).toBe(true);
+      // Derive-on-read does not require materializing the ai-chat mirror.
       expect(
-        instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx'),
-      ).toBe(2);
+        instance.ctx.storage.sql
+          .exec<{ count: number }>(
+            'SELECT COUNT(*) AS count FROM cf_ai_chat_agent_messages',
+          )
+          .one().count,
+      ).toBe(0);
 
-      // Idempotent: a second call with no new rows returns the same list and
-      // does not rewrite or reorder existing rows.
       const second = await instance.getUiMessages();
       expect(second.map((m: AnyRecord) => m.id)).toEqual([
         'pi_user_1000_0',
         'resp-1',
       ]);
-      expect(createdAts()).toEqual(afterFirst);
 
-      // Top-up of a newly appended pi_core row.
       seedPiCoreRow(instance, 2, {
         role: 'user',
         content: 'second question',
@@ -587,9 +551,6 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
         'resp-1',
         'pi_user_2000_2',
       ]);
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(3);
-      const afterThird = createdAts();
-      expect(afterThird[1].created_at < afterThird[2].created_at).toBe(true);
     });
   });
 
@@ -633,17 +594,13 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       });
 
       const messages = await instance.getUiMessages();
-      // The pi_core rows were recognized as already-present and skipped: the
-      // live-written ids survive, no pi_user_*/resp duplicates were inserted.
+      // Derive-on-read overlays live skeletons onto matching pi rows by
+      // piCoreMessageKey / forkEntryId so client/minted ids win.
       expect(messages.map((m: AnyRecord) => m.id)).toEqual([
         'client-user-1',
         'turn-mint-1',
       ]);
-      // The high-water mark still advanced past the skipped rows.
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(2);
 
-      // A later genuinely-new pi_core row (one with no live-written counterpart)
-      // still backfills, and the live rows are not duplicated.
       seedPiCoreRow(instance, 2, {
         role: 'user',
         content: 'second question',
@@ -655,7 +612,6 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       expect(ids).toContain('turn-mint-1');
       expect(ids).toContain('pi_user_2000_2');
       expect(ids).toHaveLength(3);
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(3);
     });
   });
 
@@ -697,16 +653,18 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       }
       await instance.persistMessages(renderMessages);
       expect(instance.messages).toHaveLength(50);
-      instance.ctx.storage.kv.delete('uiMessagesPiCoreHighWaterIdx');
-      instance.ctx.storage.kv.delete('uiMessagesPiCoreRevisionV1');
 
-      await instance.getUiMessages();
+      const derived = await instance.getUiMessages();
+      // Live skeletons overlay matching derived rows; no duplicate pi_user_*/resp ids.
+      expect(derived).toHaveLength(50);
+      expect(new Set(derived.map((m: AnyRecord) => m.id)).size).toBe(50);
 
       const durableRows = instance.ctx.storage.sql
         .exec<{ count: number }>(
           'SELECT COUNT(*) AS count FROM cf_ai_chat_agent_messages',
         )
         .one().count;
+      // Derive-on-read does not rewrite the live/archive table on read.
       expect(durableRows).toBe(60);
       const durableIds = instance.ctx.storage.sql
         .exec<{ id: string }>(
@@ -720,9 +678,6 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       expect(
         durableIds.some((id: string) => id.startsWith('legacy-response-')),
       ).toBe(false);
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(
-        60,
-      );
     });
   });
 
@@ -774,40 +729,18 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       await target.replacePiCoreForkMessages(forkMessages);
 
       const messages = await target.getUiMessages();
-      // The sliced fork converts to render history in order with the
-      // deterministic fork ids; the later source turns are absent.
+      // Derive-on-read serves the forked pi_core slice; later source turns are absent.
       expect(messages.map((m: AnyRecord) => m.id)).toEqual([
         'pi_user_1000_0',
         'resp-1',
       ]);
       expect(messages.map((m: AnyRecord) => m.role)).toEqual(['user', 'assistant']);
 
-      // created_at strictly increases even though both fork rows share pi
-      // timestamp 1000 (replacePiCoreForkMessages also rewrites the row
-      // created_at column, so the monotonic stamp comes from the backfill).
-      const createdAts = () =>
-        (
-          target.ctx.storage.sql
-            .exec(
-              'SELECT id, created_at FROM cf_ai_chat_agent_messages ORDER BY created_at',
-            )
-            .toArray() as Array<{ id: string; created_at: string }>
-        );
-      const afterFork = createdAts();
-      expect(afterFork.map((row) => row.id)).toEqual(['pi_user_1000_0', 'resp-1']);
-      expect(afterFork[0].created_at < afterFork[1].created_at).toBe(true);
-      expect(
-        target.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx'),
-      ).toBe(2);
-
-      // Idempotent: a second render load returns the same list and does not
-      // rewrite or reorder the existing rows.
       const second = await target.getUiMessages();
       expect(second.map((m: AnyRecord) => m.id)).toEqual([
         'pi_user_1000_0',
         'resp-1',
       ]);
-      expect(createdAts()).toEqual(afterFork);
     });
   });
 
@@ -867,6 +800,7 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
         ],
         timestamp: 1100,
         responseId: 'resp-1',
+        uiMetadata: { renderMessageId: 'turn-mint-1' },
       });
       seedPiCoreRow(instance, 2, {
         role: 'toolResult',
@@ -880,6 +814,7 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
         content: [{ type: 'text', text: 'final answer' }],
         timestamp: 1300,
         responseId: 'resp-2',
+        uiMetadata: { renderMessageId: 'turn-mint-1' },
       });
 
       // Reload (the loader path).
@@ -899,8 +834,6 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       expect(
         messages.some((m: AnyRecord) => m.id === 'resp-1' || m.id === 'resp-2'),
       ).toBe(false);
-      // The mark advanced past all skipped rows.
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(3);
 
       // A second reload stays stable.
       const again = await instance.getUiMessages();
@@ -947,7 +880,6 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
         'client-user-1',
         'turn-mint-1',
       ]);
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(2);
     });
   });
 
@@ -1004,17 +936,18 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       });
 
       const messages = await instance.getUiMessages();
+      // Derive-on-read follows pi_core sequence: the channel-history user row
+      // lands after the assistant in pi_core, so it renders after the turn.
       expect(messages.map((m: AnyRecord) => m.id)).toEqual([
         'client-user-1',
         'client-user-2',
-        'channel-1',
         'turn-mint-1',
+        'channel-1',
       ]);
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(4);
     });
   });
 
-  it('defers the top-up while a Pi turn is in flight (active-turn marker gate)', async () => {
+  it('derives settled history while a Pi turn marker is set (no top-up gate)', async () => {
     const stub = await newChatThreadStub('thread-marker-gate');
     await runInDurableObject(stub, async (instance: any) => {
       instance.chatContext = { threadId: 'thread-marker-gate' };
@@ -1032,14 +965,11 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
         turnId: 'turn-live',
         openedAt: Date.now(),
       });
+      // Derive-on-read serves settled history even while a turn marker is set;
+      // the live open-turn row is overlaid when present.
       const during = await instance.getUiMessages();
-      expect(during).toEqual([]);
-      expect(
-        instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx'),
-      ).toBeUndefined();
+      expect(during.map((m: AnyRecord) => m.id)).toEqual(['pi_user_1000_0', 'resp-1']);
 
-      // Rollback simulation: the turn's terminal path cleared the marker but no
-      // live render row exists — the rows convert exactly once.
       instance.ctx.storage.kv.delete('piActiveTurn');
       const after = await instance.getUiMessages();
       expect(after.map((m: AnyRecord) => m.id)).toEqual(['pi_user_1000_0', 'resp-1']);
@@ -1067,7 +997,12 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
           metadata: { pi: { forkEntryId: 'resp-1' } },
         },
       ]);
-      seedPiCoreRow(instance, 0, { role: 'user', content: 'q', timestamp: 1000 });
+      seedPiCoreRow(instance, 0, {
+        role: 'user',
+        content: 'q',
+        timestamp: 1000,
+        uiMetadata: { renderMessageId: 'client-user-1' },
+      });
       seedPiCoreRow(instance, 1, {
         role: 'assistant',
         content: [{ type: 'text', text: 'streamed answer' }],
@@ -1076,13 +1011,11 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
         uiMetadata: { renderMessageId: 'turn-live' },
       });
 
-      // Stamped rows dedup by plain id-existence — no content heuristics.
       const after = await instance.getUiMessages();
       expect(after.map((m: AnyRecord) => m.id)).toEqual([
         'client-user-1',
         'turn-live',
       ]);
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(2);
     });
   });
 
@@ -1319,7 +1252,7 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
     });
   });
 
-  it('post-turn compaction preserves render history and re-pins the mark', async () => {
+  it('post-turn compaction keeps pre-compaction visible history via archive hybrid', async () => {
     const stub = await newChatThreadStub('thread-compaction-mark');
     await runInDurableObject(stub, async (instance: any) => {
       instance.chatContext = { threadId: 'thread-compaction-mark' };
@@ -1340,14 +1273,18 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       });
       const before = await instance.getUiMessages();
       expect(before).toHaveLength(4);
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(4);
 
-      // Compaction rewrites pi_core to a summary + the kept tail. The render
-      // mirror must keep the user's full visible history, and the mark must be
-      // re-pinned to the new (shorter) parsed count instead of going stale.
+      // Compaction rewrites pi_core to a summary + the kept tail. Preserve
+      // materializes the prior derive into the ai-chat archive first; reads then
+      // derive the tail and prepend archive-only rows (summary stays model-only).
       await instance['replacePiCoreMessages'](
         [
-          { role: 'user', content: 'summary of earlier work', timestamp: 1000 },
+          {
+            role: 'user',
+            content: 'summary of earlier work',
+            timestamp: 1000,
+            metadata: { compactSummary: true },
+          },
           { role: 'user', content: 'new q', timestamp: 2000 },
           {
             role: 'assistant',
@@ -1362,16 +1299,13 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       expect(preserved.map((m: AnyRecord) => m.id)).toEqual(
         before.map((m: AnyRecord) => m.id),
       );
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(3);
 
-      // A post-compaction turn's rows still top up exactly once.
       seedPiCoreRow(instance, 3, { role: 'user', content: 'later q', timestamp: 3000 });
       const after = await instance.getUiMessages();
       expect(after.map((m: AnyRecord) => m.id)).toEqual([
         ...before.map((m: AnyRecord) => m.id),
         'pi_user_3000_3',
       ]);
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(4);
     });
   });
 
@@ -1398,9 +1332,6 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
       // The render mirror was rebuilt from the repaired pi_core (the mark is
       // consistent with it), not left pointing at pre-repair indexes.
       const parsed = await instance.getPiCoreParsedMessages('thread-repair-rebuild');
-      expect(instance.ctx.storage.kv.get('uiMessagesPiCoreHighWaterIdx')).toBe(
-        parsed.length,
-      );
       const messages = await instance.getUiMessages();
       expect(messages.length).toBe(parsed.length);
     });
@@ -1423,14 +1354,15 @@ describe('ChatThreadDO native stream bridge (commit 3b)', () => {
         responseId: 'resp-old',
       });
 
-      const backfilled = await instance.getUiMessages();
-      expect(backfilled.map((m: AnyRecord) => m.id)).toEqual([
+      const derived = await instance.getUiMessages();
+      expect(derived.map((m: AnyRecord) => m.id)).toEqual([
         'pi_user_500_0',
         'resp-old',
       ]);
 
-      // A subsequent live persist (the CF_AGENT_CHAT_MESSAGES broadcast path)
-      // must not clobber the older backfilled rows.
+      // Materialize the derive into the archive table, then persist a new live
+      // row — older archive rows must remain (persist upserts, does not wipe).
+      await instance.resyncUiMessagesFromPiCore();
       await instance.persistMessages([
         ...instance.messages,
         {
@@ -1588,9 +1520,12 @@ describe('ChatThreadDO onConnect render-history delivery', () => {
       waitUntil: vi.fn((promise: Promise<unknown>) => background.push(promise)),
     };
     fake.sweepOrphanedActiveTurnMarker = vi.fn(async () => {});
-    fake.topUpUiMessagesFromPiCore = vi.fn(async () => {});
-    fake.healLegacyUiMessageTimes = vi.fn(async () => {});
-    fake.healLegacyUiMessageAuthors = vi.fn(async () => {});
+    fake.scheduleTranscriptLakeSync = vi.fn();
+    fake.getDerivedUiMessagePage = vi.fn(async () => ({
+      messages: fake.messages,
+      nextCursor: null,
+      hasMore: false,
+    }));
     fake.isThreadStreaming = vi.fn(() => false);
     fake.syncAgentState = vi.fn();
     fake.recordChatThreadObservabilityEvent = vi.fn();
@@ -1667,13 +1602,14 @@ describe('ChatThreadDO onConnect render-history delivery', () => {
     await Promise.all(fake.background);
   });
 
-  it('returns before repair gates resolve, then delivers corrected state and history', async () => {
+  it('returns before repair gates resolve, then delivers derived history after sweep', async () => {
     let releaseRepair!: () => void;
     const repairGate = new Promise<void>((resolve) => { releaseRepair = resolve; });
     const fake = makeConnectFake([{ id: 'stale', role: 'user', parts: [] }]);
     fake.sweepOrphanedActiveTurnMarker = vi.fn(() => repairGate);
-    fake.topUpUiMessagesFromPiCore = vi.fn(async () => {
+    fake.getDerivedUiMessagePage = vi.fn(async () => {
       fake.messages = [{ id: 'corrected', role: 'assistant', parts: [] }];
+      return { messages: fake.messages, nextCursor: null, hasMore: false };
     });
     const connection = { send: vi.fn(), close: vi.fn(), serializeAttachment: vi.fn() } as any;
 
@@ -1682,13 +1618,13 @@ describe('ChatThreadDO onConnect render-history delivery', () => {
     } as any);
 
     expect(fake.sweepOrphanedActiveTurnMarker).not.toHaveBeenCalled();
-    expect(fake.topUpUiMessagesFromPiCore).not.toHaveBeenCalled();
+    expect(fake.getDerivedUiMessagePage).not.toHaveBeenCalled();
     expect(connection.send).toHaveBeenCalledTimes(1);
     await connected;
     releaseRepair();
     await Promise.all(fake.background);
 
-    expect(fake.topUpUiMessagesFromPiCore).toHaveBeenCalledTimes(1);
+    expect(fake.getDerivedUiMessagePage).toHaveBeenCalledTimes(1);
     expect(fake.syncAgentState).toHaveBeenCalledTimes(2);
     const corrected = JSON.parse(connection.send.mock.calls.at(-1)?.[0] as string);
     expect(corrected.messages.map((message: AnyRecord) => message.id)).toEqual(['corrected']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase C derive-on-read** for chat render history so settled message order comes from `pi_core` instead of the secondary `cf_ai_chat_agent_messages` mirror (which can scramble under long steered turns — the Illiana thread class of bug).

### What changed
- New pure transform `deriveUiMessagesFromParsedPiCore` + `overlayLiveUiMessages` (`src/lib/derive-ui-messages-from-pi-core.ts`)
- `getUiMessages` / paging read settled history from pi_core, overlay the live open-turn / client skeletons, and prepend pre-compaction archive rows when present
- Connect handshake still sends the resident window synchronously; background reconcile sweeps orphaned active-turn markers then ships the derived page
- Compaction `uiRender: "preserve"` materializes the prior derive into the ai-chat table before pi_core shrinks so archive hybrid can keep full visible history
- Read-path high-water top-up / reconcile heals removed from the connect/loader path

### Follow-ups (not in this PR)
- Delete remaining high-water top-up / settled-mirror write path for storage
- Compaction stamp retention for stable `renderMessageId`s across rewrite
- Doc restore for `docs/chat-transcript-simplification.md` if that file is tracked in-repo

### Test plan
- [x] `bun run test:run -- tests/derive-ui-messages-from-pi-core.test.ts tests/chat-render-history.test.ts`
- [x] `bun run test:workers -- chat-thread-pi-stream-bridge chat-thread-ui-mirror`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a97af71-e2cc-4f84-a87b-7efc4db22daf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a97af71-e2cc-4f84-a87b-7efc4db22daf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

