### PR TITLE
Strip SELFHOST_AGENT_HOST_DIR from self-host Worker bindings

### DIFF
--- a/scripts/selfhost-workerd-config.mjs
+++ b/scripts/selfhost-workerd-config.mjs
@@ -752,6 +752,7 @@ async function main() {
   // Do not leak host-only path knobs into the Worker env.
   delete vars.SELFHOST_AGENT_DIR;
   delete vars.SELFHOST_AGENT_SKILLS_DIR;
+  delete vars.SELFHOST_AGENT_HOST_DIR;
 
   for (const [name, value] of Object.entries(vars)) {
     bindings.push(bindingText(name, value));

--- a/scripts/test-selfhost-workerd-config.mjs
+++ b/scripts/test-selfhost-workerd-config.mjs
@@ -215,10 +215,16 @@ description: Follow ACME runbooks. Use when shipping internal tools.
     config.includes('acme-runbooks/SKILL.md'),
     'config should embed custom skill markdown in skills JSON',
   );
-  assert(
-    !config.includes('SELFHOST_AGENT_DIR'),
-    'host-only SELFHOST_AGENT_DIR must not leak into Worker bindings',
-  );
+  for (const hostOnly of [
+    'SELFHOST_AGENT_DIR',
+    'SELFHOST_AGENT_SKILLS_DIR',
+    'SELFHOST_AGENT_HOST_DIR',
+  ]) {
+    assert(
+      !config.includes(`name = "${hostOnly}"`),
+      `host-only ${hostOnly} must not leak into Worker bindings`,
+    );
+  }
   for (const [containerClass, image] of [
     ['ProjectBuildSandbox', 'camelai-selfhost-project-build:0.12.0'],
     ['AnalysisSandbox', 'camelai-selfhost-analysis:0.12.0'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #23.

`SELFHOST_AGENT_HOST_DIR` is a Compose host-mount path only. It was still being copied into workerd text bindings alongside the resolved agent pack. Strip it with the other host-only knobs (`SELFHOST_AGENT_DIR`, `SELFHOST_AGENT_SKILLS_DIR`).

Verified with `node scripts/test-selfhost-workerd-config.mjs` and a real config generation against `.env.selfhost`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27738bdf-387c-431c-879c-155eeb99da88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27738bdf-387c-431c-879c-155eeb99da88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

