### PR TITLE
Fix analysis sandbox zombie s3fs mounts (Errno 5 after DO recycle)

### DIFF
--- a/tests/selfhost-health.test.ts
+++ b/tests/selfhost-health.test.ts
@@ -77,10 +77,6 @@ describe("self-host health route", () => {
       state: "disabled",
       available: false,
     });
-    expect(body.capabilities.features.connections_binding).toMatchObject({
-      state: "disabled",
-      available: false,
-    });
     expect(body.capabilities.features.project_builds).toMatchObject({
       state: "configured",
       available: null,

--- a/tests/selfhost-health.test.ts
+++ b/tests/selfhost-health.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SELFHOST_CAPABILITY_CONTRACT_VERSION } from "@/lib/selfhost-capabilities";
 
 const getEnvMock = vi.fn();
 
@@ -71,8 +72,12 @@ describe("self-host health route", () => {
         expect.objectContaining({ name: "email", status: "warn" }),
       ]),
     );
-    expect(body.capabilities.version).toBe(2);
+    expect(body.capabilities.version).toBe(SELFHOST_CAPABILITY_CONTRACT_VERSION);
     expect(body.capabilities.features.outbound_email).toMatchObject({
+      state: "disabled",
+      available: false,
+    });
+    expect(body.capabilities.features.connections_binding).toMatchObject({
       state: "disabled",
       available: false,
     });

--- a/workers/main/src/analysis-sandbox.ts
+++ b/workers/main/src/analysis-sandbox.ts
@@ -5,13 +5,14 @@ import { handleAuthenticatedConnectionsRpc } from "./routes/connections-rpc.js";
 import type { Env } from "./types.js";
 
 /**
- * Both of these mean "the prefix is already mounted" — the state we want — so a
- * mount attempt that hits either is a success, not a failure:
+ * Both of these mean "the prefix is already mounted" — recoverable presence, not
+ * a hard failure — so callers can unmount+remount (see `mountOrRecover`):
  *
- * - `S3FSMountError`: the prefix is still mounted at the kernel level from a
- *   previous container life (this DO instance was recreated, losing the SDK's
- *   in-memory mount registry, while the container kept the mount), so s3fs
- *   reports the mountpoint busy.
+ * - `S3FSMountError` whose message looks like a busy/nonempty mountpoint: the
+ *   prefix is still mounted at the kernel level from a previous container life
+ *   (this DO instance was recreated, losing the SDK's in-memory mount registry,
+ *   while the container kept the mount). We match the message so genuine s3fs
+ *   failures (auth, network, missing bucket) still surface.
  * - `InvalidMountConfigError` with an "already in use" message: the SDK's own
  *   in-memory registry already holds this path, so it rejects a second mount of
  *   it (e.g. a concurrent `ensureMounted` that mounted it first). We match the
@@ -21,11 +22,103 @@ import type { Env } from "./types.js";
  * Any other error (bad binding name, missing binding, invalid path) is genuine.
  */
 export function isMountAlreadyPresent(error: unknown): boolean {
-  if (error instanceof S3FSMountError) return true;
+  if (
+    error instanceof S3FSMountError &&
+    /not empty|MOUNTPOINT|busy|already mounted/i.test(String(error.message ?? error))
+  ) {
+    return true;
+  }
   if (error instanceof InvalidMountConfigError && /already in use/i.test(String(error.message))) {
     return true;
   }
   return false;
+}
+
+/** Options forwarded to `Sandbox.mountBucket` for R2 binding mounts. */
+export type R2MountBucketOptions = {
+  prefix: string;
+  readOnly?: boolean;
+  s3fsOptions?: string[];
+};
+
+/**
+ * Minimal surface `mountOrRecover` needs from a Sandbox. Kept narrow so the
+ * recovery path is unit-testable without spinning a container.
+ */
+export interface MountRecoverTarget {
+  mountBucket(bucket: string, mountPath: string, options: R2MountBucketOptions): Promise<void>;
+  unmountBucket(mountPath: string): Promise<void>;
+  exec(
+    command: string,
+    options?: { timeout?: number },
+  ): Promise<{ exitCode?: number; stdout?: string; stderr?: string }>;
+}
+
+/**
+ * Mount an R2 prefix, recovering from the warm-container remount hazard:
+ *
+ * When a Sandbox DO is recreated, the SDK loses its in-memory mount registry
+ * and `r2.internal` interception, but the container can keep the old FUSE
+ * mounts. A naive remount then fails with "MOUNTPOINT … is not empty". The SDK
+ * cleans up the failed attempt by calling `configureR2EgressOutbound` with the
+ * *remaining* (often empty) bucket set — which **removes** `r2.internal` —
+ * while the zombie FUSE mounts stay. Every subsequent read returns Errno 5.
+ *
+ * Swallowing that error (the old behaviour) left the workspace permanently
+ * wedged until the container was destroyed. Instead: unmount, remount (so
+ * egress is re-registered), and if the mount still only "looks" present, probe
+ * a directory listing and fail loudly when I/O is dead.
+ */
+export async function mountOrRecover(
+  target: MountRecoverTarget,
+  bucket: string,
+  mountPath: string,
+  options: R2MountBucketOptions,
+): Promise<void> {
+  try {
+    await target.mountBucket(bucket, mountPath, options);
+    return;
+  } catch (error) {
+    if (!isMountAlreadyPresent(error)) throw error;
+  }
+
+  try {
+    await target.unmountBucket(mountPath);
+  } catch (error) {
+    console.warn(`[sandbox] unmount ${mountPath} before remount failed`, error);
+  }
+
+  try {
+    await target.mountBucket(bucket, mountPath, options);
+    return;
+  } catch (error) {
+    if (!isMountAlreadyPresent(error)) throw error;
+  }
+
+  if (!(await mountAllowsList(target, mountPath))) {
+    throw new Error(
+      `R2 mount at ${mountPath} appears present but is not readable (I/O error). ` +
+        `Recreate the analysis sandbox container to recover.`,
+    );
+  }
+}
+
+/** True when `ls` against the mount path succeeds without an I/O error. */
+export async function mountAllowsList(
+  target: Pick<MountRecoverTarget, "exec">,
+  mountPath: string,
+): Promise<boolean> {
+  // Mount paths are platform-controlled (`/uploads`, `/outputs`, `/warehouse/<uuid>`).
+  if (!/^\/[A-Za-z0-9._/-]+$/.test(mountPath) || mountPath.includes("..")) return false;
+  try {
+    const result = await target.exec(`ls -ld -- ${mountPath}`, { timeout: 15_000 });
+    if ((result.exitCode ?? 1) !== 0) return false;
+    const combined = `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
+    if (/Input\/output error|Errno 5/i.test(combined)) return false;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -151,7 +244,8 @@ export class AnalysisSandbox extends Sandbox<Env> {
    * The mount runs at most once per mount path per container life: the
    * single-flight gate coalesces concurrent callers and caches success; repeated
    * calls on a warm container are a no-op. An already-mounted error from a
-   * previous container life is treated as success (see isMountAlreadyPresent).
+   * previous container life is recovered via unmount+remount (see mountOrRecover)
+   * so `r2.internal` egress is re-registered instead of leaving zombie FUSE mounts.
    */
   async ensureMounted(
     bucketBinding: string,
@@ -168,19 +262,15 @@ export class AnalysisSandbox extends Sandbox<Env> {
     }
     const readOnly = options.readOnly ?? true;
     await gate(async () => {
-      try {
-        await this.mountBucket(bucketBinding, resolvedMountPath, {
-          prefix: `/${prefix}`,
-          readOnly,
-          // Shrink the s3fs stat cache (default 60s + negative caching) so a
-          // just-staged export/upload isn't read through a stale/partial view —
-          // which otherwise surfaces as a read failure. The stage → read gap
-          // exceeds 1s, so this adds no real overhead. Matches WarehouseSandbox.
-          s3fsOptions: ["stat_cache_expire=1"],
-        });
-      } catch (error) {
-        if (!isMountAlreadyPresent(error)) throw error;
-      }
+      await mountOrRecover(this, bucketBinding, resolvedMountPath, {
+        prefix: `/${prefix}`,
+        readOnly,
+        // Shrink the s3fs stat cache (default 60s + negative caching) so a
+        // just-staged export/upload isn't read through a stale/partial view —
+        // which otherwise surfaces as a read failure. The stage → read gap
+        // exceeds 1s, so this adds no real overhead. Matches WarehouseSandbox.
+        s3fsOptions: ["stat_cache_expire=1"],
+      });
       this.mountedPaths.add(resolvedMountPath);
     });
   }

--- a/workers/main/src/db-query-sandbox.ts
+++ b/workers/main/src/db-query-sandbox.ts
@@ -1,6 +1,6 @@
 import { Sandbox } from "@cloudflare/sandbox";
 
-import { createSingleFlight, isMountAlreadyPresent } from "./analysis-sandbox.js";
+import { createSingleFlight, mountOrRecover } from "./analysis-sandbox.js";
 import { DB_QUERY_SLEEP_AFTER } from "./container-sizing.js";
 import type { Env } from "./types.js";
 
@@ -70,7 +70,8 @@ export class DbQuerySandbox extends Sandbox<Env> {
    * so an export staged at R2 key `<prefix>/x` is written at `/<prefix>/x` —
    * the same `'/' + r2_key` contract the analysis container reads with. At
    * most one mount attempt per path per container life; an already-mounted
-   * error from a previous life counts as success.
+   * error from a previous life is recovered via unmount+remount (see
+   * mountOrRecover) so `r2.internal` egress is re-registered.
    */
   async ensureWarehouseExportMount(prefix: string): Promise<void> {
     const mountPath = `/${prefix}`;
@@ -81,17 +82,13 @@ export class DbQuerySandbox extends Sandbox<Env> {
       this.mountGates.set(mountPath, gate);
     }
     await gate(async () => {
-      try {
-        await this.mountBucket(WAREHOUSE_EXPORT_BUCKET_BINDING, mountPath, {
-          prefix: mountPath,
-          readOnly: false,
-          // Shrink the s3fs stat cache so a re-export of the same key doesn't
-          // read/write through a stale view (matches the analysis mounts).
-          s3fsOptions: ["stat_cache_expire=1"],
-        });
-      } catch (error) {
-        if (!isMountAlreadyPresent(error)) throw error;
-      }
+      await mountOrRecover(this, WAREHOUSE_EXPORT_BUCKET_BINDING, mountPath, {
+        prefix: mountPath,
+        readOnly: false,
+        // Shrink the s3fs stat cache so a re-export of the same key doesn't
+        // read/write through a stale view (matches the analysis mounts).
+        s3fsOptions: ["stat_cache_expire=1"],
+      });
       this.mountedPaths.add(mountPath);
     });
   }

--- a/workers/main/src/routes/admin/routes.ts
+++ b/workers/main/src/routes/admin/routes.ts
@@ -806,6 +806,73 @@ routes.post(
 );
 
 // ---------------------------------------------------------------------------
+// POST /workspaces/:workspaceId/analysis-sandbox/reset
+// ---------------------------------------------------------------------------
+
+const AnalysisSandboxResetResponseSchema = z.object({
+  ok: z.boolean(),
+  workspace_id: z.string(),
+  destroyed: z.array(z.string()),
+  errors: z.array(z.object({ sandbox_id: z.string(), error: z.string() })),
+});
+
+routes.post(
+  "/workspaces/:workspaceId/analysis-sandbox/reset",
+  openApi({
+    summary:
+      "Destroy the workspace analysis sandbox containers so the next run gets fresh R2/s3fs mounts",
+    responses: {
+      200: AnalysisSandboxResetResponseSchema,
+      400: ErrorSchema,
+    },
+  }),
+  async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    if (!c.env.ANALYSIS_SANDBOX) {
+      return c.json({ error: "ANALYSIS_SANDBOX container binding is not configured" }, 400);
+    }
+
+    // Mirror AnalysisService.resolveSandbox ids: one agent container per
+    // workspace, plus a separate app-scoped container for deployed-app runCode.
+    const sandboxIds = [workspaceId, `app-${workspaceId}`];
+    const destroyed: string[] = [];
+    const errors: Array<{ sandbox_id: string; error: string }> = [];
+
+    for (const sandboxId of sandboxIds) {
+      try {
+        const sandbox = getSandbox(c.env.ANALYSIS_SANDBOX, sandboxId, {
+          normalizeId: true,
+        }) as { destroy: () => Promise<void> };
+        await sandbox.destroy();
+        destroyed.push(sandboxId);
+      } catch (error) {
+        errors.push({
+          sandbox_id: sandboxId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    recordObservabilityEvent(c.env, {
+      event: "analysis_sandbox_reset",
+      severity: errors.length > 0 ? "warn" : "info",
+      component: "admin",
+      operation: "analysis-sandbox-reset",
+      status: errors.length > 0 ? "partial" : "ok",
+      workspaceId,
+      count: destroyed.length,
+    });
+
+    return c.json({
+      ok: errors.length === 0,
+      workspace_id: workspaceId,
+      destroyed,
+      errors,
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
 // POST /db-query-sandbox/query
 // ---------------------------------------------------------------------------
 

--- a/workers/main/tests/analysis-sandbox.test.ts
+++ b/workers/main/tests/analysis-sandbox.test.ts
@@ -1,13 +1,31 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { InvalidMountConfigError, S3FSMountError } from '@cloudflare/sandbox';
-import { createSingleFlight, isMountAlreadyPresent } from '../src/analysis-sandbox.js';
+import {
+  createSingleFlight,
+  isMountAlreadyPresent,
+  mountAllowsList,
+  mountOrRecover,
+  type MountRecoverTarget,
+} from '../src/analysis-sandbox.js';
 
 describe('isMountAlreadyPresent', () => {
-  it('treats the SDK s3fs mount error as already-mounted (branch on type, not message)', () => {
+  it('treats nonempty / busy s3fs mount errors as already-mounted', () => {
     // The warm-container remount symptom: the prefix is already mounted at the
-    // kernel level and s3fs reports the mountpoint busy.
+    // kernel level and s3fs reports the mountpoint busy / nonempty.
     const error = new S3FSMountError('S3FS mount failed: s3fs: MOUNTPOINT directory /warehouse/ws_1 is not empty');
     expect(isMountAlreadyPresent(error)).toBe(true);
+    expect(
+      isMountAlreadyPresent(new S3FSMountError('S3FS mount failed: fuse: mountpoint is busy')),
+    ).toBe(true);
+  });
+
+  it('does NOT swallow unrelated S3FSMountError variants (auth / network)', () => {
+    expect(
+      isMountAlreadyPresent(new S3FSMountError('S3FS mount failed: 403 AccessDenied')),
+    ).toBe(false);
+    expect(
+      isMountAlreadyPresent(new S3FSMountError('S3FS mount failed: unable to connect')),
+    ).toBe(false);
   });
 
   it('treats the SDK "mount path already in use" config error as already-mounted', () => {
@@ -31,6 +49,122 @@ describe('isMountAlreadyPresent', () => {
     expect(isMountAlreadyPresent(new Error('permission denied'))).toBe(false);
     expect(isMountAlreadyPresent('not even an error')).toBe(false);
     expect(isMountAlreadyPresent(undefined)).toBe(false);
+  });
+});
+
+describe('mountOrRecover', () => {
+  const options = { prefix: '/uploads-prefix', readOnly: true as const };
+
+  function makeTarget(overrides: Partial<MountRecoverTarget> = {}): MountRecoverTarget & {
+    mounts: string[];
+    unmounts: string[];
+  } {
+    const mounts: string[] = [];
+    const unmounts: string[] = [];
+    return {
+      mounts,
+      unmounts,
+      async mountBucket(_bucket, mountPath) {
+        mounts.push(mountPath);
+      },
+      async unmountBucket(mountPath) {
+        unmounts.push(mountPath);
+      },
+      async exec() {
+        return { exitCode: 0, stdout: 'ok', stderr: '' };
+      },
+      ...overrides,
+    };
+  }
+
+  it('returns after a clean first mount', async () => {
+    const target = makeTarget();
+    await mountOrRecover(target, 'R2_BUCKET', '/uploads', options);
+    expect(target.mounts).toEqual(['/uploads']);
+    expect(target.unmounts).toEqual([]);
+  });
+
+  it('unmounts and remounts when the first attempt hits nonempty mountpoint', async () => {
+    const target = makeTarget();
+    let attempts = 0;
+    target.mountBucket = async (_bucket, mountPath) => {
+      attempts += 1;
+      target.mounts.push(mountPath);
+      if (attempts === 1) {
+        throw new S3FSMountError(
+          'S3FS mount failed: s3fs: MOUNTPOINT directory /uploads is not empty',
+        );
+      }
+    };
+
+    await mountOrRecover(target, 'R2_BUCKET', '/uploads', options);
+    expect(target.unmounts).toEqual(['/uploads']);
+    expect(attempts).toBe(2);
+  });
+
+  it('fails loudly when remount is still blocked and the mount cannot list', async () => {
+    const target = makeTarget({
+      async mountBucket() {
+        throw new S3FSMountError(
+          'S3FS mount failed: s3fs: MOUNTPOINT directory /uploads is not empty',
+        );
+      },
+      async exec() {
+        return { exitCode: 2, stdout: '', stderr: 'ls: Input/output error' };
+      },
+    });
+
+    await expect(mountOrRecover(target, 'R2_BUCKET', '/uploads', options)).rejects.toThrow(
+      /not readable \(I\/O error\)/,
+    );
+    expect(target.unmounts).toEqual(['/uploads']);
+  });
+
+  it('accepts a still-present mount when directory listing works after remount failure', async () => {
+    const target = makeTarget({
+      async mountBucket() {
+        throw new S3FSMountError(
+          'S3FS mount failed: s3fs: MOUNTPOINT directory /uploads is not empty',
+        );
+      },
+      async exec() {
+        return { exitCode: 0, stdout: 'drwxr-xr-x 1 root root 0 /uploads', stderr: '' };
+      },
+    });
+
+    await expect(mountOrRecover(target, 'R2_BUCKET', '/uploads', options)).resolves.toBeUndefined();
+  });
+
+  it('rethrows genuine mount failures without attempting recovery', async () => {
+    const target = makeTarget({
+      async mountBucket() {
+        throw new S3FSMountError('S3FS mount failed: 403 AccessDenied');
+      },
+    });
+    await expect(mountOrRecover(target, 'R2_BUCKET', '/uploads', options)).rejects.toBeInstanceOf(
+      S3FSMountError,
+    );
+    expect(target.unmounts).toEqual([]);
+  });
+});
+
+describe('mountAllowsList', () => {
+  it('rejects unsafe mount paths', async () => {
+    expect(await mountAllowsList({ exec: vi.fn() }, '/uploads/../etc')).toBe(false);
+    expect(await mountAllowsList({ exec: vi.fn() }, 'uploads')).toBe(false);
+  });
+
+  it('returns false on I/O errors in ls output', async () => {
+    expect(
+      await mountAllowsList(
+        {
+          async exec() {
+            return { exitCode: 0, stdout: '', stderr: 'Input/output error' };
+          },
+        },
+        '/uploads',
+      ),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production incident for workspace `1d83d721-ff52-4398-9bfe-0c7a4af3dca5` (SecLock / Jon): all analysis-sandbox R2 FUSE mounts (`/uploads`, `/outputs`, `/warehouse/...`) returned **Errno 5 Input/output error** while still showing as `fuse.s3fs` in `mount`.

### Root cause

Worker logs for this workspace:

1. **11:18 UTC** — successful mounts of warehouse / uploads / outputs  
2. **11:22 UTC** — remount attempts fail with:
   `S3FS mount failed: s3fs: MOUNTPOINT directory … is not empty`
3. Our code treated **any** `S3FSMountError` as “already mounted → success”
4. On that failed remount, the Sandbox SDK calls `configureR2EgressOutbound` with the *remaining* (often empty) bucket set, which **removes** the `r2.internal` interception
5. Zombie kernel FUSE mounts stay → every read/list returns EIO across fresh `run_code` / `analysis_exec` sessions (they share one warm container per workspace)

R2 itself is fine (warehouse objects list via the API; `tools.read` with `location: "r2"` still works).

### Fix

- `mountOrRecover()`: on nonempty/busy mountpoint errors, **unmount + remount** so egress is re-registered; if still blocked, probe `ls` and fail loudly on I/O errors
- Narrow `isMountAlreadyPresent` so auth/network `S3FSMountError`s are not swallowed
- Same recovery path in `DbQuerySandbox`
- Admin: `POST /api/admin/workspaces/:workspaceId/analysis-sandbox/reset` destroys agent + app analysis containers for immediate recovery
- CI: fix pre-existing `selfhost-health` assertion still expecting capabilities contract v2 after #22 bumped it to v3

### Immediate ops (before deploy)

Destroy the wedged container for this workspace via `admin_js_exec`:

```js
const { getSandbox } = await import("@cloudflare/sandbox");
const ws = "1d83d721-ff52-4398-9bfe-0c7a4af3dca5";
await getSandbox(env.ANALYSIS_SANDBOX, ws, { normalizeId: true }).destroy();
await getSandbox(env.ANALYSIS_SANDBOX, `app-${ws}`, { normalizeId: true }).destroy();
```

Or after this ships: `POST /api/admin/workspaces/1d83d721-ff52-4398-9bfe-0c7a4af3dca5/analysis-sandbox/reset`

## Test plan

- [x] `bun run test:workers -- analysis-sandbox`
- [x] `bun run test:workers -- analysis-service`
- [x] `bun run test:run -- selfhost-health`
- [ ] After deploy: reset SecLock workspace sandbox and confirm `/uploads` `ls` works in `run_code`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc7b2-6f98-7726-8ad4-48310646db67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc7b2-6f98-7726-8ad4-48310646db67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

