### PR TITLE
Track Stream purchase conversion on checkout success

### DIFF
--- a/src/components/stream-purchase-tracker.tsx
+++ b/src/components/stream-purchase-tracker.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router";
+import { trackMarketingEventOnce } from "@/lib/marketing-attribution.client";
+
+type PurchaseResponse = {
+  purchased: boolean;
+  shouldTrack?: boolean;
+  eventId?: string;
+  billingStatus?: "active" | "trialing";
+  subscriptionId?: string | null;
+};
+
+export function StreamPurchaseTracker() {
+  const location = useLocation();
+  const attemptedRef = useRef(false);
+
+  useEffect(() => {
+    if (attemptedRef.current) return;
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get("checkout") !== "success") return;
+
+    attemptedRef.current = true;
+
+    void fetch("/api/marketing-attribution/purchase", {
+      method: "POST",
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("Failed to confirm purchase");
+        }
+        return response.json() as Promise<PurchaseResponse>;
+      })
+      .then(async (result) => {
+        if (result.purchased && result.shouldTrack && result.eventId) {
+          await trackMarketingEventOnce("purchase", result.eventId, {
+            billing_status: result.billingStatus,
+            subscription_id: result.subscriptionId,
+            transaction_id: result.eventId,
+          });
+        }
+      })
+      .catch((error) => {
+        attemptedRef.current = false;
+        console.error("Failed to track Stream purchase", error);
+      })
+      .finally(() => {
+        const cleanUrl = new URL(window.location.href);
+        cleanUrl.searchParams.delete("checkout");
+        window.history.replaceState(
+          window.history.state,
+          "",
+          `${cleanUrl.pathname}${cleanUrl.search}${cleanUrl.hash}`,
+        );
+      });
+  }, [location.search]);
+
+  return null;
+}

--- a/src/lib/marketing-attribution.server.ts
+++ b/src/lib/marketing-attribution.server.ts
@@ -5,6 +5,7 @@ const COOKIE_NAME = "camel_attribution_id";
 const KV_PREFIX = "marketing_attribution:";
 const USER_PREFIX = "user_marketing_attribution:";
 const ACTIVATION_PREFIX = "new_camel_activation:";
+const PURCHASE_PREFIX = "stream_purchase:";
 const TTL_SECONDS = 60 * 60 * 24 * 90;
 const ATTRIBUTION_KEYS = [
   "gclid",
@@ -54,6 +55,15 @@ export type NewCamelActivationRecord = {
   attributionId: string | null;
   firstTouch: MarketingFirstTouch | null;
   campaign: MarketingAttribution;
+};
+
+export type StreamPurchaseRecord = {
+  eventId: string;
+  eventName: "purchase";
+  orgId: string;
+  purchasedAt: string;
+  billingStatus: "active" | "trialing";
+  subscriptionId: string | null;
 };
 
 function validId(value: string | null | undefined): value is string {
@@ -167,4 +177,31 @@ export async function recordNewCamelActivation(
   } satisfies NewCamelActivationRecord;
   await kv.put(key, JSON.stringify(record));
   return record;
+}
+
+export async function recordStreamPurchase(
+  kv: KVNamespace,
+  input: {
+    orgId: string;
+    purchasedAt: number;
+    billingStatus: "active" | "trialing";
+    subscriptionId: string | null;
+  },
+): Promise<{ record: StreamPurchaseRecord; isFirst: boolean }> {
+  const key = `${PURCHASE_PREFIX}${input.orgId}`;
+  const existing = await kv.get<StreamPurchaseRecord>(key, "json");
+  if (existing) {
+    return { record: existing, isFirst: false };
+  }
+
+  const record = {
+    eventId: crypto.randomUUID(),
+    eventName: "purchase",
+    orgId: input.orgId,
+    purchasedAt: new Date(input.purchasedAt).toISOString(),
+    billingStatus: input.billingStatus,
+    subscriptionId: input.subscriptionId,
+  } satisfies StreamPurchaseRecord;
+  await kv.put(key, JSON.stringify(record));
+  return { record, isFirst: true };
 }

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -23,6 +23,7 @@ import { ChatThreadSnapshotsProvider } from "@/hooks/use-chat-thread-snapshots";
 import { BillingDialogPresenceProvider } from "@/hooks/use-billing-dialog-presence";
 import type { AuthState } from "@/types";
 import type { ChatGroupView } from "@/types";
+import { StreamPurchaseTracker } from "@/components/stream-purchase-tracker";
 import {
   isOrgBillingAccessReady,
   resolveOrgBillingAccess,
@@ -244,6 +245,7 @@ export default function AppLayout() {
       <ChatGroupsProvider disableLiveStatus={embedMode}>
         <BillingDialogPresenceProvider>
           <ChatThreadSnapshotsProvider>
+            <StreamPurchaseTracker />
             {embedMode ? null : (
               <AppSidebar
                 billingAccessMode={billingAccessMode}

--- a/src/routes/api/marketing-attribution.purchase.ts
+++ b/src/routes/api/marketing-attribution.purchase.ts
@@ -1,0 +1,45 @@
+import type { Route } from "./+types/marketing-attribution.purchase";
+import { requireAuthContext } from "@/lib/auth.server";
+import { getEnv } from "@/lib/cloudflare.server";
+import { recordStreamPurchase } from "@/lib/marketing-attribution.server";
+
+const PURCHASE_STATUSES = new Set(["active", "trialing"]);
+
+export async function action({ request, context }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const auth = await requireAuthContext(request, context);
+  const env = getEnv(context);
+  const billingStatus = auth.currentOrg.billing_status;
+
+  if (!PURCHASE_STATUSES.has(billingStatus)) {
+    return Response.json(
+      {
+        purchased: false,
+        reason: "billing_not_active",
+        billingStatus,
+      },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  const { record, isFirst } = await recordStreamPurchase(env.APP_KV, {
+    orgId: auth.currentOrg.id,
+    purchasedAt: Date.now(),
+    billingStatus: billingStatus as "active" | "trialing",
+    subscriptionId: auth.currentOrg.billing_subscription_id ?? null,
+  });
+
+  return Response.json(
+    {
+      purchased: true,
+      shouldTrack: isFirst,
+      eventId: record.eventId,
+      billingStatus: record.billingStatus,
+      subscriptionId: record.subscriptionId,
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}


### PR DESCRIPTION
## What changed
This adds a Stream-specific `purchase` marketing event instead of relying on the old `camelai.dev` activation flow.

- adds an authenticated purchase-confirmation endpoint at `POST /api/marketing-attribution/purchase`
- records a one-time per-org purchase marker in KV once the org billing state is actually `active` or `trialing`
- mounts a small app-level tracker that listens for `?checkout=success` and emits a `purchase` event through the existing marketing attribution client
- keeps the event on the Stream app path rather than tying Stream campaign diagnostics to `camelai.dev`

## Why
The Stream Google Ads campaign now uses `purchase` as its primary conversion. The app did not appear to emit a real Stream-side GA4/Zaraz `purchase` event yet, even though Google Ads was configured to optimize against one. This change gives the campaign a Stream-specific purchase signal with basic idempotency and a real billing-state check.

## Impact
- Stream campaign purchase attribution can now come from a real Stream checkout success path
- Stream conversion reporting no longer needs to lean on `new_camel_activation` for this campaign
- the event only fires after authenticated app return and only when billing is actually in a paid/trialing state

## Validation
- inspected the current Stream billing and marketing attribution paths in the repo
- confirmed subscription checkout success currently returns through the authenticated app
- local full typecheck could not be completed in this sandbox because `bun` temp-file writes were blocked by environment permissions

## Follow-up
After this is deployed, Google Ads/GA4 should be aligned so the Stream campaign watches Stream-native events such as `sign_up`, `stream_console_login_complete`, and `purchase`, with `purchase` remaining primary.