### PR TITLE
Add camelStream auth rescue links

### DIFF
--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -165,6 +165,16 @@ export function LoginForm({
               </div>
 
               <div className="text-center text-xs text-muted-foreground">
+                <p>Looking for camelStream, the flat-rate inference API?</p>
+                <a
+                  href="https://stream.camelai.com/login?utm_source=camelai_dev&utm_medium=auth_rescue"
+                  className="hover:underline underline-offset-4"
+                >
+                  Log in at stream.camelai.com →
+                </a>
+              </div>
+
+              <div className="text-center text-xs text-muted-foreground">
                 Looking for old camelAI?{" "}
                 <a
                   href="https://app.camelai.com"

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -234,6 +234,16 @@ export function SignupForm({
                   Sign in
                 </Link>
               </div>
+
+              <div className="text-center text-xs text-muted-foreground">
+                <p>Looking for camelStream, the flat-rate inference API?</p>
+                <a
+                  href="https://stream.camelai.com/login?utm_source=camelai_dev&utm_medium=auth_rescue"
+                  className="hover:underline underline-offset-4"
+                >
+                  Log in at stream.camelai.com →
+                </a>
+              </div>
             </form>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- add a camelStream rescue link to both the camelAI login and signup forms
- send users directly to the camelStream login entry point
- attach `utm_source=camelai_dev&utm_medium=auth_rescue` for measurable recovery traffic
- preserve the existing legacy camelAI link on the login form

## Why

Users who reach the camelAI auth flow while looking for the flat-rate inference product currently have no clear route to camelStream. This gives them a quiet, contextual exit without disrupting the primary coding-agent signup flow.

## User impact

Misrouted camelStream users can recover from either camelAI auth screen in one click, and the handoff can be measured through existing Stream attribution.

## Validation

- `bun run typecheck`
- `bun run build`