### PR TITLE
Add per-user LLM usage tracking and limits

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -70,6 +70,95 @@ sidecars, which are unreachable through a nested Compose bridge. The app still
 listens on `SELFHOST_BIND_ADDRESS` (default `127.0.0.1`), so keep that loopback
 default and put the deployment behind the documented reverse proxy.
 
+## Per-user LLM usage limits
+
+`selfhost:init` generates a distinct `ADMIN_API_KEY` in `.env.selfhost`. The
+operator API accepts it as a bearer token; keep it on the host and never pass it
+to project containers, sandbox code, or deployed apps. The CloudFormation and
+Terraform single-node installers also run `selfhost:init`, so they generate and
+retain the same separate secret in the installation's `0600` environment file.
+Upgrades preserve that file. Backups intentionally exclude it along with the
+other operator-owned secrets, so retain the environment file in your normal
+secret backup system.
+
+For an existing source-mode installation created before this key existed, run
+`bun run selfhost:migrate-secrets` once. `selfhost:up` also performs that
+idempotent migration automatically.
+
+Run the following commands on the installation host. They read only the two
+needed values with the self-host dotenv parser (without sourcing or exporting
+the rest of the environment) and use the loopback app URL, which bypasses the
+interactive Pomerium login protecting the public URL:
+
+```bash
+ADMIN_API_KEY="$(bun -e 'const {readSelfhostEnv}=await import("./scripts/selfhost-common.mjs"); process.stdout.write((await readSelfhostEnv(true)).ADMIN_API_KEY || "")')"
+BASE_URL="$(bun -e 'const {readSelfhostEnv}=await import("./scripts/selfhost-common.mjs"); process.stdout.write((await readSelfhostEnv(true)).SELFHOST_INTERNAL_APP_URL || "http://127.0.0.1:3001")')"
+curl -fsS -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+  "${BASE_URL}/api/admin/orgs?limit=100"
+curl -fsS -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+  "${BASE_URL}/api/admin/users?limit=100"
+```
+
+Inspect one rolling report and its exact provider/model pricing discovery. The
+report range is inclusive at `from` and exclusive at `to`:
+
+```bash
+NOW_MS=$(date +%s000)
+FROM_MS=$((NOW_MS - 30 * 24 * 60 * 60 * 1000))
+curl -fsS -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+  "${BASE_URL}/api/admin/orgs/${ORG_ID}/usage/users?from=${FROM_MS}&to=${NOW_MS}"
+curl -fsS -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+  "${BASE_URL}/api/admin/orgs/${ORG_ID}/usage/pricing"
+```
+
+Custom model IDs must have exact pricing before a limited member can use them.
+An all-zero override is valid for an operator-owned model that is genuinely
+free. Pricing `PUT` is a full replacement, not an upsert: first `GET` the
+current list, merge the change, and send the complete desired `prices` array.
+The following is safe only when this is the complete desired list:
+
+```bash
+curl -fsS -X PUT -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+  -H 'Content-Type: application/json' \
+  --data '{"prices":[{"provider":"custom","model":"acme-code-70b","input_usd_per_million":0.8,"output_usd_per_million":2.4,"cache_creation_usd_per_million":1,"cache_read_usd_per_million":0.08}]}' \
+  "${BASE_URL}/api/admin/orgs/${ORG_ID}/usage/pricing"
+```
+
+Set simultaneous rolling limits, or clear them with an empty list:
+
+```bash
+curl -fsS -X PUT -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+  -H 'Content-Type: application/json' \
+  --data '{"limits":[{"window_hours":24,"limit_usd":5,"label":"daily"},{"window_hours":720,"limit_usd":50,"label":"30-day"}]}' \
+  "${BASE_URL}/api/admin/orgs/${ORG_ID}/usage/users/${USER_ID}/limits"
+
+curl -fsS -X PUT -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+  -H 'Content-Type: application/json' --data '{"limits":[]}' \
+  "${BASE_URL}/api/admin/orgs/${ORG_ID}/usage/users/${USER_ID}/limits"
+```
+
+Limits are rolling stop-new-pull soft caps. A pull already accepted can cross a
+cap, and concurrent pulls can settle afterward; the next pull is denied. With
+an active limit, an unknown requested model or any unpriced LLM row still in an
+active window fails closed. Adding an override makes future pulls for that exact
+provider/model eligible, but historical rows are never repriced: an existing
+unpriced row continues to block until it ages out of every configured window or
+the operator clears the affected user's policy. Main/child agents, context
+compaction, and attributable virtual-AI calls count. Auxiliary title,
+completion-summary, and chat-group icon generation is not covered in this
+version.
+
+When finished, remove the key from the shell:
+
+```bash
+unset ADMIN_API_KEY BASE_URL
+```
+
+Within a live chat-thread isolate, a failed accounting write is retained and
+retried with the same idempotency key before another model pull. That pending
+retry queue is currently isolate-local; eviction during an accounting outage is
+the remaining recovery boundary.
+
 ## Capability contract
 
 `GET /api/selfhost/health` is both the readiness endpoint and the

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -9,6 +9,7 @@ services:
       NODE_ENV: production
       TOKEN_SIGNING_SECRET: ${TOKEN_SIGNING_SECRET:?Run bun run selfhost:init}
       INTEGRATION_SECRET_KEY: ${INTEGRATION_SECRET_KEY:?Run bun run selfhost:init}
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?Run bun run selfhost:migrate-secrets}
       CONNECTIONS_BINDING_ENABLED: ${CONNECTIONS_BINDING_ENABLED:-true}
       WORKER_BASE_URL: ${SELFHOST_PUBLIC_BASE_URL:?Run bun run selfhost:init}
       LOCAL_ARTIFACTS_BASE_URL: http://127.0.0.1:7001

--- a/infra/selfhost/cloudformation/aws-single-node.yaml
+++ b/infra/selfhost/cloudformation/aws-single-node.yaml
@@ -681,6 +681,7 @@ Resources:
                 git checkout --detach "$REPOSITORY_REF"
                 bun install --frozen-lockfile
                 [ -f .env.selfhost ] || bun run selfhost:init
+                bun run selfhost:migrate-secrets
 
                 SELFHOST_AI_API_KEY=$(aws secretsmanager get-secret-value --secret-id "$SELFHOST_AI_API_KEY_SECRET_ARN" --query SecretString --output text)
                 [ -n "$SELFHOST_AI_API_KEY" ] && [ "$SELFHOST_AI_API_KEY" != None ]
@@ -800,6 +801,7 @@ Resources:
                 Type=oneshot
                 RemainAfterExit=yes
                 WorkingDirectory=/srv/camelai/repo
+                ExecStartPre=/usr/local/bin/bun run selfhost:migrate-secrets
                 ExecStartPre=/usr/local/bin/bun run selfhost:configure
                 ExecStartPre=/usr/local/sbin/camelai-selfhost-compose pull
                 ExecStart=/usr/local/sbin/camelai-selfhost-compose up --detach --remove-orphans --wait --wait-timeout 900

--- a/infra/selfhost/terraform/cloud-init.sh.tpl
+++ b/infra/selfhost/terraform/cloud-init.sh.tpl
@@ -137,6 +137,7 @@ bun install --frozen-lockfile
 if [ ! -f .env.selfhost ]; then
   bun run selfhost:init
 fi
+bun run selfhost:migrate-secrets
 
 SELFHOST_AI_API_KEY="$(aws secretsmanager get-secret-value \
   --secret-id "$${SELFHOST_AI_API_KEY_SECRET_ARN}" \
@@ -319,9 +320,11 @@ Requires=docker.service
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/srv/camelai/repo
+ExecStartPre=/usr/local/bin/bun run selfhost:migrate-secrets
 ExecStartPre=/usr/local/bin/bun run selfhost:configure
 ExecStartPre=/usr/local/sbin/camelai-selfhost-compose pull
 ExecStart=/usr/local/sbin/camelai-selfhost-compose up --detach --remove-orphans --wait --wait-timeout 900
+ExecReload=/usr/local/bin/bun run selfhost:migrate-secrets
 ExecReload=/usr/local/bin/bun run selfhost:configure
 ExecReload=/usr/local/sbin/camelai-selfhost-compose pull
 ExecReload=/usr/local/sbin/camelai-selfhost-compose up --detach --remove-orphans --wait --wait-timeout 900

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"check:pi-bedrock-build": "node scripts/check-pi-bedrock-build.mjs",
 		"start": "node scripts/wrangler-dev.mjs",
 		"selfhost:init": "node scripts/selfhost-init.mjs",
+		"selfhost:migrate-secrets": "node scripts/selfhost-migrate-secrets.mjs",
 		"selfhost:configure": "node scripts/selfhost-configure.mjs",
 		"selfhost:doctor": "node scripts/selfhost-doctor.mjs",
 		"selfhost:up": "node scripts/selfhost-up.mjs",

--- a/scripts/selfhost-doctor.mjs
+++ b/scripts/selfhost-doctor.mjs
@@ -56,8 +56,15 @@ await check("env file", async () => {
     "TOKEN_SIGNING_SECRET",
     "INTEGRATION_SECRET_KEY",
     "LOCAL_ARTIFACTS_SECRET",
+    "ADMIN_API_KEY",
   ]) {
-    if (!env[key]) fail(`missing ${key}`);
+    if (!env[key]) {
+      fail(
+        key === "ADMIN_API_KEY"
+          ? "missing ADMIN_API_KEY; run `bun run selfhost:migrate-secrets`"
+          : `missing ${key}`,
+      );
+    }
     if (env[key].includes("change-me")) fail(`${key} still uses a development default`);
   }
 });

--- a/scripts/selfhost-init.mjs
+++ b/scripts/selfhost-init.mjs
@@ -109,6 +109,7 @@ const values = {
   TOKEN_SIGNING_SECRET: secret(),
   INTEGRATION_SECRET_KEY: secret(),
   LOCAL_ARTIFACTS_SECRET: secret(),
+  ADMIN_API_KEY: secret(),
   // Deployed apps get a CONNECTIONS service binding that can list/invoke
   // workspace connections. Set to false for on-prem installs that must keep
   // connection-backed data out of published apps. Chat/agent connections stay

--- a/scripts/selfhost-migrate-secrets.mjs
+++ b/scripts/selfhost-migrate-secrets.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { envFile, readSelfhostEnv, repoRoot } from "./selfhost-common.mjs";
+import { ensureSelfhostAdminApiKey } from "./selfhost-secret-migrations.mjs";
+
+await readSelfhostEnv(true);
+const result = await ensureSelfhostAdminApiKey(envFile);
+console.log(
+  result.created
+    ? `Added ADMIN_API_KEY to ${path.relative(repoRoot, envFile)}.`
+    : `Self-host secrets are current in ${path.relative(repoRoot, envFile)}.`,
+);

--- a/scripts/selfhost-secret-migrations.mjs
+++ b/scripts/selfhost-secret-migrations.mjs
@@ -1,0 +1,76 @@
+import { randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const ADMIN_API_KEY_PATTERN = /^\s*ADMIN_API_KEY\s*=(.*)$/;
+
+function decodeEnvValue(value) {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export async function ensureSelfhostAdminApiKey(envPath) {
+  let text = await fs.readFile(envPath, "utf8");
+  const lines = text.split(/\r?\n/);
+  const definitions = lines.flatMap((line, index) => {
+    const match = line.match(ADMIN_API_KEY_PATTERN);
+    return match ? [{ index, value: decodeEnvValue(match[1]) }] : [];
+  });
+  const existingValue = definitions.at(-1)?.value ?? "";
+
+  if (existingValue) {
+    await fs.chmod(envPath, 0o600);
+    return { created: false };
+  }
+
+  const value = randomBytes(32).toString("base64url");
+  const line = `ADMIN_API_KEY=${value}`;
+  if (definitions.length > 0) {
+    const definitionIndexes = new Set(definitions.map((definition) => definition.index));
+    const firstIndex = definitions[0].index;
+    text = lines
+      .flatMap((existingLine, index) => {
+        if (index === firstIndex) return [line];
+        return definitionIndexes.has(index) ? [] : [existingLine];
+      })
+      .join("\n");
+  } else {
+    text = `${text.trimEnd()}\n${line}\n`;
+  }
+  await atomicWritePrivateFile(envPath, text);
+  return { created: true };
+}
+
+async function atomicWritePrivateFile(filePath, contents) {
+  const directory = path.dirname(filePath);
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`,
+  );
+  let handle;
+  try {
+    handle = await fs.open(temporaryPath, "wx", 0o600);
+    await handle.writeFile(contents, "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await fs.rename(temporaryPath, filePath);
+    const directoryHandle = await fs.open(directory, "r");
+    try {
+      await directoryHandle.sync();
+    } finally {
+      await directoryHandle.close();
+    }
+  } catch (error) {
+    await handle?.close().catch(() => {});
+    await fs.unlink(temporaryPath).catch(() => {});
+    throw error;
+  }
+}

--- a/scripts/selfhost-up.mjs
+++ b/scripts/selfhost-up.mjs
@@ -4,6 +4,7 @@ import {
 } from "./selfhost-agent-pack.mjs";
 import {
   composeArgs,
+  envFile,
   loadCaddyConfig,
   readSelfhostEnv,
   repoRoot,
@@ -12,7 +13,10 @@ import {
 } from "./selfhost-common.mjs";
 import { writeCaddyConfig } from "./selfhost-caddy-config.mjs";
 import { writePomeriumConfig } from "./selfhost-pomerium-config.mjs";
+import { ensureSelfhostAdminApiKey } from "./selfhost-secret-migrations.mjs";
 
+await readSelfhostEnv(true);
+await ensureSelfhostAdminApiKey(envFile);
 const env = await readSelfhostEnv(true);
 await writePomeriumConfig(env);
 await writeCaddyConfig(env);

--- a/scripts/selfhost-upgrade.mjs
+++ b/scripts/selfhost-upgrade.mjs
@@ -19,6 +19,7 @@ import {
   SELFHOST_IMAGE_ENV_BY_MANIFEST_KEY,
 } from "./selfhost-latest-release.mjs";
 import { writePomeriumConfig } from "./selfhost-pomerium-config.mjs";
+import { ensureSelfhostAdminApiKey } from "./selfhost-secret-migrations.mjs";
 
 const args = parseArgs(process.argv.slice(2));
 const skipBackup = args.flags.has("skip-backup");
@@ -52,6 +53,12 @@ if (latest && (releaseRef || manifestArg)) {
 if (Boolean(releaseRef) !== Boolean(manifestArg)) {
   usage("--release and --manifest must be provided together");
 }
+
+// Target releases may introduce operator secrets that older installations do
+// not have. Migrate before snapshots, environment reads, doctor, or Compose so
+// rollback captures the exact effective value and repeated upgrades never
+// rotate it.
+await ensureSelfhostAdminApiKey(envFile);
 
 if (resumeUpgradeArg) {
   await resumeReleaseUpgrade(path.resolve(repoRoot, resumeUpgradeArg));

--- a/scripts/selfhost-workerd-config.mjs
+++ b/scripts/selfhost-workerd-config.mjs
@@ -63,6 +63,7 @@ const SELFHOST_DEFAULT_VARS = {
   WORKSPACE_EMAIL_DOMAIN: 'localhost',
   TOKEN_SIGNING_SECRET: 'selfhost-token-signing-secret-change-me',
   INTEGRATION_SECRET_KEY: 'selfhost-integration-secret-32bytes',
+  ADMIN_API_KEY: '',
   // Deployed-app CONNECTIONS broker. Set to "false" for on-prem installs that
   // must not let published apps pull workspace connection data.
   CONNECTIONS_BINDING_ENABLED: 'true',

--- a/scripts/test-selfhost-release.mjs
+++ b/scripts/test-selfhost-release.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
   caddyComposeFile,
@@ -11,6 +12,7 @@ import {
   volumeNamesForEnv,
 } from "./selfhost-common.mjs";
 import { selfhostTlsMode } from "./selfhost-tls-mode.mjs";
+import { ensureSelfhostAdminApiKey } from "./selfhost-secret-migrations.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -48,6 +50,7 @@ const [
   backupScript,
   restoreScript,
   doctorScript,
+  initScript,
   cloudFormation,
   terraformMain,
   terraformCloudInit,
@@ -72,6 +75,7 @@ const [
   read("scripts/selfhost-backup.mjs"),
   read("scripts/selfhost-restore.mjs"),
   read("scripts/selfhost-doctor.mjs"),
+  read("scripts/selfhost-init.mjs"),
   read("infra/selfhost/cloudformation/aws-single-node.yaml"),
   read("infra/selfhost/terraform/main.tf"),
   read("infra/selfhost/terraform/cloud-init.sh.tpl"),
@@ -80,6 +84,7 @@ const [
 includesAll(
   compose,
   [
+    "ADMIN_API_KEY: ${ADMIN_API_KEY:?Run bun run selfhost:migrate-secrets}",
     "SELFHOST_APP_IMAGE",
     "SELFHOST_LOCAL_ARTIFACTS_IMAGE",
     "SELFHOST_PROJECT_BUILD_IMAGE",
@@ -265,7 +270,7 @@ includesAll(
 );
 includesAll(
   upScript,
-  ["loadCaddyConfig", "{ build: sourceMode }"],
+  ["ensureSelfhostAdminApiKey(envFile)", "loadCaddyConfig", "{ build: sourceMode }"],
   "self-host startup Caddy configuration reload",
 );
 for (const [name, env, expectedFiles] of [
@@ -427,6 +432,7 @@ includesAll(
 includesAll(
   upgradeScript,
   [
+    "ensureSelfhostAdminApiKey(envFile)",
     "downloadLatestReleaseManifest",
     "--latest",
     "--refresh",
@@ -446,6 +452,53 @@ includesAll(
   ],
   "self-host release upgrade helper",
 );
+
+const secretMigrationDir = await fs.mkdtemp(path.join(os.tmpdir(), "camelai-secret-migration-"));
+const legacyEnvPath = path.join(secretMigrationDir, ".env.selfhost");
+const legacyEnv = [
+  "TOKEN_SIGNING_SECRET=existing-token-secret",
+  "INTEGRATION_SECRET_KEY=existing-integration-secret",
+  "LOCAL_ARTIFACTS_SECRET=existing-artifact-secret",
+  "SELFHOST_DEPLOYMENT_MODE=release",
+  "",
+].join("\n");
+await fs.writeFile(legacyEnvPath, legacyEnv, { mode: 0o644 });
+const firstSecretMigration = await ensureSelfhostAdminApiKey(legacyEnvPath);
+const firstMigratedEnv = await fs.readFile(legacyEnvPath, "utf8");
+const generatedAdminKey = firstMigratedEnv.match(/^ADMIN_API_KEY=(.+)$/m)?.[1] ?? "";
+assert(firstSecretMigration.created, "legacy self-host env must receive ADMIN_API_KEY");
+assert(/^[A-Za-z0-9_-]{43}$/.test(generatedAdminKey), "migrated ADMIN_API_KEY must be a 32-byte base64url secret");
+assert(firstMigratedEnv.includes("TOKEN_SIGNING_SECRET=existing-token-secret"), "secret migration must preserve token signing secret");
+assert(firstMigratedEnv.includes("INTEGRATION_SECRET_KEY=existing-integration-secret"), "secret migration must preserve integration secret");
+assert(firstMigratedEnv.includes("LOCAL_ARTIFACTS_SECRET=existing-artifact-secret"), "secret migration must preserve artifact secret");
+assert((await fs.stat(legacyEnvPath)).mode % 0o1000 === 0o600, "migrated env file must be mode 0600");
+const secondSecretMigration = await ensureSelfhostAdminApiKey(legacyEnvPath);
+const secondMigratedEnv = await fs.readFile(legacyEnvPath, "utf8");
+assert(!secondSecretMigration.created, "repeat secret migration must be idempotent");
+assert(secondMigratedEnv === firstMigratedEnv, "repeat secret migration must not rotate or rewrite ADMIN_API_KEY");
+
+const whitespaceEnvPath = path.join(secretMigrationDir, ".env.selfhost-whitespace");
+const whitespaceAdminKey = "preserve-this-existing-admin-key";
+const whitespaceEnv = `TOKEN_SIGNING_SECRET=existing\n  ADMIN_API_KEY = '${whitespaceAdminKey}'\n`;
+await fs.writeFile(whitespaceEnvPath, whitespaceEnv, { mode: 0o644 });
+const whitespaceMigration = await ensureSelfhostAdminApiKey(whitespaceEnvPath);
+assert(!whitespaceMigration.created, "migration must recognize whitespace and quoted dotenv definitions");
+assert(
+  (await fs.readFile(whitespaceEnvPath, "utf8")) === whitespaceEnv,
+  "migration must preserve an existing effective ADMIN_API_KEY without rewriting it",
+);
+assert((await fs.stat(whitespaceEnvPath)).mode % 0o1000 === 0o600, "preserved env file must be mode 0600");
+
+const duplicateEnvPath = path.join(secretMigrationDir, ".env.selfhost-duplicate");
+await fs.writeFile(duplicateEnvPath, "ADMIN_API_KEY=stale\n ADMIN_API_KEY = \"\"\n", { mode: 0o644 });
+const duplicateMigration = await ensureSelfhostAdminApiKey(duplicateEnvPath);
+const duplicateMigratedEnv = await fs.readFile(duplicateEnvPath, "utf8");
+assert(duplicateMigration.created, "an empty final dotenv definition must be migrated");
+assert(
+  duplicateMigratedEnv.match(/^ADMIN_API_KEY=/gm)?.length === 1,
+  "migration must normalize duplicate ADMIN_API_KEY definitions",
+);
+await fs.rm(secretMigrationDir, { recursive: true, force: true });
 includesAll(
   latestReleaseScript,
   [
@@ -464,6 +517,11 @@ includesAll(
     "@sha256:",
   ],
   "latest self-host release resolver",
+);
+assert(
+  packageJson.scripts?.["selfhost:migrate-secrets"] ===
+    "node scripts/selfhost-migrate-secrets.mjs",
+  "selfhost:migrate-secrets must expose the idempotent existing-install migration",
 );
 assert(
   packageJson.scripts?.["selfhost:upgrade"] ===
@@ -511,6 +569,7 @@ includesAll(
 includesAll(
   doctorScript,
   [
+    '"ADMIN_API_KEY"',
     'await check("network binding"',
     "SELFHOST_BIND_ADDRESS must remain loopback",
     'await check("TLS front door"',
@@ -522,11 +581,28 @@ includesAll(
   ],
   "self-host network and TLS validation",
 );
+includesAll(
+  initScript,
+  ["TOKEN_SIGNING_SECRET: secret()", "INTEGRATION_SECRET_KEY: secret()", "ADMIN_API_KEY: secret()"],
+  "self-host secret initialization",
+);
 
 for (const [name, template] of [
   ["CloudFormation", cloudFormation],
   ["Terraform cloud-init", terraformCloudInit],
 ]) {
+  assert(
+    template.includes("bun run selfhost:init"),
+    `${name} must generate the self-host admin API secret through selfhost:init`,
+  );
+  assert(
+    template.includes("bun run selfhost:migrate-secrets"),
+    `${name} must migrate secrets in persistent environments`,
+  );
+  assert(
+    template.includes("ExecStartPre=/usr/local/bin/bun run selfhost:migrate-secrets"),
+    `${name} systemd startup must migrate secrets before Compose validation`,
+  );
   assert(
     !template.includes("project-runtime") &&
       !template.includes("PROJECT_RUNTIME_"),
@@ -576,6 +652,7 @@ includesAll(
     "docker-compose.selfhost.caddy.yml",
     "docker-compose.selfhost.pomerium.yml",
     "docker-compose.selfhost.pomerium-loopback.yml",
+    "ExecReload=/usr/local/bin/bun run selfhost:migrate-secrets",
   ],
   "Terraform bundled Pomerium bootstrap",
 );

--- a/scripts/test-selfhost-workerd-config.mjs
+++ b/scripts/test-selfhost-workerd-config.mjs
@@ -19,6 +19,15 @@ function includesAll(actual, expected, label) {
 }
 
 async function main() {
+  const generatorSource = await fs.readFile(
+    path.join(repoRoot, 'scripts/selfhost-workerd-config.mjs'),
+    'utf8',
+  );
+  assert(
+    generatorSource.includes("ADMIN_API_KEY: ''") &&
+      !generatorSource.includes('selfhost-admin-api-key-change-me'),
+    'workerd config must fail closed when ADMIN_API_KEY is absent',
+  );
   const wranglerPath = path.join(repoRoot, 'build/server/wrangler.json');
   await fs.access(wranglerPath).catch(() => {
     throw new Error('Missing build/server/wrangler.json. Run `bun run build:cf` first.');
@@ -66,6 +75,7 @@ description: Follow ACME runbooks. Use when shipping internal tools.
       LOCAL_AUTH_USER_NAME: 'Self-host Operator',
       TURNSTILE_SITE_KEY: 'process-turnstile-site',
       TURNSTILE_SECRET_KEY: 'process-turnstile-secret',
+      ADMIN_API_KEY: 'process-admin-api-key-test-only',
     },
     encoding: 'utf8',
   });
@@ -92,6 +102,7 @@ description: Follow ACME runbooks. Use when shipping internal tools.
     'LOCAL_AUTH_USER_NAME',
     'TURNSTILE_SITE_KEY',
     'TURNSTILE_SECRET_KEY',
+    'ADMIN_API_KEY',
   ], 'vars');
   assert(!bindings.vars.includes('PROJECT_REPO_PROVIDER'), 'PROJECT_REPO_PROVIDER must not be a self-host var');
   assert(!bindings.vars.includes('R2_PARENT_ACCESS_KEY_ID'), 'Cloudflare dev R2 credentials must not leak into self-host vars');
@@ -158,6 +169,7 @@ description: Follow ACME runbooks. Use when shipping internal tools.
     ['LOCAL_AUTH_USER_NAME', 'Self-host Operator'],
     ['TURNSTILE_SITE_KEY', 'process-turnstile-site'],
     ['TURNSTILE_SECRET_KEY', 'process-turnstile-secret'],
+    ['ADMIN_API_KEY', 'process-admin-api-key-test-only'],
   ]) {
     assert(
       config.includes(`(name = "${name}", text = "${value}")`),

--- a/src/lib/usage-pricing.ts
+++ b/src/lib/usage-pricing.ts
@@ -363,6 +363,7 @@ export function normalizePricingModel(model: string): string {
       "camelai-openrouter/",
       "openrouter/",
       "openai/",
+      "openai.",
     ]) {
       if (normalized.startsWith(prefix)) {
         normalized = normalized.slice(prefix.length);
@@ -373,6 +374,15 @@ export function normalizePricingModel(model: string): string {
 }
 
 export function lookupPricing(model: string): ModelPricing {
+  return lookupPricingOrNull(model) ?? modelPricingTable[SONNET_FALLBACK_MODEL];
+}
+
+/**
+ * Resolve pricing only when the model is explicitly known. Unlike
+ * `lookupPricing`, this helper never applies the compatibility Sonnet fallback
+ * and is therefore safe to use as an accounting authority for hard limits.
+ */
+export function lookupPricingOrNull(model: string): ModelPricing | null {
   if (modelPricingTable[model]) return modelPricingTable[model];
   const normalized = normalizePricingModel(model);
   if (modelPricingTable[normalized]) return modelPricingTable[normalized];
@@ -441,7 +451,10 @@ export function lookupPricing(model: string): ModelPricing {
   if (normalized.includes("deepseek-v4-flash")) {
     return modelPricingTable["deepseek/deepseek-v4-flash"];
   }
-  if (normalized.includes("claude-haiku-4.5")) {
+  if (
+    normalized.includes("claude-haiku-4.5") ||
+    normalized.includes("claude-haiku-4-5")
+  ) {
     return modelPricingTable["anthropic/claude-haiku-4.5"];
   }
   if (normalized.includes("gemini-3.5-flash")) {
@@ -453,7 +466,7 @@ export function lookupPricing(model: string): ModelPricing {
   if (normalized.includes("gemini-3-flash-preview")) {
     return modelPricingTable["google/gemini-3-flash-preview"];
   }
-  return modelPricingTable[SONNET_FALLBACK_MODEL];
+  return null;
 }
 
 export function calculateUsageCostUsd(usage: UsageTokens): number {
@@ -477,23 +490,19 @@ export function calculateUsageCostUsd(usage: UsageTokens): number {
 }
 
 export function calculateEffectiveUsageCostUsd(usage: UsageTokens): number {
-  let reportedCost = 0;
   if (
     usage.reportedCostUsd !== null &&
     usage.reportedCostUsd !== undefined &&
     usage.reportedCostUsd > 0
   ) {
-    reportedCost += usage.reportedCostUsd;
+    return usage.reportedCostUsd;
   }
   if (
     usage.upstreamInferenceCostUsd !== null &&
     usage.upstreamInferenceCostUsd !== undefined &&
     usage.upstreamInferenceCostUsd > 0
   ) {
-    reportedCost += usage.upstreamInferenceCostUsd;
-  }
-  if (reportedCost > 0) {
-    return reportedCost;
+    return usage.upstreamInferenceCostUsd;
   }
   return calculateUsageCostUsd(usage);
 }

--- a/tests/admin-usage-routes.test.ts
+++ b/tests/admin-usage-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   OrgUsageLogSchema,
   OrgUsageLogSumSchema,
+  SetUserLlmLimitsBodySchema,
 } from '../workers/main/src/routes/admin/schemas.js';
 import { z } from 'zod';
 
@@ -26,6 +27,15 @@ const UsageLogSumQuerySchema = z.object({
 // ---------------------------------------------------------------------------
 
 describe('usage log query validation', () => {
+  it('rejects duplicate rolling limit windows', () => {
+    expect(SetUserLlmLimitsBodySchema.safeParse({
+      limits: [
+        { window_hours: 24, limit_usd: 1 },
+        { window_hours: 24, limit_usd: 2 },
+      ],
+    }).success).toBe(false);
+  });
+
   it('accepts limit up to 1000', () => {
     const result = UsageLogQuerySchema.safeParse({ limit: '1000' });
     expect(result.success).toBe(true);
@@ -160,6 +170,10 @@ describe('OrgUsageLogSchema', () => {
           cache_creation_input_tokens: 100,
           cache_read_input_tokens: 50,
           cost_usd: 0.015,
+          metered_cost_usd: 0.015,
+          cost_source: 'builtin_pricing',
+          usage_kind: 'llm',
+          usage_surface: 'agent',
           duration_ms: 3200,
           created_at_ms: 1710000000000,
         },

--- a/tests/usage-pricing.test.ts
+++ b/tests/usage-pricing.test.ts
@@ -3,10 +3,11 @@ import {
   calculateEffectiveUsageCostUsd,
   calculateUsageCostUsd,
   lookupPricing,
+  lookupPricingOrNull,
 } from "@/lib/usage-pricing";
 
 describe("calculateEffectiveUsageCostUsd", () => {
-  it("adds reported and upstream inference costs", () => {
+  it("uses total reported cost instead of adding its upstream component", () => {
     expect(
       calculateEffectiveUsageCostUsd({
         model: "anthropic/claude-4.6-sonnet-20260217",
@@ -17,7 +18,7 @@ describe("calculateEffectiveUsageCostUsd", () => {
         reportedCostUsd: 0.0012,
         upstreamInferenceCostUsd: 0.0048,
       }),
-    ).toBeCloseTo(0.006);
+    ).toBeCloseTo(0.0012);
   });
 
   it("falls back to table pricing when reported cost is zero", () => {
@@ -35,6 +36,16 @@ describe("calculateEffectiveUsageCostUsd", () => {
 });
 
 describe("calculateUsageCostUsd", () => {
+  it("keeps strict lookup separate from the legacy Sonnet fallback", () => {
+    expect(lookupPricingOrNull("camel/anthropic/claude-sonnet-5:nitro")).toEqual(
+      lookupPricing("claude-sonnet-5"),
+    );
+    expect(lookupPricingOrNull("operator/private-model-v9")).toBeNull();
+    expect(lookupPricing("operator/private-model-v9")).toBe(
+      lookupPricing("claude-sonnet-5"),
+    );
+  });
+
   it("prices GPT-5.6 aliases and long prompts", () => {
     expect(lookupPricing("openai/gpt-5.6-terra")).toMatchObject({
       inputPerToken: 0.000002,
@@ -49,6 +60,12 @@ describe("calculateUsageCostUsd", () => {
       lookupPricing("gpt-5.6-luna"),
     );
     expect(lookupPricing("gpt-5.6")).toBe(lookupPricing("gpt-5.6-sol"));
+    expect(lookupPricingOrNull("openai.gpt-5.6-sol")).toBe(
+      lookupPricing("gpt-5.6-sol"),
+    );
+    expect(lookupPricingOrNull("openai.gpt-5.6-terra")).toBe(
+      lookupPricing("gpt-5.6-terra"),
+    );
     expect(
       calculateUsageCostUsd({
         model: "gpt-5.6-sol",

--- a/workers/main/src/ai-virtual-binding.ts
+++ b/workers/main/src/ai-virtual-binding.ts
@@ -9,8 +9,14 @@ import {
   DEFAULT_CLOUDFLARE_AI_GATEWAY_ORIGIN,
   resolveCloudflareGatewayOrigin,
 } from "../../../src/lib/cloudflare-ai-gateway";
-import { chatCompletionToPiCall, runBedrockViaPi } from "./bedrock-pi-adapter";
+import {
+  BedrockPiCompletionError,
+  chatCompletionToPiCall,
+  runBedrockViaPi,
+} from "./bedrock-pi-adapter";
 import { getHostedVllmPriority } from "./hosted-vllm-priority";
+import { assertUserLlmUsageAccess } from "./user-llm-usage-policy";
+import { recordObservabilityEvent } from "./observability";
 
 export interface AIVirtualBindingEnv {
   ORG: DurableObjectNamespace<OrgDO>;
@@ -23,6 +29,7 @@ export interface AIVirtualBindingEnv {
   AI_GATEWAY_AUTH_TOKEN?: string;
   TEST_LLM_REPLAY_URL?: string;
   INTEGRATION_SECRET_KEY?: string;
+  OBSERVABILITY_EVENTS?: AnalyticsEngineDataset;
 }
 
 export interface AIVirtualBindingProps {
@@ -35,6 +42,7 @@ export interface VirtualAiRunScope {
   env: AIVirtualBindingEnv;
   props: AIVirtualBindingProps;
   waitUntil: (promise: Promise<unknown>) => void;
+  runBedrock?: typeof runBedrockViaPi;
 }
 
 export type TierName = "cheap" | "fast" | "auto" | "smart";
@@ -324,15 +332,58 @@ export async function executeVirtualAiRun(
         isCreditFreeHostedModel(requestedModel),
       );
   const billingSource: "byok" | "hosted" = usesByok ? "byok" : "hosted";
+  const usageProvider = routing.usageProvider ?? routing.provider;
+  const requestId = crypto.randomUUID();
+  if (scope.props.userId) {
+    const orgStub = scope.env.ORG.get(scope.env.ORG.idFromName(scope.props.orgId));
+    await assertUserLlmUsageAccess(orgStub, {
+      env: scope.env,
+      orgId: scope.props.orgId,
+      workspaceId: scope.props.workspaceId,
+      threadId: "virtual-ai",
+      userId: scope.props.userId,
+      provider: usageProvider,
+      model: routing.model,
+    });
+  } else if (requestId.charCodeAt(0) % 16 === 0) {
+    recordObservabilityEvent(scope.env, {
+      event: "virtual_ai_usage_unattributed",
+      severity: "warn",
+      component: "ai_virtual_binding",
+      operation: "execute_virtual_ai_run",
+      status: "allowed_unattributed",
+      orgId: scope.props.orgId,
+      workspaceId: scope.props.workspaceId,
+      provider: usageProvider,
+      model: routing.model,
+      sampleIndex: scope.props.workspaceId,
+    });
+  }
 
   const settings = routing.provider === "bedrock"
     ? undefined
     : requireGatewaySettings(scope.env);
 
   const startedAt = Date.now();
-  const result =
-    routing.provider === "bedrock"
-      ? await runBedrockViaPi({
+  const fallbackModel = routing.model;
+  const record = (usage: ExtractedUsage) =>
+    recordVirtualAiUsage(
+      scope.env,
+      scope.props,
+      usage,
+      usageProvider,
+      routing.model,
+      Date.now() - startedAt,
+      access.creditChargeable,
+      billingSource,
+      requestId,
+    ).catch((error) => {
+      console.error("[AIVirtualBinding] failed to record usage", error);
+    });
+  let result: unknown;
+  try {
+    result = routing.provider === "bedrock"
+      ? await (scope.runBedrock ?? runBedrockViaPi)({
           call: chatCompletionToPiCall(sanitizedInput),
           modelId: routing.model,
           // Bedrock BYOK is the only path here — if we got bedrock routing
@@ -353,26 +404,21 @@ export async function executeVirtualAiRun(
             ? access.vllmPriority
             : undefined,
         );
-
-  const fallbackModel = routing.model;
-  const record = (usage: ExtractedUsage) =>
-    recordVirtualAiUsage(
-      scope.env,
-      scope.props,
-      usage,
-      routing.usageProvider ?? routing.provider,
-      Date.now() - startedAt,
-      access.creditChargeable,
-      billingSource,
-    ).catch((error) => {
-      console.error("[AIVirtualBinding] failed to record usage", error);
-    });
+  } catch (error) {
+    if (error instanceof BedrockPiCompletionError) {
+      const usage = extractPiAssistantUsage(error.completion, fallbackModel);
+      if (usage) await record(usage);
+    }
+    throw error;
+  }
   if (result instanceof ReadableStream) {
     const [clientStream, usageStream] = result.tee();
     scope.waitUntil(
-      extractStreamingUsage(usageStream, fallbackModel).then((usage) =>
-        usage ? record(usage) : undefined,
-      ),
+      extractStreamingUsage(usageStream, fallbackModel)
+        .then((usage) => usage ? record(usage) : undefined)
+        .catch((error) => {
+          console.error("[AIVirtualBinding] failed to extract streaming usage", error);
+        }),
     );
     return clientStream;
   }
@@ -390,6 +436,7 @@ async function runLegacyAutoImage(
 ): Promise<unknown> {
   const access = await checkHostedModelAccess(scope.env, scope.props);
   const startedAt = Date.now();
+  const requestId = crypto.randomUUID();
   const result = await runViaGatewayHTTP(
     settings,
     scope.props,
@@ -405,18 +452,24 @@ async function runLegacyAutoImage(
       scope.props,
       usage,
       "openrouter",
+      fallbackModel,
       Date.now() - startedAt,
       access.creditChargeable,
       "hosted",
+      requestId,
+      "image",
+      "auxiliary",
     ).catch((error) => {
       console.error("[AIVirtualBinding] failed to record usage", error);
     });
   if (result instanceof ReadableStream) {
     const [clientStream, usageStream] = result.tee();
     scope.waitUntil(
-      extractStreamingUsage(usageStream, fallbackModel).then((usage) =>
-        usage ? record(usage) : undefined,
-      ),
+      extractStreamingUsage(usageStream, fallbackModel)
+        .then((usage) => usage ? record(usage) : undefined)
+        .catch((error) => {
+          console.error("[AIVirtualBinding] failed to extract streaming usage", error);
+        }),
     );
     return clientStream;
   }
@@ -478,19 +531,25 @@ async function recordVirtualAiUsage(
   props: AIVirtualBindingProps,
   usage: ExtractedUsage,
   provider: string,
+  requestedModel: string,
   durationMs: number,
   creditChargeable: boolean,
   billingSource: "byok" | "hosted",
+  sourceId: string,
+  usageKind: "llm" | "image" = "llm",
+  usageSurface: "virtual_ai" | "auxiliary" = "virtual_ai",
 ): Promise<void> {
   const orgStub = env.ORG.get(env.ORG.idFromName(props.orgId));
   await orgStub.recordUsage({
     workspace_id: props.workspaceId,
     user_id: props.userId ?? "",
     thread_id: "virtual-ai",
-    model: usage.model,
+    model: requestedModel,
     provider,
     billing_source: billingSource,
     credit_chargeable: creditChargeable,
+    usage_kind: usageKind,
+    usage_surface: usageSurface,
     input_tokens: usage.inputTokens,
     output_tokens: usage.outputTokens,
     cache_creation_input_tokens: usage.cacheCreationInputTokens,
@@ -499,6 +558,8 @@ async function recordVirtualAiUsage(
     upstream_inference_cost_usd: usage.upstreamInferenceCostUsd,
     duration_ms: durationMs,
     created_at_ms: Date.now(),
+    source: "virtual_ai",
+    source_id: sourceId,
   });
 }
 
@@ -738,6 +799,39 @@ interface ExtractedUsage {
   upstreamInferenceCostUsd: number | null;
 }
 
+function extractPiAssistantUsage(
+  message: BedrockPiCompletionError["completion"],
+  fallbackModel: string,
+): ExtractedUsage | null {
+  const inputTokens = Math.max(0, Math.floor(Number(message.usage.input ?? 0)));
+  const outputTokens = Math.max(0, Math.floor(Number(message.usage.output ?? 0)));
+  const cacheCreationInputTokens = Math.max(
+    0,
+    Math.floor(Number(message.usage.cacheWrite ?? 0)),
+  );
+  const cacheReadInputTokens = Math.max(
+    0,
+    Math.floor(Number(message.usage.cacheRead ?? 0)),
+  );
+  if (
+    inputTokens === 0 &&
+    outputTokens === 0 &&
+    cacheCreationInputTokens === 0 &&
+    cacheReadInputTokens === 0
+  ) {
+    return null;
+  }
+  return {
+    model: message.responseModel ?? message.model ?? fallbackModel,
+    inputTokens,
+    outputTokens,
+    cacheCreationInputTokens,
+    cacheReadInputTokens,
+    reportedCostUsd: null,
+    upstreamInferenceCostUsd: null,
+  };
+}
+
 function extractJsonUsage(payload: unknown, fallbackModel: string): ExtractedUsage | null {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return null;
@@ -778,6 +872,11 @@ async function extractStreamingUsage(
         if (usage) lastUsage = usage;
       }
     }
+  } catch (error) {
+    // Preserve usage that was already observed before a provider truncated the
+    // stream. Without this, the billable terminal frame is silently discarded.
+    if (!lastUsage) throw error;
+    console.warn("[AIVirtualBinding] usage stream ended after terminal usage", error);
   } finally {
     reader.releaseLock();
   }
@@ -794,7 +893,7 @@ function extractUsageFromObject(
   const costDetails = asRecord(usageObj.cost_details);
   const inputDetails = asRecord(usageObj.input_tokens_details);
   const promptDetails = asRecord(usageObj.prompt_tokens_details);
-  const inputTokens = usageNumber(
+  const promptTokens = usageNumber(
     usageObj.input_tokens ?? usageObj.prompt_tokens,
   );
   const outputTokens = usageNumber(
@@ -807,6 +906,13 @@ function extractUsageFromObject(
     inputDetails?.cache_write_tokens ??
       inputDetails?.cache_creation_input_tokens ??
       promptDetails?.cache_write_tokens,
+  );
+  // OpenAI-compatible prompt/input token totals include cache-read and
+  // cache-write detail counts. Store the mutually exclusive token classes
+  // used by camelAI pricing instead of charging the cached subset twice.
+  const inputTokens = Math.max(
+    0,
+    promptTokens - cacheReadInputTokens - cacheCreationInputTokens,
   );
   const reportedCostUsd = usageCostNumber(usageObj.cost);
   const upstreamInferenceCostUsd = usageCostNumber(
@@ -856,11 +962,17 @@ function toGatewayPayload(
   input: unknown,
   model: string,
 ): Record<string, unknown> {
-  if (input && typeof input === "object" && !Array.isArray(input)) {
-    const asObject = input as Record<string, unknown>;
-    return { ...asObject, model };
+  const payload = input && typeof input === "object" && !Array.isArray(input)
+    ? { ...(input as Record<string, unknown>), model }
+    : { model };
+  if (payload.stream === true) {
+    const streamOptions = asRecord(payload.stream_options) ?? {};
+    return {
+      ...payload,
+      stream_options: { ...streamOptions, include_usage: true },
+    };
   }
-  return { model };
+  return payload;
 }
 
 function shouldPassthroughStream(

--- a/workers/main/src/app-index-db.ts
+++ b/workers/main/src/app-index-db.ts
@@ -1875,6 +1875,19 @@ export class AppIndexDatabase {
     return rows.map((u) => ({ ...u, avatar: { color: u.avatar_color || '#666', content: u.avatar_content || 'U' }, is_superuser: u.is_superuser === 1, is_orphaned: u.is_orphaned === 1, signup_ip: u.signup_ip ?? null }));
   }
 
+  async getUsersByIds(userIds: string[]): Promise<AdminUserSummaryRow[]> {
+    const normalizedUserIds = Array.from(
+      new Set(userIds.map((userId) => userId.trim()).filter((userId) => userId.length > 0)),
+    );
+    if (normalizedUserIds.length === 0) return [];
+    const rows = await this.all<any>(`
+      SELECT u.*
+      FROM users u
+      WHERE u.id IN (SELECT value FROM json_each(?))
+    `, JSON.stringify(normalizedUserIds));
+    return rows.map((u) => ({ ...u, avatar: { color: u.avatar_color || '#666', content: u.avatar_content || 'U' }, is_superuser: u.is_superuser === 1, is_orphaned: u.is_orphaned === 1, signup_ip: u.signup_ip ?? null }));
+  }
+
   async getThreadsByOrgIds(orgIds: string[]): Promise<AdminThreadListRow[]> {
     const normalizedOrgIds = Array.from(
       new Set(orgIds.map((orgId) => orgId.trim()).filter((orgId) => orgId.length > 0)),

--- a/workers/main/src/bedrock-pi-adapter.ts
+++ b/workers/main/src/bedrock-pi-adapter.ts
@@ -1,5 +1,6 @@
 /** OpenAI chat/completions compatibility surface for Bedrock Mantle via pi-ai. */
 import { streamSimple } from "@earendil-works/pi-ai/api/anthropic-messages";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 
 import type { PiBedrockCall } from "./bedrock-pi-contracts.js";
 import { buildBedrockPiModel } from "./bedrock-pi-model.js";
@@ -7,6 +8,16 @@ import {
   piEventStreamToSSE,
   piMessageToChatCompletion,
 } from "./bedrock-pi-output.js";
+
+export class BedrockPiCompletionError extends Error {
+  constructor(
+    message: string,
+    readonly completion: AssistantMessage,
+  ) {
+    super(message);
+    this.name = "BedrockPiCompletionError";
+  }
+}
 
 export type { PiBedrockCall } from "./bedrock-pi-contracts.js";
 export { chatCompletionToPiCall } from "./bedrock-pi-input.js";
@@ -33,5 +44,15 @@ export async function runBedrockViaPi(args: {
     },
   );
   if (args.call.stream) return piEventStreamToSSE(eventStream, args.modelId);
-  return piMessageToChatCompletion(await eventStream.result(), args.modelId);
+  const completion = await eventStream.result();
+  if (completion.stopReason === "error" || completion.stopReason === "aborted") {
+    throw new BedrockPiCompletionError(
+      completion.errorMessage ||
+        (completion.stopReason === "error"
+          ? "Bedrock request failed"
+          : "Bedrock request was aborted"),
+      completion,
+    );
+  }
+  return piMessageToChatCompletion(completion, args.modelId);
 }

--- a/workers/main/src/bedrock-pi-output.ts
+++ b/workers/main/src/bedrock-pi-output.ts
@@ -78,6 +78,21 @@ export function piEventStreamToSSE(
     );
   };
 
+  const emitUsageOnly = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    message: AssistantMessage,
+  ) => {
+    const chunk = {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model: message.responseModel ?? lastResponseModel ?? modelId,
+      choices: [],
+      usage: piUsageToOpenAi(message.usage),
+    };
+    controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+  };
+
   return new ReadableStream<Uint8Array>({
     async start(controller) {
       try {
@@ -138,6 +153,14 @@ export function piEventStreamToSSE(
               break;
             }
             case "error":
+              if (
+                (event.error.usage.input ?? 0) > 0 ||
+                (event.error.usage.output ?? 0) > 0 ||
+                (event.error.usage.cacheRead ?? 0) > 0 ||
+                (event.error.usage.cacheWrite ?? 0) > 0
+              ) {
+                emitUsageOnly(controller, event.error);
+              }
               throw new Error(
                 event.error.errorMessage || "Bedrock stream errored",
               );
@@ -176,6 +199,9 @@ function piStopReasonToFinishReason(
 function piUsageToOpenAi(
   usage: AssistantMessage["usage"],
 ): Record<string, unknown> {
+  const promptTokens =
+    (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+  const completionTokens = usage.output ?? 0;
   const details: Record<string, number> = {};
   if (usage.cacheRead) details.cached_tokens = usage.cacheRead;
   if (usage.cacheWrite) {
@@ -183,10 +209,12 @@ function piUsageToOpenAi(
     details.cache_creation_input_tokens = usage.cacheWrite;
   }
   return {
-    prompt_tokens: usage.input ?? 0,
-    completion_tokens: usage.output ?? 0,
-    total_tokens:
-      usage.totalTokens ?? (usage.input ?? 0) + (usage.output ?? 0),
+    // OpenAI-compatible token details are subsets of prompt_tokens. Pi keeps
+    // uncached input/cache-read/cache-write as exclusive counters, so rebuild
+    // the inclusive wire total here for round-trip-compatible accounting.
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens,
     ...(Object.keys(details).length > 0
       ? { prompt_tokens_details: details }
       : {}),

--- a/workers/main/src/chat-thread-do.ts
+++ b/workers/main/src/chat-thread-do.ts
@@ -278,6 +278,10 @@ import {
   primaryPiThinkingLevel,
 } from "./chat-thread/pi-model-config";
 import { FREE_VLLM_PRIORITY } from "./hosted-vllm-priority";
+import {
+  assertUserLlmUsageAccess,
+  UserLlmUsageLimitError,
+} from "./user-llm-usage-policy";
 
 // Provider-level transient-retry ladder for Pi model streams.
 import {
@@ -1097,6 +1101,9 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
   private cachedChatMemoryStatsAt = 0;
   private titleGenerationInFlight: boolean = false;
   private activeTurnUserId: string | null = null;
+  private llmUsageSettlementChain: Promise<void> = Promise.resolve();
+  private pendingLlmUsageSettlements: Array<() => Promise<void>> = [];
+  private pendingPiPostTurnCompactionUserId: string | null = null;
   private workspaceStatusStubs = new Map<string, DurableObjectStub<WorkspaceDO>>();
   // Trailing-debounce state for coalescing WorkspaceDO.recordThreadStreaming
   // running-activity updates. This is a per-thread DO, so a single pending entry
@@ -1157,6 +1164,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
   private piCurrentBillingSource: PiBillingSource = "hosted";
   private piCurrentCreditChargeable: boolean = false;
   private piCurrentUsageProvider: string | null = null;
+  private piCurrentUsageModel: string | null = null;
   private piTurnLastProgressAtMs: number = 0;
   // In-process transient-retry state (see PI_TURN_TRANSIENT_RETRY_ATTEMPTS).
   // agent_end defers terminal surfacing of a retryable provider error by
@@ -5961,16 +5969,16 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     // single canonical timestamp shared by the message we persist below and the
     // one sendRunnerCommand prompts Pi with, so both carry the same
     // piCoreMessageKey and the turn-end commit dedups instead of double-storing.
+    const joinsExistingTurn = this.isThreadStreaming();
     const startsNewTurn =
-      options.persistUserMessageImmediately === true &&
-      (this.piSession
-        ? !this.piSession.state.isStreaming
-        : this.readPiActiveTurn() === null);
+      options.persistUserMessageImmediately === true && !joinsExistingTurn;
     const turnTimestamp = Date.now();
 
     let sent = false;
     try {
-      this.setActiveTurnUserId(context.userId);
+      // Steering is authored by the new sender but remains part of the
+      // initiator's provider turn for billing attribution.
+      if (!joinsExistingTurn) this.setActiveTurnUserId(context.userId);
       // Turn-start bookkeeping runs from agent_start once the run begins; the
       // spinner turns on via the derived sync after the fiber row is created (below).
       this.publishRunningUserMessageActivity(rawContent);
@@ -6001,7 +6009,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       });
     } catch (error) {
       this.finishTurn();
-      this.setActiveTurnUserId(null);
+      if (!joinsExistingTurn) this.setActiveTurnUserId(null);
       throw error;
     }
     if (!sent) {
@@ -6011,7 +6019,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
         clear: true,
       });
       this.finishTurn();
-      this.setActiveTurnUserId(null);
+      if (!joinsExistingTurn) this.setActiveTurnUserId(null);
       return { status: "error", error: "Failed to send message" };
     }
 
@@ -7457,10 +7465,13 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
             current.apiKey,
             completeSimple,
             signal,
+            { context, modelConfig: current, userId: this.getActiveTurnUserId() },
           );
         }),
       getApiKey: async () => {
+        const requestUserId = this.getActiveTurnUserId();
         const current = await resolveCurrentModel();
+        await this.assertPiUserLlmUsageAccess(context, current, requestUserId);
         if (this.piSession) {
           this.piSession.state.model = capPiMainRequestOutput(current.model);
           this.refreshPiSessionCapabilitySurface(context, envVars);
@@ -7543,6 +7554,11 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     apiKey: string,
     completeSimple: typeof import("@earendil-works/pi-ai/compat").completeSimple,
     signal?: AbortSignal,
+    metering?: {
+      context: ChatContextState;
+      modelConfig: PiResolvedModelConfig;
+      userId: string | null;
+    },
   ): Promise<AgentMessage[]> {
     const degraded = this.piDegradedResumeAttempt;
     // The ONE estimate of this request. It used to be computed three times
@@ -7557,6 +7573,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       contextTokens: footprint.tokens,
       contextBytes: footprint.bytes,
       outcome,
+      metering,
     };
     const compacted = await this.compactPiContext(
       messages,
@@ -7653,6 +7670,11 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       byteCeiling?: number;
       /** Written by this method so the caller can report what the request did. */
       outcome?: PiCompactionOutcome;
+      metering?: {
+        context: ChatContextState;
+        modelConfig: PiResolvedModelConfig;
+        userId: string | null;
+      };
     } = {},
   ): Promise<AgentMessage[]> {
     const force = options.force === true;
@@ -7797,6 +7819,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       }
     };
     try {
+      const metering = options.metering;
       const summary = await summarizePiMessages(
         messagesToSummarize,
         model,
@@ -7804,6 +7827,30 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
         completeSimple,
         signal,
         previousSummary,
+        metering
+          ? {
+              beforePull: () => this.assertPiUserLlmUsageAccess(
+                metering.context,
+                metering.modelConfig,
+                metering.userId,
+              ),
+              afterPull: (response, pullId, durationMs) =>
+                this.recordPiAssistantUsage(
+                  response,
+                  durationMs,
+                  metering.modelConfig.billingSource,
+                  metering.modelConfig.creditChargeable,
+                  metering.modelConfig.usageProvider,
+                  {
+                    userId: metering.userId,
+                    model: metering.modelConfig.model.id,
+                    usageSurface: "compaction",
+                    sourceScope: `${metering.context.threadId}:compaction:${pullId}`,
+                    source: "pi_compaction",
+                  },
+                ),
+            }
+          : undefined,
       );
       recordCut(summary);
       return finish(
@@ -7811,6 +7858,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
         "summarized",
       );
     } catch (error) {
+      if (error instanceof UserLlmUsageLimitError) throw error;
       console.error("[ChatThreadDO] Pi context compaction failed", error);
       const fallbackSummary = createFallbackPiCompactionSummary(
         messagesToSummarize,
@@ -7872,6 +7920,8 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       return;
     }
 
+    const initiatingUserId = this.getActiveTurnUserId();
+    this.pendingPiPostTurnCompactionUserId = initiatingUserId;
     this.ctx.waitUntil(
       this.compactPiContextAfterTurn(latestAssistant).catch((error) => {
         console.error("[ChatThreadDO] Pi post-turn compaction failed", error);
@@ -7879,9 +7929,13 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     );
   }
 
-  private async compactPiContextAfterTurn(triggerMessage: AgentMessage): Promise<void> {
+  private async compactPiContextAfterTurn(
+    triggerMessage: AgentMessage,
+  ): Promise<void> {
     const resolver = this.piModelResolver;
     const session = this.piSession;
+    const initiatingUserId = this.pendingPiPostTurnCompactionUserId;
+    this.pendingPiPostTurnCompactionUserId = null;
     if (!resolver || !session) return;
 
     // `agent_end` fires from inside the Pi run, and `isStreaming` is only
@@ -7913,6 +7967,7 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     }
 
     const before = session.state.messages;
+    const context = this.chatContext;
     const compacted = await this.compactPiContext(
       before,
       current.model,
@@ -7921,7 +7976,12 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       undefined,
       // Already threshold-gated by shouldCompactPiAfterAssistantUsage above, so no
       // extra floor; the session is idle here, so every index is committed.
-      { force: true },
+      {
+        force: true,
+        ...(context
+          ? { metering: { context, modelConfig: current, userId: initiatingUserId } }
+          : {}),
+      },
     );
     if (compacted === before || session.state.isStreaming || session.state.messages !== before) {
       return;
@@ -7971,7 +8031,10 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       context,
       envVars,
       getModelFn,
-    );
+    ).then((modelConfig) => {
+      if (!sponsoredCapability) this.piCurrentUsageModel = modelConfig.model.id;
+      return modelConfig;
+    });
   }
 
   private resolvePiRequestConfig(
@@ -8117,6 +8180,47 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     return value;
   }
 
+  private async assertPiUserLlmUsageAccess(
+    context: ChatContextState,
+    modelConfig: PiResolvedModelConfig,
+    userId: string | null = this.getActiveTurnUserId(),
+  ): Promise<void> {
+    if (!userId) return;
+    try {
+      await this.awaitPiUsageSettlements();
+    } catch {
+      recordObservabilityEvent(this.env, {
+        event: "user_llm_usage_limit_denied",
+        severity: "error",
+        component: "chat_thread",
+        operation: "await_usage_settlement",
+        status: "usage_policy_unavailable",
+        orgId: context.orgId,
+        workspaceId: context.workspaceId,
+        threadId: context.threadId,
+        userId,
+        provider: modelConfig.usageProvider,
+        model: modelConfig.model.id,
+      });
+      throw new UserLlmUsageLimitError(
+        "usage_policy_unavailable",
+        null,
+        modelConfig.usageProvider,
+        modelConfig.model.id,
+      );
+    }
+    const orgStub = this.env.ORG.get(this.env.ORG.idFromName(context.orgId));
+    await assertUserLlmUsageAccess(orgStub, {
+      env: this.env,
+      orgId: context.orgId,
+      workspaceId: context.workspaceId,
+      threadId: context.threadId,
+      userId,
+      provider: modelConfig.usageProvider || modelConfig.model.provider,
+      model: modelConfig.model.id,
+    });
+  }
+
   private resolveCurrentByokCredentials(
     context: ChatContextState,
     options: { includeOpenAiSubscription: boolean },
@@ -8231,14 +8335,17 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       consumeCapabilityAllowance: (context, capability, idempotencyKey) =>
         this.consumeCapabilityAllowance(context, capability, idempotencyKey),
       piModelResolver: () => this.piModelResolver,
+      activeTurnUserId: () => this.getActiveTurnUserId(),
+      assertUserLlmUsageAccess: (context, modelConfig, userId) =>
+        this.assertPiUserLlmUsageAccess(context, modelConfig, userId),
       afterPiToolCall: (toolContext, signal, options) =>
         this.afterPiToolCall(toolContext, signal, options),
       beforePiToolCall: (toolContext, signal) =>
         this.beforePiToolCall(toolContext, signal),
       streamPiModel: (model, llmContext, options, streamSimple) =>
         this.streamPiModel(model, llmContext, options, streamSimple),
-      recordPiAssistantUsage: (message, durationMs, billingSource, creditChargeable, usageProvider) =>
-        this.recordPiAssistantUsage(message, durationMs, billingSource, creditChargeable, usageProvider),
+      recordPiAssistantUsage: (message, durationMs, billingSource, creditChargeable, usageProvider, attribution) =>
+        this.recordPiAssistantUsage(message, durationMs, billingSource, creditChargeable, usageProvider, attribution),
       waitUntil: (promise) => this.ctx.waitUntil(promise),
       createPiToolDefinitions: (context, options) =>
         this.createPiToolDefinitions(context, options),
@@ -8411,6 +8518,38 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     }
 
     if (event.type === "turn_end") {
+      // Failed and user-aborted responses can still contain provider-reported
+      // usage (for example, a stream that fails after emitting billable
+      // tokens). Meter before the transcript-specific early returns so every
+      // completed provider pull with usage reaches the settlement queue.
+      const durationMs = this.piTurnStartedAtMs
+        ? Date.now() - this.piTurnStartedAtMs
+        : 0;
+      const billingSource = this.piCurrentBillingSource;
+      const creditChargeable = this.piCurrentCreditChargeable;
+      const usageProvider = this.piCurrentUsageProvider;
+      const usageUserId = this.getActiveTurnUserId();
+      this.ctx.waitUntil(
+        this.recordPiAssistantUsage(
+          event.message,
+          durationMs,
+          billingSource,
+          creditChargeable,
+          usageProvider,
+          {
+            userId: usageUserId,
+            model:
+              (event.message as AgentMessage & { model?: string }).model ||
+              this.piCurrentUsageModel ||
+              undefined,
+            usageSurface: "agent",
+            sourceScope: this.piRuntimeThreadId(),
+          },
+        ).catch((error) => {
+          console.error("[ChatThreadDO] failed to record Pi usage", error);
+        }),
+      );
+
       if (
         this.piUserStopRequestedAtMs > 0 &&
         isAbortedPiAssistantMessage(event.message)
@@ -8439,12 +8578,6 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       // This turn is committed to pi_core_messages; drop its journaled tail (the
       // agent run may still have more turns, which will re-journal their tail).
       this.clearPiTurnJournal();
-      const durationMs = this.piTurnStartedAtMs
-        ? Date.now() - this.piTurnStartedAtMs
-        : 0;
-      const billingSource = this.piCurrentBillingSource;
-      const creditChargeable = this.piCurrentCreditChargeable;
-      const usageProvider = this.piCurrentUsageProvider;
       this.piLastTurnUsage = piRuntimeUsageSummary(event.message);
       this.piSdkTurnUsageTotal = addPiRuntimeUsageSummaries(
         this.piSdkTurnUsageTotal,
@@ -8458,17 +8591,6 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
         ...(usageProvider ? { provider: usageProvider } : {}),
         ...(this.piLastTurnUsage ? { usage: this.piLastTurnUsage } : {}),
       });
-      this.ctx.waitUntil(
-        this.recordPiAssistantUsage(
-          event.message,
-          durationMs,
-          billingSource,
-          creditChargeable,
-          usageProvider,
-        ).catch((error) => {
-          console.error("[ChatThreadDO] failed to record Pi usage", error);
-        }),
-      );
     }
 
     if (event.type === "message_update") {
@@ -8819,8 +8941,86 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
     billingSource: PiBillingSource,
     creditChargeable: boolean,
     usageProvider?: string | null,
+    attribution: {
+      userId: string | null;
+      model?: string;
+      usageSurface: "agent" | "subagent" | "compaction";
+      sourceScope?: string;
+      source?: "pi_assistant" | "pi_compaction";
+    } = {
+      userId: this.getActiveTurnUserId(),
+      usageSurface: "agent",
+    },
   ): Promise<void> {
-    if (message.role !== "assistant" || !this.chatContext) return;
+    const context = this.chatContext;
+    if (message.role !== "assistant" || !context) return;
+    const immutableContext = { ...context };
+    const createdAtMs = Date.now();
+    const job = () => this.recordPiAssistantUsageSettled(
+      message,
+      durationMs,
+      billingSource,
+      creditChargeable,
+      usageProvider,
+      attribution,
+      immutableContext,
+      createdAtMs,
+    );
+    const queue = (this.pendingLlmUsageSettlements ??= []);
+    queue.push(job);
+    const settlement = (this.llmUsageSettlementChain ?? Promise.resolve())
+      .catch(() => undefined)
+      .then(() => this.drainPiUsageSettlements());
+    this.llmUsageSettlementChain = settlement;
+    return settlement;
+  }
+
+  private async awaitPiUsageSettlements(): Promise<void> {
+    try {
+      await (this.llmUsageSettlementChain ?? Promise.resolve());
+      return;
+    } catch (error) {
+      if (!(this.pendingLlmUsageSettlements?.length > 0)) throw error;
+    }
+
+    // A failed job remains at the head of the in-memory queue with the same
+    // deterministic source/source_id inputs. Retry it before policy evaluation
+    // so recovery cannot bypass spend that should have settled. Isolate
+    // eviction remains the recovery boundary; provider-response journaling is
+    // intentionally a separate durability project.
+    const retry = (this.llmUsageSettlementChain ?? Promise.resolve())
+      .catch(() => undefined)
+      .then(() => this.drainPiUsageSettlements());
+    this.llmUsageSettlementChain = retry;
+    await retry;
+  }
+
+  private async drainPiUsageSettlements(): Promise<void> {
+    const queue = (this.pendingLlmUsageSettlements ??= []);
+    while (queue.length > 0) {
+      const job = queue[0];
+      await job();
+      queue.shift();
+    }
+  }
+
+  private async recordPiAssistantUsageSettled(
+    message: AgentMessage,
+    durationMs: number,
+    billingSource: PiBillingSource,
+    creditChargeable: boolean,
+    usageProvider: string | null | undefined,
+    attribution: {
+      userId: string | null;
+      model?: string;
+      usageSurface: "agent" | "subagent" | "compaction";
+      sourceScope?: string;
+      source?: "pi_assistant" | "pi_compaction";
+    },
+    context: ChatContextState,
+    createdAtMs: number,
+  ): Promise<void> {
+    if (message.role !== "assistant") return;
 
     const assistant = message as AgentMessage & {
       provider?: string;
@@ -8854,10 +9054,12 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       return;
     }
 
-    const context = this.chatContext;
+    const immutableAssistant = Number.isFinite(Number(assistant.timestamp))
+      ? assistant
+      : { ...assistant, timestamp: createdAtMs };
     const usageSourceId = piUsageSourceId(
-      context.threadId,
-      assistant,
+      attribution.sourceScope || context.threadId,
+      immutableAssistant,
       inputTokens,
       outputTokens,
       cacheReadTokens,
@@ -8870,23 +9072,25 @@ export class ChatThreadDO extends AIChatAgent<ChatAgentEnv, ChatThreadAgentState
       () =>
         getOrgStub().recordUsage({
           workspace_id: context.workspaceId,
-          user_id: context.userId ?? "",
+          user_id: attribution.userId ?? "",
           thread_id: context.threadId,
-          model: assistant.responseModel || assistant.model || "unknown",
+          model: attribution.model || assistant.model || "unknown",
           provider: usageProvider || assistant.provider || "unknown",
           billing_source: billingSource,
           credit_chargeable: billingSource === "hosted" && creditChargeable,
+          usage_kind: "llm",
+          usage_surface: attribution.usageSurface,
           input_tokens: inputTokens,
           output_tokens: outputTokens,
           cache_creation_input_tokens: cacheWriteTokens,
           cache_read_input_tokens: cacheReadTokens,
-          cost_usd:
+          estimated_cost_usd:
             typeof usage.cost?.total === "number" && usage.cost.total > 0
               ? usage.cost.total
               : undefined,
           duration_ms: durationMs,
-          created_at_ms: Date.now(),
-          source: "pi_assistant",
+          created_at_ms: createdAtMs,
+          source: attribution.source ?? "pi_assistant",
           source_id: usageSourceId,
         }),
       { attempts: 4, initialDelayMs: 150 },

--- a/workers/main/src/chat-thread/pi-compaction.ts
+++ b/workers/main/src/chat-thread/pi-compaction.ts
@@ -620,6 +620,7 @@ export async function summarizePiMessages(
   completeSimple: typeof import("@earendil-works/pi-ai/compat").completeSimple,
   signal?: AbortSignal,
   previousSummary?: string,
+  hooks?: PiCompactionPullHooks,
 ): Promise<string> {
   const summaryMaxTokens = piSummaryMaxTokens(model);
   const inputTokenBudget = piSummaryInputTokenBudget(model, summaryMaxTokens);
@@ -630,6 +631,7 @@ export async function summarizePiMessages(
 
   let summary: string | undefined = previousSummary;
   for (const chunk of chunks) {
+    const pullId = crypto.randomUUID();
     summary = await summarizePiMessageChunk(
       chunk,
       model,
@@ -639,9 +641,20 @@ export async function summarizePiMessages(
       inputTokenBudget,
       signal,
       summary,
+      hooks,
+      pullId,
     );
   }
   return summary ?? "";
+}
+
+export interface PiCompactionPullHooks {
+  beforePull(pullId: string): Promise<void>;
+  afterPull(
+    response: AgentMessage,
+    pullId: string,
+    durationMs: number,
+  ): Promise<void>;
 }
 
 export function piSummaryMaxTokens(model: Model<any>): number {
@@ -692,6 +705,8 @@ export async function summarizePiMessageChunk(
   inputTokenBudget: number,
   signal?: AbortSignal,
   previousSummary?: string,
+  hooks?: PiCompactionPullHooks,
+  pullId = crypto.randomUUID(),
 ): Promise<string> {
   const serialized = messages
     .map((message) => serializePiMessageForSummary(message))
@@ -718,11 +733,14 @@ export async function summarizePiMessageChunk(
     maxTokens: summaryMaxTokens,
     ...(model.reasoning ? { reasoning: "high" as const } : {}),
   } as Parameters<typeof completeSimple>[2];
+  await hooks?.beforePull(pullId);
+  const startedAt = Date.now();
   const response = await completeSimple(
     model,
     summaryContext,
     summaryOptions,
   );
+  await hooks?.afterPull(response, pullId, Math.max(0, Date.now() - startedAt));
   if ((response as { stopReason?: unknown }).stopReason === "error") {
     const errorMessage = typeof (response as { errorMessage?: unknown }).errorMessage === "string"
       ? (response as { errorMessage: string }).errorMessage

--- a/workers/main/src/chat-thread/pi-stream-retry.ts
+++ b/workers/main/src/chat-thread/pi-stream-retry.ts
@@ -88,6 +88,72 @@ export type PiProviderStreamTerminalStatus =
   | "non_transient"
   | "aborted";
 
+type PiAssistantUsage = AssistantMessage["usage"];
+
+function mergeAssistantUsage(
+  accumulated: PiAssistantUsage | null,
+  current: PiAssistantUsage,
+): PiAssistantUsage {
+  if (!accumulated) return current;
+  const sum = (key: "input" | "output" | "cacheRead" | "cacheWrite" | "totalTokens") =>
+    Math.max(0, Number(accumulated[key]) || 0) +
+    Math.max(0, Number(current[key]) || 0);
+  const costKeys = ["input", "output", "cacheRead", "cacheWrite", "total"] as const;
+  const cost = Object.fromEntries(costKeys.map((key) => [
+    key,
+    Math.max(0, Number(accumulated.cost?.[key]) || 0) +
+      Math.max(0, Number(current.cost?.[key]) || 0),
+  ])) as PiAssistantUsage["cost"];
+  return {
+    input: sum("input"),
+    output: sum("output"),
+    cacheRead: sum("cacheRead"),
+    cacheWrite: sum("cacheWrite"),
+    totalTokens: sum("totalTokens"),
+    cost,
+  };
+}
+
+function usageWithNonzeroBilling(usage: PiAssistantUsage): PiAssistantUsage | null {
+  return usage.input > 0 || usage.output > 0 || usage.cacheRead > 0 ||
+    usage.cacheWrite > 0 || usage.cost.total > 0
+    ? usage
+    : null;
+}
+
+function mergeHiddenUsageIntoEvent(
+  event: AssistantMessageEvent,
+  hiddenUsage: PiAssistantUsage | null,
+): AssistantMessageEvent {
+  if (!hiddenUsage) return event;
+  if (event.type === "done") {
+    return {
+      ...event,
+      message: {
+        ...event.message,
+        usage: mergeAssistantUsage(hiddenUsage, event.message.usage),
+      },
+    };
+  }
+  if (event.type === "error") {
+    return {
+      ...event,
+      error: {
+        ...event.error,
+        usage: mergeAssistantUsage(hiddenUsage, event.error.usage),
+      },
+    };
+  }
+  return event;
+}
+
+function usageFromEvent(event: AssistantMessageEvent): PiAssistantUsage | null {
+  if (event.type === "done") return event.message.usage;
+  if (event.type === "error") return event.error.usage;
+  if ("partial" in event) return event.partial.usage;
+  return null;
+}
+
 /**
  * Sleep that rejects with "Request was aborted" if the signal fires (or has
  * already fired). Shared by the provider ladder here and ChatThreadDO's
@@ -130,6 +196,7 @@ export function streamPiModelWithTransientRetry(
   } = {},
 ): AssistantMessageEventStream {
   const outer = createAssistantMessageEventStream();
+  let hiddenRetryUsage: PiAssistantUsage | null = null;
   const maxRetryAttempts = retryOptions.maxRetryAttempts ??
     PI_PROVIDER_TRANSIENT_RETRY_ATTEMPTS;
   const isRetryableError = (message: string) =>
@@ -142,21 +209,28 @@ export function streamPiModelWithTransientRetry(
       let forwardedEvent = false;
       let pendingStartEvent: AssistantMessageEvent | null = null;
       let retryErrorMessage = "";
+      let latestAttemptUsage: PiAssistantUsage | null = null;
       try {
         const inner = createStream();
         for await (const event of inner) {
+          latestAttemptUsage = usageFromEvent(event) ?? latestAttemptUsage;
           if (event.type === "start") {
             pendingStartEvent = event;
             continue;
           }
           const errorMessage = piProviderStreamErrorMessage(event);
           if (
+            event.type === "error" &&
             errorMessage &&
             !forwardedEvent &&
             !options?.signal?.aborted &&
             attempt < maxRetryAttempts &&
             isRetryableError(errorMessage)
           ) {
+            const retryUsage = usageWithNonzeroBilling(event.error.usage);
+            if (retryUsage) {
+              hiddenRetryUsage = mergeAssistantUsage(hiddenRetryUsage, retryUsage);
+            }
             retryErrorMessage = errorMessage;
             break;
           }
@@ -179,10 +253,20 @@ export function streamPiModelWithTransientRetry(
             pendingStartEvent = null;
             forwardedEvent = true;
           }
-          outer.push(event);
+          const forwarded = mergeHiddenUsageIntoEvent(event, hiddenRetryUsage);
+          if (forwarded.type === "done" || forwarded.type === "error") {
+            hiddenRetryUsage = null;
+          }
+          outer.push(forwarded);
           forwardedEvent = true;
         }
       } catch (error) {
+        const billableAttemptUsage = latestAttemptUsage
+          ? usageWithNonzeroBilling(latestAttemptUsage)
+          : null;
+        if (billableAttemptUsage) {
+          hiddenRetryUsage = mergeAssistantUsage(hiddenRetryUsage, billableAttemptUsage);
+        }
         const errorMessage = error instanceof Error ? error.message : String(error);
         if (
           !forwardedEvent &&
@@ -204,7 +288,7 @@ export function streamPiModelWithTransientRetry(
             attempt + 1,
             forwardedEvent,
           );
-          outer.push({
+          const terminalEvent = mergeHiddenUsageIntoEvent({
             type: "error",
             reason: options?.signal?.aborted ? "aborted" : "error",
             error: createPiProviderStreamErrorMessage(
@@ -212,7 +296,9 @@ export function streamPiModelWithTransientRetry(
               errorMessage,
               options?.signal?.aborted ? "aborted" : "error",
             ),
-          });
+          }, hiddenRetryUsage);
+          hiddenRetryUsage = null;
+          outer.push(terminalEvent);
           outer.end();
           return;
         }
@@ -228,7 +314,7 @@ export function streamPiModelWithTransientRetry(
       await abortableSleep(PI_PROVIDER_TRANSIENT_RETRY_DELAY_MS, options?.signal);
     }
   })().catch((error) => {
-    outer.push({
+    const terminalEvent = mergeHiddenUsageIntoEvent({
       type: "error",
       reason: options?.signal?.aborted ? "aborted" : "error",
       error: createPiProviderStreamErrorMessage(
@@ -236,7 +322,9 @@ export function streamPiModelWithTransientRetry(
         error instanceof Error ? error.message : String(error),
         options?.signal?.aborted ? "aborted" : "error",
       ),
-    });
+    }, hiddenRetryUsage);
+    hiddenRetryUsage = null;
+    outer.push(terminalEvent);
     outer.end();
   });
 

--- a/workers/main/src/chat-thread/pi-tools.ts
+++ b/workers/main/src/chat-thread/pi-tools.ts
@@ -334,6 +334,12 @@ export interface PiToolSurfaceDeps {
   }>;
   /** Reads the DO's current `piModelResolver` field (null when no main turn set one). */
   piModelResolver(): (() => Promise<PiResolvedModelConfig>) | null;
+  activeTurnUserId(): string | null;
+  assertUserLlmUsageAccess(
+    context: ChatContextState,
+    modelConfig: PiResolvedModelConfig,
+    userId: string | null,
+  ): Promise<void>;
   afterPiToolCall(
     context: AfterToolCallContext,
     signal?: AbortSignal,
@@ -355,6 +361,12 @@ export interface PiToolSurfaceDeps {
     billingSource: PiBillingSource,
     creditChargeable: boolean,
     usageProvider?: string | null,
+    attribution?: {
+      userId: string | null;
+      model?: string;
+      usageSurface: "agent" | "subagent" | "compaction";
+      sourceScope?: string;
+    },
   ): Promise<void>;
   waitUntil(promise: Promise<unknown>): void;
   // Sibling routing back through the owning DO's same-named delegates, so a
@@ -642,6 +654,8 @@ export async function runPiSubagentTool(
   const resolveCurrentModel =
     deps.piModelResolver() ?? (() => deps.resolvePiModel(context, {}, getModel));
   let modelConfig = await resolveCurrentModel();
+  const usageUserId = deps.activeTurnUserId();
+  const childSessionId = `${context.threadId}:${toolName}:${crypto.randomUUID()}`;
   const child = new Agent({
     initialState: {
       systemPrompt: await deps.createPiSubagentSystemPrompt(context, isExplore),
@@ -658,6 +672,7 @@ export async function runPiSubagentTool(
       const current = await resolveCurrentModel();
       modelConfig = current;
       child.state.model = capPiMainRequestOutput(current.model);
+      await deps.assertUserLlmUsageAccess(context, current, usageUserId);
       return current.apiKey;
     },
     beforeToolCall: (toolContext, signal) =>
@@ -666,7 +681,7 @@ export async function runPiSubagentTool(
       deps.afterPiToolCall(toolContext, signal),
     streamFn: (model, llmContext, options) =>
       deps.streamPiModel(model, llmContext, options, streamSimple),
-    sessionId: `${context.threadId}:${toolName}:${crypto.randomUUID()}`,
+    sessionId: childSessionId,
     toolExecution: "parallel",
   });
 
@@ -719,6 +734,12 @@ export async function runPiSubagentTool(
             modelConfig.billingSource,
             modelConfig.creditChargeable,
             modelConfig.usageProvider,
+            {
+              userId: usageUserId,
+              model: modelConfig.model.id,
+              usageSurface: "subagent",
+              sourceScope: childSessionId,
+            },
           ).catch((error) => {
             console.error("[ChatThreadDO] failed to record Pi subagent usage", error);
           }),
@@ -846,6 +867,8 @@ export async function runPiCapabilityAgentTool(
         }))
     : childToolDefinitions;
   const systemPrompt = capabilityAgentSystemPrompt(toolName);
+  const usageUserId = deps.activeTurnUserId();
+  const childSessionId = `${context.threadId}:${toolName}:${crypto.randomUUID()}`;
 
   const child = new Agent({
     initialState: {
@@ -863,6 +886,7 @@ export async function runPiCapabilityAgentTool(
       );
       modelConfig = current;
       child.state.model = capOutputTokens(current.model);
+      await deps.assertUserLlmUsageAccess(context, current, usageUserId);
       return current.apiKey;
     },
     beforeToolCall: (toolContext, childSignal) =>
@@ -877,7 +901,7 @@ export async function runPiCapabilityAgentTool(
       }),
     streamFn: (model, llmContext, options) =>
       deps.streamPiModel(model, llmContext, options, streamSimple),
-    sessionId: `${context.threadId}:${toolName}:${crypto.randomUUID()}`,
+    sessionId: childSessionId,
     toolExecution: "sequential",
   });
 
@@ -932,6 +956,12 @@ export async function runPiCapabilityAgentTool(
             modelConfig.billingSource,
             modelConfig.creditChargeable,
             modelConfig.usageProvider,
+            {
+              userId: usageUserId,
+              model: modelConfig.model.id,
+              usageSurface: "subagent",
+              sourceScope: childSessionId,
+            },
           ).catch((error) => {
             console.error(`[ChatThreadDO] failed to record Pi ${capability} usage`, error);
           }),

--- a/workers/main/src/code-mode-tools.ts
+++ b/workers/main/src/code-mode-tools.ts
@@ -5419,6 +5419,8 @@ export class CodeModeToolsBinding extends WorkerEntrypoint<ChatEnv, CodeModeTool
       provider,
       billing_source: "hosted_capability",
       credit_chargeable: false,
+      usage_kind: "capability",
+      usage_surface: "capability",
       cost_usd: Number.isFinite(costUsd) && costUsd > 0 ? costUsd : 0,
       duration_ms: Number.isFinite(durationMs) && durationMs > 0 ? durationMs : undefined,
       created_at_ms: Date.now(),

--- a/workers/main/src/identity/index.ts
+++ b/workers/main/src/identity/index.ts
@@ -43,4 +43,17 @@ export type {
 export type {
   OrgAuthContextBootstrap,
   OrgChatWebSocketAccessResult,
+  CheckUserLlmUsageAccessInput,
+  LlmModelPricingInput,
+  LlmPricingResponse,
+  UsageAggregateQuery,
+  UsageAggregateResult,
+  UsageCostSource,
+  UsageKind,
+  UsageSurface,
+  UserLlmUsageAccessResult,
+  UserLlmUsageLimit,
+  UserLlmUsageLimitInput,
+  UserLlmUsageReport,
+  UserLlmUsageReportQuery,
 } from "./org-do";

--- a/workers/main/src/identity/org-do.ts
+++ b/workers/main/src/identity/org-do.ts
@@ -101,9 +101,42 @@ import {
   type CustomDomain,
   type CustomDomainStatus,
 } from "./org/custom-domains";
+import {
+  OrgUsageControls,
+  UsageControlsValidationError,
+  normalizeUsageKind,
+  normalizeUsageSurface,
+  type CheckUserLlmUsageAccessInput,
+  type LlmModelPricingInput,
+  type LlmPricingResponse,
+  type UsageAggregateQuery,
+  type UsageAggregateResult,
+  type UsageCostSource,
+  type UsageKind,
+  type UsageSurface,
+  type UserLlmUsageAccessResult,
+  type UserLlmUsageLimitInput,
+  type UserLlmUsageReport,
+  type UserLlmUsageReportQuery,
+} from "./org/usage-controls";
 
 // Re-export for consumers that import from this module
 export type { OrgRole, BillingStatus } from "../../../../src/types";
+export type {
+  CheckUserLlmUsageAccessInput,
+  LlmModelPricingInput,
+  LlmPricingResponse,
+  UsageAggregateQuery,
+  UsageAggregateResult,
+  UsageCostSource,
+  UsageKind,
+  UsageSurface,
+  UserLlmUsageAccessResult,
+  UserLlmUsageLimit,
+  UserLlmUsageLimitInput,
+  UserLlmUsageReport,
+  UserLlmUsageReportQuery,
+} from "./org/usage-controls";
 
 const ORG_MODEL_PICKER_CONFIG_KEY = "model_picker_config";
 const ORG_INDEX_PREFIX = "org_index:";
@@ -603,8 +636,11 @@ export interface UsageRecordInput {
   cache_creation_input_tokens?: number | null;
   cache_read_input_tokens?: number | null;
   cost_usd?: number | null;
+  estimated_cost_usd?: number | null;
   reported_cost_usd?: number | null;
   upstream_inference_cost_usd?: number | null;
+  usage_kind?: UsageKind;
+  usage_surface?: UsageSurface;
   duration_ms?: number | null;
   created_at_ms?: number | null;
   source?: string | null;
@@ -633,6 +669,11 @@ export interface UsageLogQuery {
   from?: number | null;
   to?: number | null;
   chargeable_only?: boolean | number | null;
+  user_id?: string | null;
+  provider?: string | null;
+  model?: string | null;
+  usage_kind?: UsageKind | null;
+  usage_surface?: UsageSurface | null;
 }
 
 export interface UsageLogEntry {
@@ -650,6 +691,11 @@ export interface UsageLogEntry {
   cache_creation_input_tokens: number;
   cache_read_input_tokens: number;
   cost_usd: number;
+  metered_cost_microusd: number | null;
+  metered_cost_usd: number | null;
+  cost_source: UsageCostSource;
+  usage_kind: UsageKind;
+  usage_surface: UsageSurface;
   duration_ms: number;
   created_at_ms: number;
   source: string;
@@ -808,6 +854,7 @@ export interface OrgSsoIdentityRecord {
 // User Durable Object - one per user
 export class OrgDO extends DurableObject<DOEnv> {
   private sql: SqlStorage;
+  private usageControlsInstance?: OrgUsageControls;
   private workerScriptsHasPreviewColumns = true;
   private static readonly LEGACY_HOST_USAGE_BACKFILL_STATUS_KEY =
     "legacyHostUsageBackfillStatus";
@@ -834,6 +881,16 @@ export class OrgDO extends DurableObject<DOEnv> {
         await this.enforceSelfhostPrivateAppAccess();
       }
     });
+  }
+
+  private get usageControls(): OrgUsageControls {
+    return (this.usageControlsInstance ??= new OrgUsageControls({
+      sql: this.sql,
+      orgId: () => this.getInfoSync()?.id ?? "",
+      isCurrentMember: (userId) =>
+        this.sql.exec("SELECT 1 FROM members WHERE user_id = ?", userId).toArray().length > 0,
+      transactionSync: (callback) => this.ctx.storage.transactionSync(callback),
+    }));
   }
 
   private async enforceSelfhostPrivateAppAccess(): Promise<void> {
@@ -2057,7 +2114,114 @@ export class OrgDO extends DurableObject<DOEnv> {
       );
     }
 
-    const CURRENT_SCHEMA_VERSION = 51;
+    const usageLogColumns = new Set(
+      this.sql.exec<{ name: string }>("PRAGMA table_info(usage_log)").toArray()
+        .map((column) => column.name),
+    );
+    const usageControlTables = new Set(
+      this.sql.exec<{ name: string }>(
+        `SELECT name FROM sqlite_master
+          WHERE type = 'table' AND name IN ('user_llm_usage_limits', 'llm_model_pricing_overrides')`,
+      ).toArray().map((row) => row.name),
+    );
+    const usageControlsSchemaIncomplete =
+      !usageLogColumns.has("usage_kind") ||
+      !usageLogColumns.has("usage_surface") ||
+      !usageLogColumns.has("metered_cost_microusd") ||
+      !usageLogColumns.has("cost_source") ||
+      !usageControlTables.has("user_llm_usage_limits") ||
+      !usageControlTables.has("llm_model_pricing_overrides");
+    if (version < 52 || usageControlsSchemaIncomplete) {
+      this.ensureColumn(
+        "usage_log",
+        "usage_kind",
+        "TEXT NOT NULL DEFAULT 'unknown'",
+      );
+      this.ensureColumn(
+        "usage_log",
+        "usage_surface",
+        "TEXT NOT NULL DEFAULT 'unknown'",
+      );
+      this.ensureColumn("usage_log", "metered_cost_microusd", "INTEGER");
+      this.ensureColumn(
+        "usage_log",
+        "cost_source",
+        "TEXT NOT NULL DEFAULT 'legacy_estimate'",
+      );
+      this.sql.exec(
+        `UPDATE usage_log
+            SET metered_cost_microusd = ROUND(cost_usd * 1000000),
+                cost_source = 'legacy_estimate'
+          WHERE metered_cost_microusd IS NULL`,
+      );
+      this.sql.exec(
+        `UPDATE usage_log SET usage_kind = 'capability', usage_surface = 'capability'
+          WHERE usage_kind = 'unknown' AND (
+            billing_source = 'hosted_capability' OR
+            source IN ('web_search', 'web_fetch')
+          )`,
+      );
+      this.sql.exec(
+        `UPDATE usage_log SET usage_kind = 'image', usage_surface = 'auxiliary'
+          WHERE usage_kind = 'unknown' AND (
+            source IN ('image_generation', 'generate_image') OR
+            (thread_id = 'virtual-ai' AND model IN ('auto_image', 'dynamic/auto_image'))
+          )`,
+      );
+      this.sql.exec(
+        `UPDATE usage_log SET usage_kind = 'audio'
+          WHERE usage_kind = 'unknown' AND source IN ('audio_transcription', 'transcribe_audio')`,
+      );
+      this.sql.exec(
+        `UPDATE usage_log SET usage_kind = 'llm', usage_surface = 'agent'
+          WHERE usage_kind = 'unknown' AND source = 'pi_assistant'`,
+      );
+      // Historical Virtual AI rows stored the provider response model, so an
+      // auto-image call can be indistinguishable from a text completion. Keep
+      // ambiguous rows out of LLM spend while still exposing their true surface
+      // to operators; only the known image route names above are classified.
+      this.sql.exec(
+        `UPDATE usage_log SET usage_surface = 'virtual_ai'
+          WHERE usage_surface = 'unknown' AND thread_id = 'virtual-ai'`,
+      );
+      this.sql.exec(
+        "CREATE INDEX IF NOT EXISTS idx_usage_log_user_created_at ON usage_log(user_id, created_at_ms)",
+      );
+      this.sql.exec(
+        "CREATE INDEX IF NOT EXISTS idx_usage_log_user_model_created_at ON usage_log(user_id, provider, model, created_at_ms)",
+      );
+      this.sql.exec(`
+        CREATE TABLE IF NOT EXISTS user_llm_usage_limits (
+          user_id TEXT NOT NULL,
+          window_ms INTEGER NOT NULL,
+          limit_microusd INTEGER NOT NULL,
+          label TEXT,
+          created_at_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL,
+          updated_by TEXT NOT NULL,
+          PRIMARY KEY (user_id, window_ms)
+        )
+      `);
+      this.sql.exec(
+        "CREATE INDEX IF NOT EXISTS idx_user_llm_usage_limits_user ON user_llm_usage_limits(user_id)",
+      );
+      this.sql.exec(`
+        CREATE TABLE IF NOT EXISTS llm_model_pricing_overrides (
+          provider TEXT NOT NULL,
+          model TEXT NOT NULL,
+          input_microusd_per_million INTEGER NOT NULL,
+          output_microusd_per_million INTEGER NOT NULL,
+          cache_creation_microusd_per_million INTEGER NOT NULL DEFAULT 0,
+          cache_read_microusd_per_million INTEGER NOT NULL DEFAULT 0,
+          created_at_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL,
+          updated_by TEXT NOT NULL,
+          PRIMARY KEY (provider, model)
+        )
+      `);
+    }
+
+    const CURRENT_SCHEMA_VERSION = 52;
     if (version < CURRENT_SCHEMA_VERSION) {
       this.ctx.storage.kv.put("schemaVersion", CURRENT_SCHEMA_VERSION);
     }
@@ -4228,6 +4392,7 @@ export class OrgDO extends DurableObject<DOEnv> {
     this.ctx.storage.transactionSync(() => {
       this.sql.exec("DELETE FROM members WHERE user_id = ?", userId);
       this.sql.exec("DELETE FROM workspace_memberships WHERE user_id = ?", userId);
+      this.sql.exec("DELETE FROM user_llm_usage_limits WHERE user_id = ?", userId);
       this.sql.exec(
         "UPDATE enterprise_sso_identities SET membership_revoked = 1 WHERE user_id = ?",
         userId,
@@ -9181,19 +9346,44 @@ export class OrgDO extends DurableObject<DOEnv> {
     const durationMs = usageInteger(usage.duration_ms);
     const createdAtMs = usageInteger(usage.created_at_ms) || now;
     const providedCost = usageCost(usage.cost_usd);
+    const estimatedCost = usageCost(usage.estimated_cost_usd);
+    const reportedCost = usageCost(usage.reported_cost_usd);
+    const upstreamInferenceCost = usageCost(usage.upstream_inference_cost_usd);
+    const effectiveReportedCost = reportedCost !== null && reportedCost > 0
+      ? reportedCost
+      : upstreamInferenceCost !== null && upstreamInferenceCost > 0
+        ? upstreamInferenceCost
+        : null;
     const source = usageText(usage.source);
     const sourceId = usageText(usage.source_id);
+    const usageKind = normalizeUsageKind(usage.usage_kind);
+    const usageSurface = normalizeUsageSurface(usage.usage_surface);
     const costUsd =
       providedCost ??
-      calculateEffectiveUsageCostUsd({
-        model,
-        inputTokens,
-        outputTokens,
-        cacheCreationInputTokens: cacheCreationTokens,
-        cacheReadInputTokens: cacheReadTokens,
-        reportedCostUsd: usage.reported_cost_usd,
-        upstreamInferenceCostUsd: usage.upstream_inference_cost_usd,
-      });
+      (effectiveReportedCost !== null
+        ? effectiveReportedCost
+        : estimatedCost ?? calculateEffectiveUsageCostUsd({
+            model,
+            inputTokens,
+            outputTokens,
+            cacheCreationInputTokens: cacheCreationTokens,
+            cacheReadInputTokens: cacheReadTokens,
+          }));
+    const strictCost = usageKind === "llm"
+      ? this.usageControls.resolveStrictCost({
+          provider,
+          model,
+          input_tokens: inputTokens,
+          output_tokens: outputTokens,
+          cache_creation_input_tokens: cacheCreationTokens,
+          cache_read_input_tokens: cacheReadTokens,
+          reported_cost_usd: usage.reported_cost_usd,
+          upstream_inference_cost_usd: usage.upstream_inference_cost_usd,
+        })
+      : {
+          meteredCostMicrousd: Math.round(costUsd * 1_000_000),
+          costSource: "legacy_estimate" as const,
+        };
 
     const result = this.ctx.storage.transactionSync(() => {
       if (source && sourceId) {
@@ -9230,8 +9420,12 @@ export class OrgDO extends DurableObject<DOEnv> {
           duration_ms,
           created_at_ms,
           source,
-          source_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          source_id,
+          usage_kind,
+          usage_surface,
+          metered_cost_microusd,
+          cost_source
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
         workspaceId,
         userId,
@@ -9249,6 +9443,10 @@ export class OrgDO extends DurableObject<DOEnv> {
         createdAtMs,
         source,
         sourceId,
+        usageKind,
+        usageSurface,
+        strictCost.meteredCostMicrousd,
+        strictCost.costSource,
       );
       this.sql.exec(
         `
@@ -9331,9 +9529,22 @@ export class OrgDO extends DurableObject<DOEnv> {
 
   getUsageLog(query: UsageLogQuery = {}): UsageLogPage {
     const limit = Math.min(1000, Math.max(1, usageInteger(query.limit) || 50));
-    const cursor = usageInteger(query.cursor);
-    const from = usageInteger(query.from);
-    const to = usageInteger(query.to);
+    const rawCursor = query.cursor;
+    let cursor = 0;
+    if (rawCursor !== undefined && rawCursor !== null) {
+      const normalizedCursor = String(rawCursor);
+      if (!/^[1-9]\d*$/.test(normalizedCursor) || !Number.isSafeInteger(Number(normalizedCursor))) {
+        throw new UsageControlsValidationError("cursor must be a positive safe integer");
+      }
+      cursor = Number(normalizedCursor);
+    }
+    const hasFrom = query.from !== undefined && query.from !== null;
+    const hasTo = query.to !== undefined && query.to !== null;
+    const from = hasFrom ? usageInteger(query.from) : null;
+    const to = hasTo ? usageInteger(query.to) : null;
+    if (from !== null && to !== null && to <= from) {
+      throw new UsageControlsValidationError("to must be greater than from");
+    }
     const chargeableOnly =
       query.chargeable_only === true || query.chargeable_only === 1;
     const where: string[] = [];
@@ -9342,16 +9553,28 @@ export class OrgDO extends DurableObject<DOEnv> {
       where.push("id < ?");
       params.push(cursor);
     }
-    if (from > 0) {
+    if (from !== null) {
       where.push("created_at_ms >= ?");
       params.push(from);
     }
-    if (to > 0) {
+    if (to !== null) {
       where.push("created_at_ms < ?");
       params.push(to);
     }
     if (chargeableOnly) {
       where.push("credit_chargeable = 1");
+    }
+    for (const [column, value] of [
+      ["user_id", query.user_id],
+      ["provider", query.provider],
+      ["model", query.model],
+      ["usage_kind", query.usage_kind],
+      ["usage_surface", query.usage_surface],
+    ] as const) {
+      if (typeof value === "string") {
+        where.push(`${column} = ?`);
+        params.push(value.trim());
+      }
     }
     const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
     const rows = this.sql
@@ -9371,6 +9594,10 @@ export class OrgDO extends DurableObject<DOEnv> {
           cache_creation_input_tokens,
           cache_read_input_tokens,
           cost_usd,
+          metered_cost_microusd,
+          cost_source,
+          usage_kind,
+          usage_surface,
           duration_ms,
           created_at_ms,
           source,
@@ -9393,6 +9620,20 @@ export class OrgDO extends DurableObject<DOEnv> {
       cache_creation_input_tokens: Number(row.cache_creation_input_tokens),
       cache_read_input_tokens: Number(row.cache_read_input_tokens),
       cost_usd: Number(row.cost_usd),
+      metered_cost_microusd:
+        row.metered_cost_microusd === null
+          ? null
+          : Number(row.metered_cost_microusd),
+      metered_cost_usd:
+        row.metered_cost_microusd === null
+          ? null
+          : Number((Number(row.metered_cost_microusd) / 1_000_000).toFixed(6)),
+      cost_source:
+        typeof row.cost_source === "string"
+          ? row.cost_source as UsageCostSource
+          : "legacy_estimate",
+      usage_kind: normalizeUsageKind(row.usage_kind),
+      usage_surface: normalizeUsageSurface(row.usage_surface),
       duration_ms: Number(row.duration_ms),
       created_at_ms: Number(row.created_at_ms),
       source: typeof row.source === "string" ? row.source : "",
@@ -9459,6 +9700,68 @@ export class OrgDO extends DurableObject<DOEnv> {
         row?.total_cache_read_input_tokens ?? 0,
       ),
     };
+  }
+
+  getUsageLogAggregate(query: UsageAggregateQuery = {}): UsageAggregateResult {
+    return this.usageControls.getAggregate(query);
+  }
+
+  checkUserLlmUsageAccess(
+    input: CheckUserLlmUsageAccessInput,
+  ): UserLlmUsageAccessResult {
+    return this.usageControls.checkAccess(input);
+  }
+
+  getUserLlmUsageReport(query: UserLlmUsageReportQuery): UserLlmUsageReport {
+    return this.usageControls.getUserReport(query);
+  }
+
+  getUserLlmUsageLimits(userId: string, nowMs = Date.now()) {
+    return {
+      org_id: this.getInfoSync()?.id ?? "",
+      user_id: usageText(userId),
+      limits: this.usageControls.getUserLimits(userId),
+      status: this.usageControls.getLimitStatus(userId, nowMs),
+    };
+  }
+
+  setUserLlmUsageLimits(
+    userId: string,
+    limits: UserLlmUsageLimitInput[],
+    updatedBy = "admin_api_key",
+  ) {
+    this.usageControls.replaceUserLimits(userId, limits, updatedBy);
+    const response = this.getUserLlmUsageLimits(userId);
+    recordObservabilityEvent(this.env, {
+      event: "user_llm_usage_limit_updated",
+      component: "org_do",
+      operation: "replace_user_llm_usage_limits",
+      status: "success",
+      orgId: response.org_id,
+      userId: response.user_id,
+      count: response.limits.length,
+    });
+    return response;
+  }
+
+  getLlmUsagePricing(): LlmPricingResponse {
+    return this.usageControls.getPricing();
+  }
+
+  setLlmUsagePricing(
+    prices: LlmModelPricingInput[],
+    updatedBy = "admin_api_key",
+  ): LlmPricingResponse {
+    const response = this.usageControls.replacePricing(prices, updatedBy);
+    recordObservabilityEvent(this.env, {
+      event: "llm_usage_pricing_updated",
+      component: "org_do",
+      operation: "replace_llm_usage_pricing",
+      status: "success",
+      orgId: response.org_id,
+      count: response.prices.length,
+    });
+    return response;
   }
 
   getUsageLimits(): OrgUsageLimits {

--- a/workers/main/src/identity/org/usage-controls.ts
+++ b/workers/main/src/identity/org/usage-controls.ts
@@ -1,0 +1,910 @@
+import {
+  lookupPricingOrNull,
+  type ModelPricing,
+} from "../../../../../src/lib/usage-pricing";
+import { usageInteger, usageText } from "../usage";
+
+export const MICRO_USD_PER_USD = 1_000_000;
+export const MAX_USER_LLM_LIMITS = 10;
+export const MIN_LIMIT_WINDOW_MS = 60_000;
+export const MAX_LIMIT_WINDOW_MS = 5 * 365 * 24 * 60 * 60 * 1000;
+
+export type UsageKind =
+  | "llm"
+  | "image"
+  | "audio"
+  | "capability"
+  | "unknown";
+
+export type UsageSurface =
+  | "agent"
+  | "subagent"
+  | "compaction"
+  | "virtual_ai"
+  | "auxiliary"
+  | "capability"
+  | "unknown";
+
+export type UsageCostSource =
+  | "provider_reported"
+  | "org_override"
+  | "builtin_pricing"
+  | "legacy_estimate"
+  | "unpriced";
+
+export interface UserLlmUsageLimitInput {
+  window_hours: number;
+  limit_usd: number;
+  label?: string | null;
+}
+
+export interface UserLlmUsageLimit {
+  window_hours: number;
+  limit_usd: number;
+  label: string | null;
+}
+
+export interface UserLlmUsageLimitStatus extends UserLlmUsageLimit {
+  spent_usd: number;
+  remaining_usd: number;
+  unpriced_requests: number;
+  exceeded: boolean;
+  retry_at_ms: number | null;
+}
+
+export type UserLlmUsageAccessReason =
+  | "no_limits"
+  | "within_limits"
+  | "limit_exceeded"
+  | "pricing_unavailable";
+
+export interface UserLlmUsageAccessResult {
+  allowed: boolean;
+  reason: UserLlmUsageAccessReason;
+  evaluated_at_ms: number;
+  blocking_limit: UserLlmUsageLimitStatus | null;
+  limits: UserLlmUsageLimitStatus[];
+}
+
+export interface CheckUserLlmUsageAccessInput {
+  user_id: string;
+  provider: string;
+  model: string;
+  now_ms?: number;
+}
+
+export interface LlmModelPricingInput {
+  provider: string;
+  model: string;
+  input_usd_per_million: number;
+  output_usd_per_million: number;
+  cache_creation_usd_per_million?: number;
+  cache_read_usd_per_million?: number;
+}
+
+export interface LlmModelPricing extends LlmModelPricingInput {
+  cache_creation_usd_per_million: number;
+  cache_read_usd_per_million: number;
+}
+
+export interface LlmPricingResponse {
+  org_id: string;
+  prices: LlmModelPricing[];
+  unpriced_models: Array<{
+    provider: string;
+    model: string;
+    last_seen_at_ms: number;
+  }>;
+}
+
+export interface UsageAggregateQuery {
+  from?: number | null;
+  to?: number | null;
+  chargeable_only?: boolean | number | null;
+  user_id?: string | null;
+  provider?: string | null;
+  model?: string | null;
+  usage_kind?: UsageKind | null;
+  usage_surface?: UsageSurface | null;
+}
+
+export interface UsageAggregateResult {
+  org_id: string;
+  total_cost_usd: number;
+  metered_cost_usd: number;
+  unpriced_requests: number;
+  total_requests: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_creation_input_tokens: number;
+  total_cache_read_input_tokens: number;
+}
+
+export interface UserLlmUsageReportQuery {
+  from: number;
+  to: number;
+  limit?: number | null;
+  cursor?: string | null;
+  user_id?: string | null;
+  now_ms?: number | null;
+}
+
+export interface UserLlmUsageTotals {
+  requests: number;
+  spend_usd: number;
+  unpriced_requests: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+}
+
+export interface UserLlmUsageModelTotals extends UserLlmUsageTotals {
+  provider: string;
+  model: string;
+}
+
+export interface UserLlmUsageSubject {
+  user_id: string | null;
+  membership_status: "current" | "former" | "unattributed";
+  totals: UserLlmUsageTotals;
+  models: UserLlmUsageModelTotals[];
+  limit_status: Pick<
+    UserLlmUsageAccessResult,
+    "allowed" | "reason" | "blocking_limit" | "limits"
+  >;
+}
+
+export interface UserLlmUsageReport {
+  org_id: string;
+  from_ms: number;
+  to_ms: number;
+  evaluated_at_ms: number;
+  users: UserLlmUsageSubject[];
+  count: number;
+  has_more: boolean;
+  next_cursor: string | null;
+}
+
+export interface StrictUsageCostInput {
+  provider: string;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+  reported_cost_usd?: number | null;
+  upstream_inference_cost_usd?: number | null;
+}
+
+export interface StrictUsageCostResult {
+  meteredCostMicrousd: number | null;
+  costSource: UsageCostSource;
+}
+
+export class UsageControlsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageControlsValidationError";
+  }
+}
+
+export interface UsageControlsContext {
+  sql: SqlStorage;
+  orgId(): string;
+  isCurrentMember(userId: string): boolean;
+  transactionSync<T>(callback: () => T): T;
+}
+
+interface LimitRow extends Record<string, SqlStorageValue> {
+  user_id: string;
+  window_ms: number;
+  limit_microusd: number;
+  label: string | null;
+}
+
+interface PricingRow extends Record<string, SqlStorageValue> {
+  provider: string;
+  model: string;
+  input_microusd_per_million: number;
+  output_microusd_per_million: number;
+  cache_creation_microusd_per_million: number;
+  cache_read_microusd_per_million: number;
+}
+
+interface LimitAggregateRow extends Record<string, SqlStorageValue> {
+  user_id: string;
+  window_ms: number;
+  spent: number;
+  unpriced: number;
+}
+
+interface LimitExpiryRow extends Record<string, SqlStorageValue> {
+  user_id: string;
+  window_ms: number;
+  retry_at_ms: number;
+}
+
+const EMPTY_TOTALS: UserLlmUsageTotals = Object.freeze({
+  requests: 0,
+  spend_usd: 0,
+  unpriced_requests: 0,
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_creation_input_tokens: 0,
+  cache_read_input_tokens: 0,
+});
+
+function finiteNonNegative(value: unknown, field: string): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    throw new UsageControlsValidationError(`${field} must be a finite non-negative number`);
+  }
+  return numeric;
+}
+
+function hasAtMostSixDecimals(value: number): boolean {
+  return isApproximatelyInteger(value * MICRO_USD_PER_USD);
+}
+
+function isApproximatelyInteger(value: number): boolean {
+  const rounded = Math.round(value);
+  const tolerance = Math.max(1e-6, Math.abs(value) * Number.EPSILON * 2);
+  return Number.isSafeInteger(rounded) && Math.abs(value - rounded) <= tolerance;
+}
+
+export function usdToMicrousd(value: number, field = "USD value"): number {
+  const numeric = finiteNonNegative(value, field);
+  if (!hasAtMostSixDecimals(numeric)) {
+    throw new UsageControlsValidationError(`${field} must have at most six decimal places`);
+  }
+  const micro = Math.round(numeric * MICRO_USD_PER_USD);
+  if (!Number.isSafeInteger(micro)) {
+    throw new UsageControlsValidationError(`${field} is too large`);
+  }
+  return micro;
+}
+
+export function microusdToUsd(value: number): number {
+  return Number((Math.max(0, Number(value) || 0) / MICRO_USD_PER_USD).toFixed(6));
+}
+
+function normalizeUsageKind(value: unknown): UsageKind {
+  return value === "llm" || value === "image" || value === "audio" ||
+    value === "capability" ? value : "unknown";
+}
+
+function normalizeUsageSurface(value: unknown): UsageSurface {
+  return value === "agent" || value === "subagent" || value === "compaction" ||
+    value === "virtual_ai" || value === "auxiliary" || value === "capability"
+    ? value
+    : "unknown";
+}
+
+export { normalizeUsageKind, normalizeUsageSurface };
+
+function pricingForInputTokens(pricing: ModelPricing, inputTokens: number): ModelPricing {
+  return pricing.tiers
+    ?.filter((tier) => inputTokens > tier.inputTokensAbove)
+    .sort((a, b) => b.inputTokensAbove - a.inputTokensAbove)[0] ?? pricing;
+}
+
+function costFromBuiltin(input: StrictUsageCostInput, pricing: ModelPricing): number {
+  const promptTokens = input.input_tokens + input.cache_creation_input_tokens + input.cache_read_input_tokens;
+  const effective = pricingForInputTokens(pricing, promptTokens);
+  return Math.round(MICRO_USD_PER_USD * (
+    input.input_tokens * effective.inputPerToken +
+    input.output_tokens * effective.outputPerToken +
+    input.cache_creation_input_tokens * (effective.cacheCreationPerToken ?? 0) +
+    input.cache_read_input_tokens * (effective.cacheReadPerToken ?? 0)
+  ));
+}
+
+function costFromOverride(input: StrictUsageCostInput, pricing: PricingRow): number {
+  const numerator =
+    input.input_tokens * Number(pricing.input_microusd_per_million) +
+    input.output_tokens * Number(pricing.output_microusd_per_million) +
+    input.cache_creation_input_tokens * Number(pricing.cache_creation_microusd_per_million) +
+    input.cache_read_input_tokens * Number(pricing.cache_read_microusd_per_million);
+  return Math.round(numerator / 1_000_000);
+}
+
+export function resolveStrictUsageCost(
+  context: Pick<UsageControlsContext, "sql">,
+  raw: StrictUsageCostInput,
+): StrictUsageCostResult {
+  const input: StrictUsageCostInput = {
+    ...raw,
+    provider: usageText(raw.provider) || "unknown",
+    model: usageText(raw.model) || "unknown",
+    input_tokens: usageInteger(raw.input_tokens),
+    output_tokens: usageInteger(raw.output_tokens),
+    cache_creation_input_tokens: usageInteger(raw.cache_creation_input_tokens),
+    cache_read_input_tokens: usageInteger(raw.cache_read_input_tokens),
+  };
+  const reported = [raw.reported_cost_usd, raw.upstream_inference_cost_usd]
+    .find((value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0);
+  if (reported !== undefined) {
+    return {
+      meteredCostMicrousd: Math.round(reported * MICRO_USD_PER_USD),
+      costSource: "provider_reported",
+    };
+  }
+  const override = context.sql.exec<PricingRow>(
+    `SELECT provider, model, input_microusd_per_million,
+            output_microusd_per_million, cache_creation_microusd_per_million,
+            cache_read_microusd_per_million
+       FROM llm_model_pricing_overrides
+      WHERE provider = ? AND model = ?`,
+    input.provider,
+    input.model,
+  ).toArray()[0];
+  if (override) {
+    return { meteredCostMicrousd: costFromOverride(input, override), costSource: "org_override" };
+  }
+  // Built-in catalog matching intentionally recognizes model families. Do not
+  // apply those broad names to an operator's custom provider/model namespace:
+  // an exact override (or provider-reported cost above) is required there.
+  const provider = input.provider.toLowerCase();
+  const model = input.model.toLowerCase();
+  const builtinProviderCompatible =
+    provider === "openrouter" ||
+    provider === "compat" ||
+    (provider === "openai" && model.includes("gpt")) ||
+    (provider === "anthropic" && model.includes("claude")) ||
+    (provider === "bedrock" && (model.includes("claude") || model.includes("gpt"))) ||
+    ((provider === "google" || provider === "vertex") && model.includes("gemini"));
+  const builtin = builtinProviderCompatible ? lookupPricingOrNull(input.model) : null;
+  if (builtin) {
+    return { meteredCostMicrousd: costFromBuiltin(input, builtin), costSource: "builtin_pricing" };
+  }
+  return { meteredCostMicrousd: null, costSource: "unpriced" };
+}
+
+function normalizeLimitInputs(inputs: UserLlmUsageLimitInput[]): Array<{
+  windowMs: number;
+  limitMicrousd: number;
+  label: string | null;
+}> {
+  if (!Array.isArray(inputs) || inputs.length > MAX_USER_LLM_LIMITS) {
+    throw new UsageControlsValidationError(`limits must contain at most ${MAX_USER_LLM_LIMITS} entries`);
+  }
+  const seen = new Set<number>();
+  const result = inputs.map((input, index) => {
+    const windowHours = finiteNonNegative(input.window_hours, `limits[${index}].window_hours`);
+    const rawWindowMs = windowHours * 60 * 60 * 1000;
+    const windowMs = Math.round(rawWindowMs);
+    if (
+      !isApproximatelyInteger(rawWindowMs) ||
+      windowMs < MIN_LIMIT_WINDOW_MS ||
+      windowMs > MAX_LIMIT_WINDOW_MS
+    ) {
+      throw new UsageControlsValidationError(`limits[${index}].window_hours must be between one minute and five years`);
+    }
+    if (seen.has(windowMs)) {
+      throw new UsageControlsValidationError(`duplicate window_hours: ${windowHours}`);
+    }
+    seen.add(windowMs);
+    const limitUsd = finiteNonNegative(input.limit_usd, `limits[${index}].limit_usd`);
+    if (limitUsd > 1_000_000_000) {
+      throw new UsageControlsValidationError(`limits[${index}].limit_usd exceeds 1000000000`);
+    }
+    return {
+      windowMs,
+      limitMicrousd: usdToMicrousd(limitUsd, `limits[${index}].limit_usd`),
+      label: usageText(input.label) || null,
+    };
+  });
+  return result.sort((a, b) => a.windowMs - b.windowMs);
+}
+
+function normalizePricingInputs(inputs: LlmModelPricingInput[]): Array<PricingRow> {
+  if (!Array.isArray(inputs) || inputs.length > 500) {
+    throw new UsageControlsValidationError("prices must contain at most 500 entries");
+  }
+  const seen = new Set<string>();
+  return inputs.map((input, index) => {
+    const provider = usageText(input.provider);
+    const model = usageText(input.model);
+    if (!provider || provider.length > 200 || !model || model.length > 200) {
+      throw new UsageControlsValidationError(`prices[${index}] provider and model must be 1-200 trimmed characters`);
+    }
+    const key = `${provider}\0${model}`;
+    if (seen.has(key)) throw new UsageControlsValidationError(`duplicate price for ${provider}/${model}`);
+    seen.add(key);
+    const rate = (value: unknown, field: string, required: boolean) => {
+      if (!required && value === undefined) return 0;
+      const numeric = finiteNonNegative(value, field);
+      if (numeric > 1_000_000) throw new UsageControlsValidationError(`${field} exceeds 1000000`);
+      return usdToMicrousd(numeric, field);
+    };
+    return {
+      provider,
+      model,
+      input_microusd_per_million: rate(input.input_usd_per_million, `prices[${index}].input_usd_per_million`, true),
+      output_microusd_per_million: rate(input.output_usd_per_million, `prices[${index}].output_usd_per_million`, true),
+      cache_creation_microusd_per_million: rate(input.cache_creation_usd_per_million, `prices[${index}].cache_creation_usd_per_million`, false),
+      cache_read_microusd_per_million: rate(input.cache_read_usd_per_million, `prices[${index}].cache_read_usd_per_million`, false),
+    };
+  }).sort((a, b) => {
+    const providerOrder = a.provider < b.provider ? -1 : a.provider > b.provider ? 1 : 0;
+    if (providerOrder !== 0) return providerOrder;
+    return a.model < b.model ? -1 : a.model > b.model ? 1 : 0;
+  });
+}
+
+function limitDto(row: LimitRow): UserLlmUsageLimit {
+  return {
+    window_hours: Number(row.window_ms) / 3_600_000,
+    limit_usd: microusdToUsd(Number(row.limit_microusd)),
+    label: typeof row.label === "string" && row.label ? row.label : null,
+  };
+}
+
+function pricingDto(row: PricingRow): LlmModelPricing {
+  return {
+    provider: String(row.provider),
+    model: String(row.model),
+    input_usd_per_million: microusdToUsd(Number(row.input_microusd_per_million)),
+    output_usd_per_million: microusdToUsd(Number(row.output_microusd_per_million)),
+    cache_creation_usd_per_million: microusdToUsd(Number(row.cache_creation_microusd_per_million)),
+    cache_read_usd_per_million: microusdToUsd(Number(row.cache_read_microusd_per_million)),
+  };
+}
+
+function encodeCursor(userId: string | null): string {
+  const encoded = btoa(JSON.stringify({ v: 1, user_id: userId }))
+    .replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+  return encoded;
+}
+
+function decodeCursor(value: string): string | null {
+  try {
+    const normalized = value.replaceAll("-", "+").replaceAll("_", "/");
+    const parsed = JSON.parse(atob(normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "="))) as unknown;
+    if (!parsed || typeof parsed !== "object" || (parsed as { v?: unknown }).v !== 1) throw new Error();
+    const userId = (parsed as { user_id?: unknown }).user_id;
+    if (userId !== null && (typeof userId !== "string" || !userId)) throw new Error();
+    return userId;
+  } catch {
+    throw new UsageControlsValidationError("cursor is malformed");
+  }
+}
+
+export function validateUserLlmUsageCursor(value: string): void {
+  decodeCursor(value);
+}
+
+function totalsFromRow(row: Record<string, SqlStorageValue> | undefined): UserLlmUsageTotals {
+  if (!row) return { ...EMPTY_TOTALS };
+  return {
+    requests: Number(row.requests ?? 0),
+    spend_usd: microusdToUsd(Number(row.spend_microusd ?? 0)),
+    unpriced_requests: Number(row.unpriced_requests ?? 0),
+    input_tokens: Number(row.input_tokens ?? 0),
+    output_tokens: Number(row.output_tokens ?? 0),
+    cache_creation_input_tokens: Number(row.cache_creation_input_tokens ?? 0),
+    cache_read_input_tokens: Number(row.cache_read_input_tokens ?? 0),
+  };
+}
+
+export class OrgUsageControls {
+  constructor(private readonly context: UsageControlsContext) {}
+
+  getUserLimits(userId: string): UserLlmUsageLimit[] {
+    return this.loadLimitRows(usageText(userId)).map(limitDto);
+  }
+
+  replaceUserLimits(userId: string, limits: UserLlmUsageLimitInput[], updatedBy: string): UserLlmUsageLimit[] {
+    const normalizedUserId = usageText(userId);
+    if (!normalizedUserId || !this.context.isCurrentMember(normalizedUserId)) {
+      throw new UsageControlsValidationError("current organization member not found");
+    }
+    const normalized = normalizeLimitInputs(limits);
+    const now = Date.now();
+    this.context.transactionSync(() => {
+      this.context.sql.exec("DELETE FROM user_llm_usage_limits WHERE user_id = ?", normalizedUserId);
+      for (const row of normalized) {
+        this.context.sql.exec(
+          `INSERT INTO user_llm_usage_limits
+             (user_id, window_ms, limit_microusd, label, created_at_ms, updated_at_ms, updated_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          normalizedUserId, row.windowMs, row.limitMicrousd, row.label, now, now,
+          usageText(updatedBy) || "admin_api_key",
+        );
+      }
+    });
+    return this.getUserLimits(normalizedUserId);
+  }
+
+  clearUserLimits(userId: string): void {
+    this.context.sql.exec("DELETE FROM user_llm_usage_limits WHERE user_id = ?", usageText(userId));
+  }
+
+  getPricing(): LlmPricingResponse {
+    const prices = this.context.sql.exec<PricingRow>(
+      `SELECT provider, model, input_microusd_per_million, output_microusd_per_million,
+              cache_creation_microusd_per_million, cache_read_microusd_per_million
+         FROM llm_model_pricing_overrides ORDER BY provider COLLATE BINARY, model COLLATE BINARY`,
+    ).toArray().map(pricingDto);
+    const since = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const unpricedModels = this.context.sql.exec<{
+      provider: string; model: string; last_seen_at_ms: number;
+    } & Record<string, SqlStorageValue>>(
+      `SELECT provider, model, MAX(created_at_ms) AS last_seen_at_ms
+         FROM usage_log
+        WHERE usage_kind = 'llm' AND metered_cost_microusd IS NULL AND created_at_ms >= ?
+        GROUP BY provider, model
+        ORDER BY last_seen_at_ms DESC, provider COLLATE BINARY, model COLLATE BINARY
+        LIMIT 100`,
+      since,
+    ).toArray().map((row) => ({
+      provider: String(row.provider), model: String(row.model), last_seen_at_ms: Number(row.last_seen_at_ms),
+    }));
+    return { org_id: this.context.orgId(), prices, unpriced_models: unpricedModels };
+  }
+
+  replacePricing(inputs: LlmModelPricingInput[], updatedBy: string): LlmPricingResponse {
+    const normalized = normalizePricingInputs(inputs);
+    const now = Date.now();
+    this.context.transactionSync(() => {
+      this.context.sql.exec("DELETE FROM llm_model_pricing_overrides");
+      for (const row of normalized) {
+        this.context.sql.exec(
+          `INSERT INTO llm_model_pricing_overrides
+             (provider, model, input_microusd_per_million, output_microusd_per_million,
+              cache_creation_microusd_per_million, cache_read_microusd_per_million,
+              created_at_ms, updated_at_ms, updated_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          row.provider, row.model, row.input_microusd_per_million,
+          row.output_microusd_per_million, row.cache_creation_microusd_per_million,
+          row.cache_read_microusd_per_million, now, now,
+          usageText(updatedBy) || "admin_api_key",
+        );
+      }
+    });
+    return this.getPricing();
+  }
+
+  resolveStrictCost(input: StrictUsageCostInput): StrictUsageCostResult {
+    return resolveStrictUsageCost(this.context, input);
+  }
+
+  checkAccess(input: CheckUserLlmUsageAccessInput): UserLlmUsageAccessResult {
+    const userId = usageText(input.user_id);
+    const now = usageInteger(input.now_ms) || Date.now();
+    const status = this.limitStatusesForUsers(userId ? [userId] : [], now).get(userId) ??
+      { allowed: true, reason: "no_limits" as const, evaluated_at_ms: now, blocking_limit: null, limits: [] };
+    if (status.reason === "no_limits") return status;
+    const requestedPricing = this.resolveStrictCost({
+      provider: input.provider,
+      model: input.model,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    });
+    if (requestedPricing.meteredCostMicrousd === null || status.reason === "pricing_unavailable") {
+      return {
+        allowed: false,
+        reason: "pricing_unavailable",
+        evaluated_at_ms: now,
+        blocking_limit: status.reason === "pricing_unavailable"
+          ? status.blocking_limit
+          : status.limits[0] ?? null,
+        limits: status.limits,
+      };
+    }
+    return status;
+  }
+
+  getLimitStatus(userId: string, nowMs = Date.now()): UserLlmUsageAccessResult {
+    const normalizedUserId = usageText(userId);
+    const now = usageInteger(nowMs) || Date.now();
+    return this.limitStatusesForUsers(normalizedUserId ? [normalizedUserId] : [], now)
+      .get(normalizedUserId) ??
+      { allowed: true, reason: "no_limits", evaluated_at_ms: now, blocking_limit: null, limits: [] };
+  }
+
+  getAggregate(query: UsageAggregateQuery = {}): UsageAggregateResult {
+    const from = usageInteger(query.from);
+    const to = usageInteger(query.to) || Date.now();
+    if (!(to > from)) {
+      throw new UsageControlsValidationError("to must be greater than from");
+    }
+    const { where, params } = this.filterWhere(query, from, to);
+    const row = this.context.sql.exec<Record<string, SqlStorageValue>>(
+      `SELECT COALESCE(SUM(cost_usd), 0) AS total_cost_usd,
+              COALESCE(SUM(metered_cost_microusd), 0) AS metered_cost_microusd,
+              SUM(CASE WHEN usage_kind = 'llm' AND metered_cost_microusd IS NULL THEN 1 ELSE 0 END) AS unpriced_requests,
+              COUNT(*) AS total_requests,
+              COALESCE(SUM(input_tokens), 0) AS total_input_tokens,
+              COALESCE(SUM(output_tokens), 0) AS total_output_tokens,
+              COALESCE(SUM(cache_creation_input_tokens), 0) AS total_cache_creation_input_tokens,
+              COALESCE(SUM(cache_read_input_tokens), 0) AS total_cache_read_input_tokens
+         FROM usage_log WHERE ${where.join(" AND ")}`,
+      ...params,
+    ).toArray()[0];
+    return {
+      org_id: this.context.orgId(),
+      total_cost_usd: Number(row?.total_cost_usd ?? 0),
+      metered_cost_usd: microusdToUsd(Number(row?.metered_cost_microusd ?? 0)),
+      unpriced_requests: Number(row?.unpriced_requests ?? 0),
+      total_requests: Number(row?.total_requests ?? 0),
+      total_input_tokens: Number(row?.total_input_tokens ?? 0),
+      total_output_tokens: Number(row?.total_output_tokens ?? 0),
+      total_cache_creation_input_tokens: Number(row?.total_cache_creation_input_tokens ?? 0),
+      total_cache_read_input_tokens: Number(row?.total_cache_read_input_tokens ?? 0),
+    };
+  }
+
+  getUserReport(query: UserLlmUsageReportQuery): UserLlmUsageReport {
+    const from = usageInteger(query.from);
+    const to = usageInteger(query.to);
+    if (!(to > from)) throw new UsageControlsValidationError("to must be greater than from");
+    const limit = Math.min(1000, Math.max(1, usageInteger(query.limit) || 100));
+    const requestedUserId = usageText(query.user_id);
+    const cursorValue = query.cursor ? decodeCursor(query.cursor) : undefined;
+    const subjects = this.subjectPage(from, to, limit + 1, requestedUserId || null, cursorValue);
+    const pageSubjects = subjects.slice(0, limit);
+    const hasMore = subjects.length > limit;
+    const userIds = pageSubjects.filter((subject) => subject.userId !== null).map((subject) => subject.userId as string);
+    const includeUnattributed = pageSubjects.some((subject) => subject.userId === null);
+    const totals = this.reportTotals(from, to, userIds, includeUnattributed);
+    const models = this.reportModels(from, to, userIds, includeUnattributed);
+    const evaluatedAt = usageInteger(query.now_ms) || Date.now();
+    const limitStatuses = this.limitStatusesForUsers(userIds, evaluatedAt);
+    const users: UserLlmUsageSubject[] = pageSubjects.map((subject) => {
+      const key = subject.userId ?? "";
+      const access = subject.userId === null
+        ? { allowed: true, reason: "no_limits" as const, blocking_limit: null, limits: [] }
+        : limitStatuses.get(subject.userId) ??
+          { allowed: true, reason: "no_limits" as const, blocking_limit: null, limits: [] };
+      const status = {
+        allowed: access.allowed,
+        reason: access.reason,
+        blocking_limit: access.blocking_limit,
+        limits: access.limits,
+      };
+      return {
+        user_id: subject.userId,
+        membership_status: subject.status,
+        totals: totals.get(key) ?? { ...EMPTY_TOTALS },
+        models: models.get(key) ?? [],
+        limit_status: status,
+      };
+    });
+    const last = pageSubjects.at(-1)?.userId;
+    return {
+      org_id: this.context.orgId(), from_ms: from, to_ms: to, evaluated_at_ms: evaluatedAt,
+      users, count: users.length, has_more: hasMore,
+      next_cursor: hasMore && last !== undefined ? encodeCursor(last) : null,
+    };
+  }
+
+  private loadLimitRows(userId: string): LimitRow[] {
+    if (!userId) return [];
+    return this.context.sql.exec<LimitRow>(
+      `SELECT user_id, window_ms, limit_microusd, label
+         FROM user_llm_usage_limits WHERE user_id = ? ORDER BY window_ms`,
+      userId,
+    ).toArray();
+  }
+
+  private limitStatusesForUsers(userIds: string[], now: number): Map<string, UserLlmUsageAccessResult> {
+    const normalizedUserIds = Array.from(new Set(userIds.map(usageText).filter(Boolean)));
+    const results = new Map<string, UserLlmUsageAccessResult>(normalizedUserIds.map((userId) => [userId, {
+      allowed: true,
+      reason: "no_limits",
+      evaluated_at_ms: now,
+      blocking_limit: null,
+      limits: [],
+    }]));
+    if (normalizedUserIds.length === 0) return results;
+
+    const encodedUserIds = JSON.stringify(normalizedUserIds);
+    const limits = this.context.sql.exec<LimitRow>(
+      `SELECT user_id, window_ms, limit_microusd, label
+         FROM user_llm_usage_limits
+        WHERE user_id IN (SELECT value FROM json_each(?))
+        ORDER BY user_id COLLATE BINARY, window_ms`,
+      encodedUserIds,
+    ).toArray();
+    if (limits.length === 0) return results;
+
+    const aggregates = this.context.sql.exec<LimitAggregateRow>(
+      `SELECT limits.user_id, limits.window_ms,
+              COALESCE(SUM(usage.metered_cost_microusd), 0) AS spent,
+              COALESCE(SUM(CASE WHEN usage.id IS NOT NULL AND usage.metered_cost_microusd IS NULL THEN 1 ELSE 0 END), 0) AS unpriced
+         FROM user_llm_usage_limits AS limits
+         LEFT JOIN usage_log AS usage
+           ON usage.user_id = limits.user_id
+          AND usage.usage_kind = 'llm'
+          AND usage.created_at_ms >= ? - limits.window_ms
+          AND usage.created_at_ms < ?
+        WHERE limits.user_id IN (SELECT value FROM json_each(?))
+        GROUP BY limits.user_id, limits.window_ms`,
+      now, now, encodedUserIds,
+    ).toArray();
+    const aggregatesByLimit = new Map(aggregates.map((row) => [
+      `${row.user_id}\0${row.window_ms}`,
+      { spent: Number(row.spent ?? 0), unpriced: Number(row.unpriced ?? 0) },
+    ]));
+    const statusesByUser = new Map<string, UserLlmUsageLimitStatus[]>();
+    const statusByLimit = new Map<string, UserLlmUsageLimitStatus>();
+    const blocked: Array<{
+      user_id: string;
+      window_ms: number;
+      spent_microusd: number;
+      limit_microusd: number;
+    }> = [];
+    for (const row of limits) {
+      const key = `${row.user_id}\0${row.window_ms}`;
+      const aggregate = aggregatesByLimit.get(key) ?? { spent: 0, unpriced: 0 };
+      const limit = Number(row.limit_microusd);
+      const status: UserLlmUsageLimitStatus = {
+        ...limitDto(row),
+        spent_usd: microusdToUsd(aggregate.spent),
+        remaining_usd: microusdToUsd(Math.max(0, limit - aggregate.spent)),
+        unpriced_requests: aggregate.unpriced,
+        exceeded: aggregate.spent >= limit,
+        retry_at_ms: null,
+      };
+      const list = statusesByUser.get(row.user_id) ?? [];
+      list.push(status);
+      statusesByUser.set(row.user_id, list);
+      statusByLimit.set(key, status);
+      if (status.exceeded && status.unpriced_requests === 0) {
+        blocked.push({
+          user_id: row.user_id,
+          window_ms: Number(row.window_ms),
+          spent_microusd: aggregate.spent,
+          limit_microusd: limit,
+        });
+      }
+    }
+
+    if (blocked.length > 0) {
+      const expiryRows = this.context.sql.exec<LimitExpiryRow>(
+        `WITH blocked AS (
+           SELECT json_extract(value, '$.user_id') AS user_id,
+                  CAST(json_extract(value, '$.window_ms') AS INTEGER) AS window_ms,
+                  CAST(json_extract(value, '$.spent_microusd') AS INTEGER) AS spent_microusd,
+                  CAST(json_extract(value, '$.limit_microusd') AS INTEGER) AS limit_microusd
+             FROM json_each(?)
+         ), expiry_candidates AS (
+           SELECT blocked.user_id, blocked.window_ms, blocked.spent_microusd,
+                  blocked.limit_microusd, usage.created_at_ms,
+                  SUM(usage.metered_cost_microusd) OVER (
+                    PARTITION BY blocked.user_id, blocked.window_ms
+                    ORDER BY usage.created_at_ms, usage.id
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                  ) AS expired_microusd
+             FROM blocked
+             JOIN usage_log AS usage
+               ON usage.user_id = blocked.user_id
+              AND usage.usage_kind = 'llm'
+              AND usage.metered_cost_microusd IS NOT NULL
+              AND usage.created_at_ms >= ? - blocked.window_ms
+              AND usage.created_at_ms < ?
+         )
+         SELECT user_id, window_ms, MIN(created_at_ms + window_ms + 1) AS retry_at_ms
+           FROM expiry_candidates
+          WHERE spent_microusd - expired_microusd < limit_microusd
+          GROUP BY user_id, window_ms`,
+        JSON.stringify(blocked), now, now,
+      ).toArray();
+      for (const row of expiryRows) {
+        const key = `${row.user_id}\0${row.window_ms}`;
+        const status = statusByLimit.get(key);
+        if (status) status.retry_at_ms = Number(row.retry_at_ms);
+      }
+    }
+
+    for (const userId of normalizedUserIds) {
+      const statuses = statusesByUser.get(userId) ?? [];
+      if (statuses.length === 0) continue;
+      const unpriced = statuses.find((status) => status.unpriced_requests > 0) ?? null;
+      const exceeded = statuses
+        .filter((status) => status.exceeded)
+        .reduce<UserLlmUsageLimitStatus | null>((blocking, candidate) => {
+          if (!blocking) return candidate;
+          // A null retry means configuration must change (for example a zero
+          // cap with no rows to age out), so it dominates any finite expiry.
+          if (blocking.retry_at_ms === null) return blocking;
+          if (candidate.retry_at_ms === null) return candidate;
+          return candidate.retry_at_ms > blocking.retry_at_ms ? candidate : blocking;
+        }, null);
+      results.set(userId, {
+        allowed: !unpriced && !exceeded,
+        reason: unpriced ? "pricing_unavailable" : exceeded ? "limit_exceeded" : "within_limits",
+        evaluated_at_ms: now,
+        blocking_limit: unpriced ?? exceeded,
+        limits: statuses,
+      });
+    }
+    return results;
+  }
+
+  private filterWhere(query: UsageAggregateQuery, from: number, to: number): { where: string[]; params: Array<string | number> } {
+    const where = ["created_at_ms >= ?", "created_at_ms < ?"];
+    const params: Array<string | number> = [from, to];
+    const exact: Array<[string, unknown]> = [
+      ["user_id", query.user_id], ["provider", query.provider], ["model", query.model],
+      ["usage_kind", query.usage_kind], ["usage_surface", query.usage_surface],
+    ];
+    for (const [column, value] of exact) {
+      if (typeof value === "string") { where.push(`${column} = ?`); params.push(value.trim()); }
+    }
+    if (query.chargeable_only === true || query.chargeable_only === 1) where.push("credit_chargeable = 1");
+    return { where, params };
+  }
+
+  private subjectPage(from: number, to: number, limit: number, requestedUserId: string | null, cursor: string | null | undefined): Array<{ userId: string | null; status: "current" | "former" | "unattributed" }> {
+    const rows = this.context.sql.exec<{ user_id: string; current_member: number } & Record<string, SqlStorageValue>>(
+      `WITH subjects(user_id) AS (
+         SELECT user_id FROM members
+         UNION
+         SELECT DISTINCT user_id FROM usage_log
+          WHERE usage_kind = 'llm' AND created_at_ms >= ? AND created_at_ms < ?
+       )
+       SELECT subjects.user_id, CASE WHEN members.user_id IS NULL THEN 0 ELSE 1 END AS current_member
+         FROM subjects LEFT JOIN members ON members.user_id = subjects.user_id
+        WHERE (? = '' OR subjects.user_id = ?)
+          AND (${cursor === undefined ? "1 = 1" : cursor === null ? "subjects.user_id != ''" : "subjects.user_id > ?"})
+        ORDER BY CASE WHEN subjects.user_id = '' THEN 0 ELSE 1 END, subjects.user_id COLLATE BINARY
+        LIMIT ?`,
+      from, to, requestedUserId ?? "", requestedUserId ?? "",
+      ...(cursor !== undefined && cursor !== null ? [cursor] : []), limit,
+    ).toArray();
+    return rows.map((row) => ({
+      userId: row.user_id === "" ? null : String(row.user_id),
+      status: row.user_id === "" ? "unattributed" : Number(row.current_member) === 1 ? "current" : "former",
+    }));
+  }
+
+  private reportTotals(from: number, to: number, userIds: string[], unattributed: boolean): Map<string, UserLlmUsageTotals> {
+    const clauses: string[] = [];
+    const params: Array<string | number> = [from, to];
+    if (userIds.length) { clauses.push("user_id IN (SELECT value FROM json_each(?))"); params.push(JSON.stringify(userIds)); }
+    if (unattributed) clauses.push("user_id = ''");
+    if (!clauses.length) return new Map();
+    const rows = this.context.sql.exec<Record<string, SqlStorageValue>>(
+      `SELECT user_id, COUNT(*) AS requests, COALESCE(SUM(metered_cost_microusd), 0) AS spend_microusd,
+              SUM(CASE WHEN metered_cost_microusd IS NULL THEN 1 ELSE 0 END) AS unpriced_requests,
+              COALESCE(SUM(input_tokens), 0) AS input_tokens, COALESCE(SUM(output_tokens), 0) AS output_tokens,
+              COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+              COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens
+         FROM usage_log WHERE usage_kind = 'llm' AND created_at_ms >= ? AND created_at_ms < ?
+          AND (${clauses.join(" OR ")}) GROUP BY user_id`, ...params,
+    ).toArray();
+    return new Map(rows.map((row) => [String(row.user_id ?? ""), totalsFromRow(row)]));
+  }
+
+  private reportModels(from: number, to: number, userIds: string[], unattributed: boolean): Map<string, UserLlmUsageModelTotals[]> {
+    const clauses: string[] = [];
+    const params: Array<string | number> = [from, to];
+    if (userIds.length) { clauses.push("user_id IN (SELECT value FROM json_each(?))"); params.push(JSON.stringify(userIds)); }
+    if (unattributed) clauses.push("user_id = ''");
+    if (!clauses.length) return new Map();
+    const rows = this.context.sql.exec<Record<string, SqlStorageValue>>(
+      `SELECT user_id, provider, model, COUNT(*) AS requests,
+              COALESCE(SUM(metered_cost_microusd), 0) AS spend_microusd,
+              SUM(CASE WHEN metered_cost_microusd IS NULL THEN 1 ELSE 0 END) AS unpriced_requests,
+              COALESCE(SUM(input_tokens), 0) AS input_tokens, COALESCE(SUM(output_tokens), 0) AS output_tokens,
+              COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+              COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens
+         FROM usage_log WHERE usage_kind = 'llm' AND created_at_ms >= ? AND created_at_ms < ?
+          AND (${clauses.join(" OR ")}) GROUP BY user_id, provider, model
+          ORDER BY user_id COLLATE BINARY, provider COLLATE BINARY, model COLLATE BINARY`, ...params,
+    ).toArray();
+    const result = new Map<string, UserLlmUsageModelTotals[]>();
+    for (const row of rows) {
+      const key = String(row.user_id ?? "");
+      const list = result.get(key) ?? [];
+      list.push({ provider: String(row.provider), model: String(row.model), ...totalsFromRow(row) });
+      result.set(key, list);
+    }
+    return result;
+  }
+}

--- a/workers/main/src/identity/user-do.ts
+++ b/workers/main/src/identity/user-do.ts
@@ -246,99 +246,15 @@ export interface ProxyUsageInput {
   cache_read_input_tokens?: number;
 }
 
-export interface UsageRecordInput {
-  workspace_id?: string | null;
-  user_id?: string | null;
-  thread_id?: string | null;
-  model: string;
-  provider: string;
-  billing_source?: string | null;
-  credit_chargeable?: boolean | number | null;
-  input_tokens?: number | null;
-  output_tokens?: number | null;
-  cache_creation_input_tokens?: number | null;
-  cache_read_input_tokens?: number | null;
-  cost_usd?: number | null;
-  reported_cost_usd?: number | null;
-  upstream_inference_cost_usd?: number | null;
-  duration_ms?: number | null;
-  created_at_ms?: number | null;
-  source?: string | null;
-  source_id?: string | null;
-}
-
-export interface UsageLogQuery {
-  limit?: number | null;
-  cursor?: string | null;
-  from?: number | null;
-  to?: number | null;
-  chargeable_only?: boolean | number | null;
-}
-
-export interface UsageLogEntry {
-  [key: string]: SqlStorageValue;
-  id: number;
-  workspace_id: string;
-  user_id: string;
-  thread_id: string;
-  model: string;
-  provider: string;
-  billing_source: string;
-  credit_chargeable: number;
-  input_tokens: number;
-  output_tokens: number;
-  cache_creation_input_tokens: number;
-  cache_read_input_tokens: number;
-  cost_usd: number;
-  duration_ms: number;
-  created_at_ms: number;
-  source: string;
-  source_id: string;
-}
-
-export interface UsageLogPage {
-  org_id: string;
-  entries: UsageLogEntry[];
-  count: number;
-  has_more: boolean;
-  next_cursor: string | null;
-}
-
-export interface UsageLogSum {
-  org_id: string;
-  total_cost_usd: number;
-  total_requests: number;
-  total_input_tokens: number;
-  total_output_tokens: number;
-  total_cache_creation_input_tokens: number;
-  total_cache_read_input_tokens: number;
-}
-
-export interface OrgUsageSpend {
-  org_id: string;
-  total_cost_usd: number;
-  total_requests: number;
-  total_input_tokens: number;
-  total_output_tokens: number;
-  total_cache_creation_input_tokens: number;
-  total_cache_read_input_tokens: number;
-  windows: Array<{
-    label: string;
-    window_ms: number;
-    limit_usd: number;
-    spent_usd: number;
-    exceeded: boolean;
-  }>;
-}
-
-export interface OrgUsageLimits {
-  org_id: string;
-  limits: Array<{
-    window_hours: number;
-    limit_usd: number;
-    label?: string;
-  }>;
-}
+export type {
+  UsageRecordInput,
+  UsageLogQuery,
+  UsageLogEntry,
+  UsageLogPage,
+  UsageLogSum,
+  OrgUsageSpend,
+  OrgUsageLimits,
+} from "./org-do";
 
 export interface OrgBillingStateUpdate {
   billing_status?: BillingStatus;

--- a/workers/main/src/routes/admin-mcp.ts
+++ b/workers/main/src/routes/admin-mcp.ts
@@ -69,6 +69,9 @@ const TOOL_GET_BAN = "get_ban";
 const TOOL_BLOCK_SIGNUP_IP = "block_signup_ip";
 const TOOL_UNBLOCK_SIGNUP_IP = "unblock_signup_ip";
 const TOOL_GET_ORG_USAGE = "get_org_usage";
+const TOOL_GET_USER_LLM_LIMITS = "get_user_llm_limits";
+const TOOL_SET_USER_LLM_LIMITS = "set_user_llm_limits";
+const TOOL_SET_LLM_USAGE_PRICING = "set_llm_usage_pricing";
 const TOOL_GRANT_ORG_CREDITS = "grant_org_credits";
 const TOOL_SET_USER_CREDITS = "set_user_credits";
 const TOOL_ADMIN_JS_EXEC = "admin_js_exec";
@@ -512,18 +515,132 @@ function adminTools() {
     },
     {
       name: TOOL_GET_ORG_USAGE,
-      description: "Get org usage data: spend, limits, recent log entries, or a summed date range.",
+      description: "Get org usage data: spend, legacy limits, per-pull logs, filtered sums, per-user/model totals, or strict pricing.",
+      inputSchema: {
+        type: "object",
+        oneOf: [
+          ...["spend", "limits", "pricing"].map((view) => ({
+            type: "object",
+            properties: {
+              org_id: { type: "string" },
+              view: { type: "string", const: view },
+            },
+            required: ["org_id", "view"],
+            additionalProperties: false,
+          })),
+          {
+            type: "object",
+            properties: {
+              org_id: { type: "string" },
+              view: { type: "string", const: "log" },
+              limit: { type: "integer", minimum: 1, maximum: 1000 },
+              cursor: { type: "string" },
+              from: { type: "integer", minimum: 0, description: "Optional start timestamp in milliseconds (inclusive)." },
+              to: { type: "integer", minimum: 0, description: "Optional end timestamp in milliseconds (exclusive)." },
+              user_id: { type: "string" },
+              provider: { type: "string" },
+              model: { type: "string" },
+              usage_kind: { type: "string", enum: ["llm", "image", "audio", "capability", "unknown"] },
+              usage_surface: { type: "string", enum: ["agent", "subagent", "compaction", "virtual_ai", "auxiliary", "capability", "unknown"] },
+            },
+            required: ["org_id", "view"],
+            additionalProperties: false,
+          },
+          {
+            type: "object",
+            properties: {
+              org_id: { type: "string" },
+              view: { type: "string", const: "log_sum" },
+              from: { type: "integer", minimum: 0, description: "Start timestamp in milliseconds (inclusive)." },
+              to: { type: "integer", minimum: 0, description: "End timestamp in milliseconds (exclusive)." },
+              chargeable_only: { type: "boolean" },
+              user_id: { type: "string" },
+              provider: { type: "string" },
+              model: { type: "string" },
+              usage_kind: { type: "string", enum: ["llm", "image", "audio", "capability", "unknown"] },
+              usage_surface: { type: "string", enum: ["agent", "subagent", "compaction", "virtual_ai", "auxiliary", "capability", "unknown"] },
+            },
+            required: ["org_id", "view", "from", "to"],
+            additionalProperties: false,
+          },
+          {
+            type: "object",
+            properties: {
+              org_id: { type: "string" },
+              view: { type: "string", const: "users" },
+              from: { type: "integer", minimum: 0, description: "Start timestamp in milliseconds (inclusive)." },
+              to: { type: "integer", minimum: 0, description: "End timestamp in milliseconds (exclusive)." },
+              limit: { type: "integer", minimum: 1, maximum: 1000 },
+              cursor: { type: "string" },
+              user_id: { type: "string" },
+            },
+            required: ["org_id", "view", "from", "to"],
+            additionalProperties: false,
+          },
+        ],
+      },
+    },
+    {
+      name: TOOL_GET_USER_LLM_LIMITS,
+      description: "Get one current organization member's rolling LLM spend limits and live status.",
+      inputSchema: {
+        type: "object",
+        properties: { org_id: { type: "string" }, user_id: { type: "string" } },
+        required: ["org_id", "user_id"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_SET_USER_LLM_LIMITS,
+      description: "Replace one current member's rolling LLM spend limits. Pass an empty limits array to clear them.",
       inputSchema: {
         type: "object",
         properties: {
           org_id: { type: "string" },
-          view: { type: "string", enum: ["spend", "limits", "log", "log_sum"] },
-          limit: { type: "number", minimum: 1, maximum: 1000 },
-          cursor: { type: "string" },
-          from: { type: "number", description: "Start timestamp in milliseconds." },
-          to: { type: "number", description: "End timestamp in milliseconds." },
+          user_id: { type: "string" },
+          limits: {
+            type: "array", maxItems: 10,
+            items: {
+              type: "object",
+              properties: {
+                window_hours: { type: "number", minimum: 1 / 60, maximum: 5 * 365 * 24 },
+                limit_usd: { type: "number", minimum: 0, maximum: 1_000_000_000 },
+                label: { type: ["string", "null"] },
+              },
+              required: ["window_hours", "limit_usd"],
+              additionalProperties: false,
+            },
+          },
         },
-        required: ["org_id", "view"],
+        required: ["org_id", "user_id", "limits"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_SET_LLM_USAGE_PRICING,
+      description: "Replace all exact provider/model pricing overrides used by per-user LLM limits.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          org_id: { type: "string" },
+          prices: {
+            type: "array", maxItems: 500,
+            items: {
+              type: "object",
+              properties: {
+                provider: { type: "string", maxLength: 200 },
+                model: { type: "string", maxLength: 200 },
+                input_usd_per_million: { type: "number", minimum: 0, maximum: 1_000_000 },
+                output_usd_per_million: { type: "number", minimum: 0, maximum: 1_000_000 },
+                cache_creation_usd_per_million: { type: "number", minimum: 0, maximum: 1_000_000 },
+                cache_read_usd_per_million: { type: "number", minimum: 0, maximum: 1_000_000 },
+              },
+              required: ["provider", "model", "input_usd_per_million", "output_usd_per_million"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ["org_id", "prices"],
         additionalProperties: false,
       },
     },
@@ -2454,17 +2571,50 @@ async function callTool(
       return fetchAdminApiTool(req, env, grant, {
         method: "GET",
         path: `/api/admin/orgs/${encodedOrgId}/usage/log`,
-        query: pickQuery(input, ["limit", "cursor", "from", "to"]),
+        query: pickQuery(input, ["limit", "cursor", "from", "to", "user_id", "provider", "model", "usage_kind", "usage_surface"]),
       });
     }
     if (view === "log_sum") {
       return fetchAdminApiTool(req, env, grant, {
         method: "GET",
         path: `/api/admin/orgs/${encodedOrgId}/usage/log/sum`,
-        query: pickQuery(input, ["from", "to"]),
+        query: pickQuery(input, ["from", "to", "chargeable_only", "user_id", "provider", "model", "usage_kind", "usage_surface"]),
       });
     }
-    return toolText({ error: "view must be one of spend, limits, log, or log_sum" }, true);
+    if (view === "users") {
+      return fetchAdminApiTool(req, env, grant, {
+        method: "GET",
+        path: `/api/admin/orgs/${encodedOrgId}/usage/users`,
+        query: pickQuery(input, ["from", "to", "limit", "cursor", "user_id"]),
+      });
+    }
+    if (view === "pricing") {
+      return fetchAdminApiTool(req, env, grant, {
+        method: "GET",
+        path: `/api/admin/orgs/${encodedOrgId}/usage/pricing`,
+      });
+    }
+    return toolText({ error: "view must be one of spend, limits, log, log_sum, users, or pricing" }, true);
+  }
+  if (name === TOOL_GET_USER_LLM_LIMITS || name === TOOL_SET_USER_LLM_LIMITS) {
+    const orgId = requiredStringArg(input, "org_id");
+    if (typeof orgId !== "string") return toolText(orgId, true);
+    const userId = requiredStringArg(input, "user_id");
+    if (typeof userId !== "string") return toolText(userId, true);
+    return fetchAdminApiTool(req, env, grant, {
+      method: name === TOOL_GET_USER_LLM_LIMITS ? "GET" : "PUT",
+      path: `/api/admin/orgs/${encodeURIComponent(orgId)}/usage/users/${encodeURIComponent(userId)}/limits`,
+      ...(name === TOOL_SET_USER_LLM_LIMITS ? { body: pickBody(input, ["limits"]) } : {}),
+    });
+  }
+  if (name === TOOL_SET_LLM_USAGE_PRICING) {
+    const orgId = requiredStringArg(input, "org_id");
+    if (typeof orgId !== "string") return toolText(orgId, true);
+    return fetchAdminApiTool(req, env, grant, {
+      method: "PUT",
+      path: `/api/admin/orgs/${encodeURIComponent(orgId)}/usage/pricing`,
+      body: pickBody(input, ["prices"]),
+    });
   }
   if (name === TOOL_GRANT_ORG_CREDITS) {
     return grantOrgCreditsTool(env, grant, input);

--- a/workers/main/src/routes/admin/index.ts
+++ b/workers/main/src/routes/admin/index.ts
@@ -28,6 +28,9 @@
  *   POST  /api/admin/orgs/:id/credits      — Grant org credits manually
  *   POST  /api/admin/orgs/:id/custom-domain/refresh — Refresh org custom domain hostnames
  *   POST  /api/admin/orgs/:id/members      — Add member to org
+ *   GET   /api/admin/orgs/:id/usage/users  — Per-user/model LLM usage
+ *   GET/PUT /api/admin/orgs/:id/usage/users/:userId/limits — Rolling user limits
+ *   GET/PUT /api/admin/orgs/:id/usage/pricing — Exact model pricing overrides
  *   PUT   /api/admin/signup-blocked-ips/:ip — Block signup attempts from an IP
  *   DELETE /api/admin/signup-blocked-ips/:ip — Remove an IP from the signup blocklist
  *   PATCH /api/admin/threads/:id           — Update thread
@@ -108,8 +111,11 @@ export async function handleAdminApi({ req, env }: RouteContext): Promise<Respon
     });
   }
 
-  // Auth passed → delegate to Hono
-  return app.fetch(req, env);
+  // This header is reserved for the already-authorized OAuth MCP bridge. A
+  // bearer-key caller must not be able to forge the audit principal.
+  const headers = new Headers(req.headers);
+  headers.delete('x-admin-mcp-user-id');
+  return app.fetch(new Request(req, { headers }), env);
 }
 
 /**

--- a/workers/main/src/routes/admin/routes.ts
+++ b/workers/main/src/routes/admin/routes.ts
@@ -99,11 +99,20 @@ import {
   DashboardRetentionQuerySchema,
   DashboardRetentionResponseSchema,
   SetOrgLimitsBodySchema,
+  SetUserLlmLimitsBodySchema,
+  UserLlmLimitsResponseSchema,
+  SetLlmPricingBodySchema,
+  LlmPricingResponseSchema,
+  UserLlmUsageReportSchema,
   EmailDomainBlocklistSchema,
   AddEmailDomainBodySchema,
   paginatedList,
   dataList,
 } from "./schemas.js";
+import {
+  UsageControlsValidationError,
+  validateUserLlmUsageCursor,
+} from "../../identity/org/usage-controls.js";
 import {
   fetchOrgUsageAnalytics,
   fetchSpamOrgIds,
@@ -215,6 +224,7 @@ type AdminOrgDirectoryLookup = {
     limit: number;
   }>;
   getUsersByOrgIds(orgIds: string[]): Promise<AdminUserSummaryRow[]>;
+  getUsersByIds(userIds: string[]): Promise<AdminUserSummaryRow[]>;
   getThreadsByOrgIds(orgIds: string[]): Promise<AdminThreadListRow[]>;
   getAppsByOrgIds(orgIds: string[]): Promise<AdminAppListRow[]>;
 };
@@ -2730,6 +2740,156 @@ routes.put(
 );
 
 // ---------------------------------------------------------------------------
+// Per-user LLM usage, rolling limits, and strict pricing
+// ---------------------------------------------------------------------------
+
+routes.get(
+  "/orgs/:id/usage/users",
+  openApi({
+    summary: "Per-user LLM usage grouped by provider and model",
+    description: "Rolling limits are stop-new-pull soft caps: an accepted pull may cross a limit and concurrently in-flight pulls may settle afterward.",
+    request: {
+      query: z.object({
+        from: z.coerce.number().int().min(0),
+        to: z.coerce.number().int().min(0),
+        limit: z.coerce.number().int().min(1).max(1000).optional().default(100),
+        cursor: z.string().optional(),
+        user_id: z.string().trim().min(1).optional(),
+      }),
+    },
+    responses: { 200: UserLlmUsageReportSchema, 400: ErrorSchema, 404: ErrorSchema, 502: ErrorSchema },
+  }),
+  async (c) => {
+    const orgId = c.req.param("id");
+    const query = c.req.valid("query");
+    if (query.to <= query.from) return c.json({ error: "to must be greater than from" }, 400);
+    if (query.cursor) {
+      try {
+        validateUserLlmUsageCursor(query.cursor);
+      } catch (error) {
+        return c.json({ error: error instanceof Error ? error.message : "cursor is malformed" }, 400);
+      }
+    }
+    try {
+      const orgStub = getOrgStub(c.env, orgId);
+      if (!(await orgStub.getInfo())) return c.json({ error: "Organization not found" }, 404);
+      const report = await orgStub.getUserLlmUsageReport(query);
+      let directory = new Map<string, { name: string | null; email: string | null }>();
+      try {
+        const adminIndex = getAdminIndexStub(c.env) as unknown as AdminOrgDirectoryLookup;
+        const users = await adminIndex.getUsersByIds(
+          report.users.flatMap((user) => user.user_id ? [user.user_id] : []),
+        );
+        directory = new Map(users.map((user) => [user.id, {
+          name: typeof user.name === "string" ? user.name : null,
+          email: typeof user.email === "string" ? user.email : null,
+        }]));
+      } catch {
+        // Directory enrichment is best effort; accounting remains authoritative.
+      }
+      return c.json({
+        ...report,
+        users: report.users.map((user) => ({
+          ...user,
+          name: user.user_id ? directory.get(user.user_id)?.name ?? null : null,
+          email: user.user_id ? directory.get(user.user_id)?.email ?? null : null,
+        })),
+      });
+    } catch (error) {
+      if (error instanceof UsageControlsValidationError) return c.json({ error: error.message }, 400);
+      return c.json({ error: error instanceof Error ? error.message : "Usage service unavailable" }, 502);
+    }
+  },
+);
+
+routes.get(
+  "/orgs/:id/usage/users/:userId/limits",
+  openApi({
+    summary: "Get one member's rolling LLM spend limits and current status",
+    responses: { 200: UserLlmLimitsResponseSchema, 404: ErrorSchema, 502: ErrorSchema },
+  }),
+  async (c) => {
+    try {
+      const orgStub = getOrgStub(c.env, c.req.param("id"));
+      const userId = c.req.param("userId");
+      if (!(await orgStub.getInfo()) || !(await orgStub.isMember(userId))) {
+        return c.json({ error: "Organization or current member not found" }, 404);
+      }
+      return c.json(await orgStub.getUserLlmUsageLimits(userId));
+    } catch (error) {
+      return c.json({ error: error instanceof Error ? error.message : "Usage service unavailable" }, 502);
+    }
+  },
+);
+
+routes.put(
+  "/orgs/:id/usage/users/:userId/limits",
+  openApi({
+    summary: "Atomically replace one member's rolling LLM spend limits",
+    description: "An empty limits array clears the policy. Limits stop later pulls after settled spend reaches the cap; they do not reserve an in-flight pull's unknown final cost.",
+    request: { json: SetUserLlmLimitsBodySchema },
+    responses: { 200: UserLlmLimitsResponseSchema, 400: ErrorSchema, 404: ErrorSchema, 502: ErrorSchema },
+  }),
+  async (c) => {
+    try {
+      const orgStub = getOrgStub(c.env, c.req.param("id"));
+      const userId = c.req.param("userId");
+      if (!(await orgStub.getInfo()) || !(await orgStub.isMember(userId))) {
+        return c.json({ error: "Organization or current member not found" }, 404);
+      }
+      return c.json(await orgStub.setUserLlmUsageLimits(
+        userId,
+        c.req.valid("json").limits,
+        c.req.header("x-admin-mcp-user-id")?.trim() || "admin_api_key",
+      ));
+    } catch (error) {
+      if (error instanceof UsageControlsValidationError) return c.json({ error: error.message }, 400);
+      return c.json({ error: error instanceof Error ? error.message : "Usage service unavailable" }, 502);
+    }
+  },
+);
+
+routes.get(
+  "/orgs/:id/usage/pricing",
+  openApi({
+    summary: "Get strict LLM pricing overrides and recently unpriced models",
+    responses: { 200: LlmPricingResponseSchema, 404: ErrorSchema, 502: ErrorSchema },
+  }),
+  async (c) => {
+    try {
+      const orgStub = getOrgStub(c.env, c.req.param("id"));
+      if (!(await orgStub.getInfo())) return c.json({ error: "Organization not found" }, 404);
+      return c.json(await orgStub.getLlmUsagePricing());
+    } catch (error) {
+      return c.json({ error: error instanceof Error ? error.message : "Usage service unavailable" }, 502);
+    }
+  },
+);
+
+routes.put(
+  "/orgs/:id/usage/pricing",
+  openApi({
+    summary: "Atomically replace exact provider/model LLM pricing overrides",
+    description: "Pricing changes affect future usage rows only. Limited users fail closed when a requested model or an active-window row is unpriced.",
+    request: { json: SetLlmPricingBodySchema },
+    responses: { 200: LlmPricingResponseSchema, 400: ErrorSchema, 404: ErrorSchema, 502: ErrorSchema },
+  }),
+  async (c) => {
+    try {
+      const orgStub = getOrgStub(c.env, c.req.param("id"));
+      if (!(await orgStub.getInfo())) return c.json({ error: "Organization not found" }, 404);
+      return c.json(await orgStub.setLlmUsagePricing(
+        c.req.valid("json").prices,
+        c.req.header("x-admin-mcp-user-id")?.trim() || "admin_api_key",
+      ));
+    } catch (error) {
+      if (error instanceof UsageControlsValidationError) return c.json({ error: error.message }, 400);
+      return c.json({ error: error instanceof Error ? error.message : "Usage service unavailable" }, 502);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
 // GET /orgs/:id/usage/log
 // ---------------------------------------------------------------------------
 
@@ -2740,7 +2900,10 @@ routes.get(
     request: {
       query: z.object({
         limit: z.coerce.number().int().min(1).max(1000).optional(),
-        cursor: z.string().optional(),
+        cursor: z.string()
+          .regex(/^[1-9]\d*$/, "cursor must be a positive integer")
+          .refine((value) => Number.isSafeInteger(Number(value)), "cursor must be a safe integer")
+          .optional(),
         from: z.coerce
           .number()
           .int()
@@ -2753,19 +2916,36 @@ routes.get(
           .min(0)
           .optional()
           .describe("End timestamp (ms since epoch, exclusive)"),
+        user_id: z.string().optional(),
+        provider: z.string().optional(),
+        model: z.string().optional(),
+        usage_kind: z.enum(["llm", "image", "audio", "capability", "unknown"]).optional(),
+        usage_surface: z.enum(["agent", "subagent", "compaction", "virtual_ai", "auxiliary", "capability", "unknown"]).optional(),
       }),
     },
     responses: {
       200: OrgUsageLogSchema,
+      400: ErrorSchema,
+      404: ErrorSchema,
       502: ErrorSchema,
     },
   }),
   async (c) => {
     const orgId = c.req.param("id");
-    const { limit, cursor, from, to } = c.req.valid("query");
-    return c.json(
-      await getOrgStub(c.env, orgId).getUsageLog({ limit, cursor, from, to }),
-    );
+    const { limit, cursor, from, to, user_id, provider, model, usage_kind, usage_surface } = c.req.valid("query");
+    if (from !== undefined && to !== undefined && to <= from) {
+      return c.json({ error: "to must be greater than from" }, 400);
+    }
+    try {
+      const orgStub = getOrgStub(c.env, orgId);
+      if (!(await orgStub.getInfo())) return c.json({ error: "Organization not found" }, 404);
+      return c.json(await orgStub.getUsageLog({
+        limit, cursor, from, to, user_id, provider, model, usage_kind, usage_surface,
+      }));
+    } catch (error) {
+      if (error instanceof UsageControlsValidationError) return c.json({ error: error.message }, 400);
+      return c.json({ error: error instanceof Error ? error.message : "Usage service unavailable" }, 502);
+    }
   },
 );
 
@@ -2800,23 +2980,39 @@ routes.get(
             }
             return value;
           }, z.boolean().optional()),
+        user_id: z.string().optional(),
+        provider: z.string().optional(),
+        model: z.string().optional(),
+        usage_kind: z.enum(["llm", "image", "audio", "capability", "unknown"]).optional(),
+        usage_surface: z.enum(["agent", "subagent", "compaction", "virtual_ai", "auxiliary", "capability", "unknown"]).optional(),
       }),
     },
     responses: {
       200: OrgUsageLogSumSchema,
+      400: ErrorSchema,
+      404: ErrorSchema,
       502: ErrorSchema,
     },
   }),
   async (c) => {
     const orgId = c.req.param("id");
-    const { from, to, chargeable_only } = c.req.valid("query");
-    return c.json(
-      await getOrgStub(c.env, orgId).getUsageLogSum(
-        from,
-        to,
-        chargeable_only === true,
-      ),
-    );
+    const { from, to, chargeable_only, user_id, provider, model, usage_kind, usage_surface } = c.req.valid("query");
+    if (to <= from) return c.json({ error: "to must be greater than from" }, 400);
+    try {
+      const orgStub = getOrgStub(c.env, orgId);
+      if (!(await orgStub.getInfo())) return c.json({ error: "Organization not found" }, 404);
+      return c.json({
+        ...await orgStub.getUsageLogAggregate({
+          from, to, chargeable_only: chargeable_only === true,
+          user_id, provider, model, usage_kind, usage_surface,
+        }),
+        from_ms: from,
+        to_ms: to,
+      });
+    } catch (error) {
+      if (error instanceof UsageControlsValidationError) return c.json({ error: error.message }, 400);
+      return c.json({ error: error instanceof Error ? error.message : "Usage service unavailable" }, 502);
+    }
   },
 );
 

--- a/workers/main/src/routes/admin/schemas.ts
+++ b/workers/main/src/routes/admin/schemas.ts
@@ -874,9 +874,9 @@ export const DashboardRetentionResponseSchema = z.object({
 });
 
 const SpendLimitSchema = z.object({
-  window: z.number(),
+  window_hours: z.number(),
   limit_usd: z.number(),
-  label: z.string(),
+  label: z.string().nullable().optional(),
 });
 
 export const OrgUsageLimitsSchema = z.object({
@@ -894,6 +894,127 @@ export const SetOrgLimitsBodySchema = z.object({
   ),
 });
 
+function isApproximatelyInteger(value: number): boolean {
+  const rounded = Math.round(value);
+  const tolerance = Math.max(1e-6, Math.abs(value) * Number.EPSILON * 2);
+  return Number.isSafeInteger(rounded) && Math.abs(value - rounded) <= tolerance;
+}
+
+const SixDecimalUsdSchema = z.number().finite().nonnegative().refine(
+  (value) => isApproximatelyInteger(value * 1_000_000),
+  "must have at most six decimal places",
+);
+
+export const UserLlmLimitInputSchema = z.object({
+  window_hours: z.number().finite().min(1 / 60).max(5 * 365 * 24).refine(
+    (value) => {
+      const rawMilliseconds = value * 60 * 60 * 1000;
+      return isApproximatelyInteger(rawMilliseconds);
+    },
+    "must resolve to a whole number of milliseconds",
+  ),
+  limit_usd: SixDecimalUsdSchema.max(1_000_000_000),
+  label: z.string().trim().max(200).nullable().optional(),
+});
+
+export const SetUserLlmLimitsBodySchema = z.object({
+  limits: z.array(UserLlmLimitInputSchema).max(10).superRefine((limits, ctx) => {
+    const seen = new Set<number>();
+    limits.forEach((limit, index) => {
+      const windowMs = Math.round(limit.window_hours * 60 * 60 * 1000);
+      if (seen.has(windowMs)) {
+        ctx.addIssue({ code: "custom", message: "duplicate window_hours", path: [index, "window_hours"] });
+      }
+      seen.add(windowMs);
+    });
+  }),
+});
+
+export const UserLlmLimitStatusSchema = UserLlmLimitInputSchema.extend({
+  label: z.string().nullable(),
+  spent_usd: z.number(),
+  remaining_usd: z.number(),
+  unpriced_requests: z.number().int(),
+  exceeded: z.boolean(),
+  retry_at_ms: z.number().int().nullable(),
+});
+
+const UserLlmAccessStatusSchema = z.object({
+  allowed: z.boolean(),
+  reason: z.enum(["no_limits", "within_limits", "limit_exceeded", "pricing_unavailable"]),
+  evaluated_at_ms: z.number().int().optional(),
+  blocking_limit: UserLlmLimitStatusSchema.nullable().optional(),
+  limits: z.array(UserLlmLimitStatusSchema),
+});
+
+export const UserLlmLimitsResponseSchema = z.object({
+  org_id: z.string(),
+  user_id: z.string(),
+  limits: z.array(UserLlmLimitInputSchema.extend({ label: z.string().nullable() })),
+  status: UserLlmAccessStatusSchema,
+});
+
+export const LlmPricingInputSchema = z.object({
+  provider: z.string().trim().min(1).max(200),
+  model: z.string().trim().min(1).max(200),
+  input_usd_per_million: SixDecimalUsdSchema.max(1_000_000),
+  output_usd_per_million: SixDecimalUsdSchema.max(1_000_000),
+  cache_creation_usd_per_million: SixDecimalUsdSchema.max(1_000_000).optional().default(0),
+  cache_read_usd_per_million: SixDecimalUsdSchema.max(1_000_000).optional().default(0),
+});
+
+export const SetLlmPricingBodySchema = z.object({
+  prices: z.array(LlmPricingInputSchema).max(500).superRefine((prices, ctx) => {
+    const seen = new Set<string>();
+    prices.forEach((price, index) => {
+      const key = `${price.provider.trim()}\0${price.model.trim()}`;
+      if (seen.has(key)) {
+        ctx.addIssue({ code: "custom", message: "duplicate provider/model", path: [index] });
+      }
+      seen.add(key);
+    });
+  }),
+});
+
+export const LlmPricingResponseSchema = z.object({
+  org_id: z.string(),
+  prices: z.array(LlmPricingInputSchema),
+  unpriced_models: z.array(z.object({
+    provider: z.string(),
+    model: z.string(),
+    last_seen_at_ms: z.number().int(),
+  })),
+});
+
+const UserLlmTotalsSchema = z.object({
+  requests: z.number().int(),
+  spend_usd: z.number(),
+  unpriced_requests: z.number().int(),
+  input_tokens: z.number().int(),
+  output_tokens: z.number().int(),
+  cache_creation_input_tokens: z.number().int(),
+  cache_read_input_tokens: z.number().int(),
+});
+
+export const UserLlmUsageReportSchema = z.object({
+  org_id: z.string(),
+  from_ms: z.number().int(),
+  to_ms: z.number().int(),
+  evaluated_at_ms: z.number().int(),
+  users: z.array(z.object({
+    user_id: z.string().nullable(),
+    name: z.string().nullable().optional(),
+    email: z.string().nullable().optional(),
+    membership_status: z.enum(["current", "former", "unattributed"]),
+    totals: UserLlmTotalsSchema,
+    models: z.array(UserLlmTotalsSchema.extend({ provider: z.string(), model: z.string() })),
+    limit_status: UserLlmAccessStatusSchema.omit({ evaluated_at_ms: true }),
+  })),
+  count: z.number().int(),
+  has_more: z.boolean(),
+  next_cursor: z.string().nullable(),
+});
+
 const UsageLogEntrySchema = z.object({
   id: z.number().int(),
   workspace_id: z.string(),
@@ -908,6 +1029,10 @@ const UsageLogEntrySchema = z.object({
   cache_creation_input_tokens: z.number().int(),
   cache_read_input_tokens: z.number().int(),
   cost_usd: z.number(),
+  metered_cost_usd: z.number().nullable(),
+  cost_source: z.enum(["provider_reported", "org_override", "builtin_pricing", "legacy_estimate", "unpriced"]),
+  usage_kind: z.enum(["llm", "image", "audio", "capability", "unknown"]),
+  usage_surface: z.enum(["agent", "subagent", "compaction", "virtual_ai", "auxiliary", "capability", "unknown"]),
   duration_ms: z.number().int(),
   created_at_ms: z.number().int(),
   source: z.string().optional(),
@@ -925,6 +1050,8 @@ export const OrgUsageLogSchema = z.object({
 export const OrgUsageLogSumSchema = z.object({
   org_id: z.string(),
   total_cost_usd: z.number(),
+  metered_cost_usd: z.number().optional(),
+  unpriced_requests: z.number().int().optional(),
   total_requests: z.number().int(),
   total_input_tokens: z.number().int(),
   total_output_tokens: z.number().int(),

--- a/workers/main/src/user-llm-usage-policy.ts
+++ b/workers/main/src/user-llm-usage-policy.ts
@@ -1,0 +1,115 @@
+import type {
+  CheckUserLlmUsageAccessInput,
+  UserLlmUsageAccessResult,
+  UserLlmUsageLimitStatus,
+} from "./identity/org/usage-controls";
+import { recordObservabilityEvent, type ObservabilityEnv } from "./observability";
+
+export type UserLlmUsageLimitErrorCode =
+  | "limit_exceeded"
+  | "pricing_unavailable"
+  | "usage_policy_unavailable";
+
+function windowLabel(limit: UserLlmUsageLimitStatus | null): string {
+  if (!limit) return "configured rolling window";
+  return limit.label?.trim() || `${limit.window_hours}-hour window`;
+}
+
+export class UserLlmUsageLimitError extends Error {
+  constructor(
+    readonly code: UserLlmUsageLimitErrorCode,
+    readonly access: UserLlmUsageAccessResult | null = null,
+    readonly provider?: string,
+    readonly model?: string,
+  ) {
+    const blocking = access?.blocking_limit ?? null;
+    let message: string;
+    if (code === "limit_exceeded") {
+      const retry = blocking?.retry_at_ms
+        ? ` Try again after ${new Date(blocking.retry_at_ms).toISOString()}.`
+        : "";
+      message = `LLM usage limit ${windowLabel(blocking)} reached (${(blocking?.spent_usd ?? 0).toFixed(6)} USD spent of ${(blocking?.limit_usd ?? 0).toFixed(6)} USD).${retry}`;
+    } else if (code === "pricing_unavailable") {
+      message = `LLM usage is blocked because ${provider || "this provider"}/${model || "this model"} is unpriced or the active limit window contains unpriced LLM usage. Configure an exact pricing override in the admin API.`;
+    } else {
+      message = "LLM usage policy could not be verified. The provider was not called; try again or ask the operator to check the organization usage service.";
+    }
+    super(message);
+    this.name = "UserLlmUsageLimitError";
+  }
+}
+
+export interface UserLlmUsagePolicyStub {
+  checkUserLlmUsageAccess(input: CheckUserLlmUsageAccessInput): Promise<UserLlmUsageAccessResult>;
+}
+
+export interface UserLlmUsagePolicyContext {
+  env?: ObservabilityEnv;
+  orgId: string;
+  workspaceId?: string | null;
+  threadId?: string | null;
+  userId: string;
+  provider: string;
+  model: string;
+}
+
+export async function assertUserLlmUsageAccess(
+  stub: UserLlmUsagePolicyStub,
+  context: UserLlmUsagePolicyContext,
+): Promise<UserLlmUsageAccessResult> {
+  let access: UserLlmUsageAccessResult;
+  try {
+    access = await stub.checkUserLlmUsageAccess({
+      user_id: context.userId,
+      provider: context.provider,
+      model: context.model,
+    });
+  } catch {
+    recordObservabilityEvent(context.env, {
+      event: "user_llm_usage_limit_denied",
+      severity: "error",
+      component: "llm_usage_policy",
+      operation: "check_user_llm_usage_access",
+      status: "usage_policy_unavailable",
+      orgId: context.orgId,
+      workspaceId: context.workspaceId,
+      threadId: context.threadId,
+      userId: context.userId,
+      provider: context.provider,
+      model: context.model,
+    });
+    throw new UserLlmUsageLimitError(
+      "usage_policy_unavailable",
+      null,
+      context.provider,
+      context.model,
+    );
+  }
+  if (access.allowed) return access;
+
+  const blocking = access.blocking_limit;
+  recordObservabilityEvent(context.env, {
+    event: "user_llm_usage_limit_denied",
+    severity: "warn",
+    component: "llm_usage_policy",
+    operation: "check_user_llm_usage_access",
+    status: access.reason,
+    orgId: context.orgId,
+    workspaceId: context.workspaceId,
+    threadId: context.threadId,
+    userId: context.userId,
+    provider: context.provider,
+    model: context.model,
+    extraCounts: [
+      blocking?.window_hours ?? 0,
+      blocking?.spent_usd ?? 0,
+      blocking?.limit_usd ?? 0,
+    ],
+  });
+  throw new UserLlmUsageLimitError(
+    access.reason === "pricing_unavailable" ? "pricing_unavailable" : "limit_exceeded",
+    access,
+    context.provider,
+    context.model,
+  );
+}

--- a/workers/main/src/workspace-cron.ts
+++ b/workers/main/src/workspace-cron.ts
@@ -1120,7 +1120,7 @@ export class WorkspaceCronDO extends DurableObject<WorkspaceCronEnv> {
     const created = (await orgStub.createThread(
       workspace.id,
       `Scheduled: ${prompt.name}`,
-      "system",
+      prompt.created_by || "system",
       prompt.prompt.slice(0, 500),
       model,
       { source: "scheduled" },
@@ -1180,6 +1180,7 @@ export class WorkspaceCronDO extends DurableObject<WorkspaceCronEnv> {
         threadId,
         workspaceId: workspace.id,
         orgId: workspace.org_id,
+        userId: prompt.created_by,
         userName: "Scheduler",
         messageSource: "scheduled prompt",
         message: this.buildScheduledMessage(prompt, scheduledForMs),

--- a/workers/main/tests/admin-api-user-llm-usage.test.ts
+++ b/workers/main/tests/admin-api-user-llm-usage.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import { env, runInDurableObject } from "cloudflare:test";
+import { handleAdminApi } from "../src/routes/admin/index";
+import type { Env as WorkerEnv } from "../src/types";
+import { createOrg, createUser, type TestEnv } from "./test-helpers";
+
+const testEnv = env as unknown as TestEnv;
+const key = "usage-admin-test-key";
+
+function workerEnv(overrides: Partial<WorkerEnv> = {}): WorkerEnv {
+  return { ...testEnv, ADMIN_API_KEY: key, ...overrides } as unknown as WorkerEnv;
+}
+
+async function request(path: string, init: RequestInit = {}, environment = workerEnv()) {
+  const req = new Request(`http://example.test/api/admin${path}`, {
+    ...init,
+    headers: { Authorization: `Bearer ${key}`, ...(init.headers ?? {}) },
+  });
+  return handleAdminApi({
+    req,
+    env: environment,
+    ctx: {} as ExecutionContext,
+    url: new URL(req.url),
+    match: req.url.match(/^.*$/)!,
+  });
+}
+
+describe("admin per-user LLM usage routes", () => {
+  it("configures pricing and limits, filters rows, and returns the user report", async () => {
+    const { userId } = await createUser(
+      testEnv,
+      `usage-api-${crypto.randomUUID()}@example.test`,
+      "password123",
+      "Usage API User",
+    );
+    const { org } = await createOrg(testEnv, "Usage API Org", userId);
+    const { userId: zeroUsageUserId } = await createUser(
+      testEnv,
+      `usage-api-zero-${crypto.randomUUID()}@example.test`,
+      "password123",
+      "Zero Usage Member",
+    );
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    await orgStub.addMember(zeroUsageUserId, "member", userId);
+    const now = Date.now();
+
+    const pricingResponse = await request(`/orgs/${org.id}/usage/pricing`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "x-admin-mcp-user-id": "forged-mcp-admin",
+      },
+      body: JSON.stringify({ prices: [{
+        provider: "custom",
+        model: "api-model",
+        input_usd_per_million: 1,
+        output_usd_per_million: 2,
+      }] }),
+    });
+    expect(pricingResponse?.status).toBe(200);
+
+    const limitsResponse = await request(`/orgs/${org.id}/usage/users/${userId}/limits`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "x-admin-mcp-user-id": "forged-mcp-admin",
+      },
+      body: JSON.stringify({ limits: [{ window_hours: 1.1, limit_usd: 5, label: "66-minute" }] }),
+    });
+    expect(limitsResponse?.status).toBe(200);
+    await expect(limitsResponse?.json()).resolves.toMatchObject({
+      org_id: org.id,
+      user_id: userId,
+      limits: [{ window_hours: 1.1, limit_usd: 5, label: "66-minute" }],
+    });
+    await runInDurableObject(orgStub, (_instance, state) => {
+      const pricingActor = state.storage.sql.exec<{ updated_by: string }>(
+        "SELECT updated_by FROM llm_model_pricing_overrides WHERE provider = 'custom' AND model = 'api-model'",
+      ).one().updated_by;
+      const limitActor = state.storage.sql.exec<{ updated_by: string }>(
+        "SELECT updated_by FROM user_llm_usage_limits WHERE user_id = ?",
+        userId,
+      ).one().updated_by;
+      expect(pricingActor).toBe("admin_api_key");
+      expect(limitActor).toBe("admin_api_key");
+    });
+
+    await orgStub.recordUsage({
+      user_id: userId,
+      provider: "custom",
+      model: "api-model",
+      usage_kind: "llm",
+      usage_surface: "virtual_ai",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      created_at_ms: now - 10,
+      source: "virtual_ai",
+      source_id: crypto.randomUUID(),
+    });
+
+    const log = await request(
+      `/orgs/${org.id}/usage/log?from=${now - 1_000}&to=${now + 1_000}&user_id=${userId}&provider=custom&model=api-model&usage_kind=llm&usage_surface=virtual_ai`,
+    );
+    expect(log?.status).toBe(200);
+    await expect(log?.json()).resolves.toMatchObject({
+      count: 1,
+      entries: [{ metered_cost_usd: 3, cost_source: "org_override" }],
+    });
+
+    const sum = await request(
+      `/orgs/${org.id}/usage/log/sum?from=${now - 1_000}&to=${now + 1_000}&user_id=${userId}&provider=custom&model=api-model&usage_kind=llm&usage_surface=virtual_ai`,
+    );
+    await expect(sum?.json()).resolves.toMatchObject({
+      total_requests: 1,
+      metered_cost_usd: 3,
+      unpriced_requests: 0,
+    });
+
+    const report = await request(
+      `/orgs/${org.id}/usage/users?from=${now - 1_000}&to=${now + 1_000}&user_id=${userId}`,
+    );
+    expect(report?.status).toBe(200);
+    await expect(report?.json()).resolves.toMatchObject({
+      org_id: org.id,
+      count: 1,
+      users: [{
+        user_id: userId,
+        membership_status: "current",
+        totals: { requests: 1, spend_usd: 3 },
+        models: [{ provider: "custom", model: "api-model", spend_usd: 3 }],
+      }],
+    });
+
+    const firstPage = await request(
+      `/orgs/${org.id}/usage/users?from=${now - 1_000}&to=${now + 1_000}&limit=1`,
+    );
+    const firstPageBody = await firstPage?.json() as {
+      users: Array<{ user_id: string; totals: { requests: number } }>;
+      has_more: boolean;
+      next_cursor: string;
+    };
+    expect(firstPageBody).toMatchObject({ count: 1, has_more: true });
+    const secondPage = await request(
+      `/orgs/${org.id}/usage/users?from=${now - 1_000}&to=${now + 1_000}&limit=1&cursor=${encodeURIComponent(firstPageBody.next_cursor)}`,
+    );
+    const secondPageBody = await secondPage?.json() as typeof firstPageBody;
+    expect(secondPageBody).toMatchObject({ count: 1, has_more: false, next_cursor: null });
+    const pagedUsers = [...firstPageBody.users, ...secondPageBody.users];
+    expect(new Set(pagedUsers.map((user) => user.user_id))).toEqual(new Set([userId, zeroUsageUserId]));
+    expect(pagedUsers.find((user) => user.user_id === zeroUsageUserId)?.totals.requests).toBe(0);
+
+    const malformedCursor = await request(
+      `/orgs/${org.id}/usage/users?from=${now - 1_000}&to=${now + 1_000}&cursor=not-a-valid-cursor`,
+    );
+    expect(malformedCursor?.status).toBe(400);
+    const reversedRange = await request(
+      `/orgs/${org.id}/usage/users?from=${now + 1_000}&to=${now}`,
+    );
+    expect(reversedRange?.status).toBe(400);
+    const reversedSumRange = await request(
+      `/orgs/${org.id}/usage/log/sum?from=${now + 1_000}&to=${now}`,
+    );
+    expect(reversedSumRange?.status).toBe(400);
+    const reversedLogRange = await request(
+      `/orgs/${org.id}/usage/log?from=${now + 1_000}&to=${now}`,
+    );
+    expect(reversedLogRange?.status).toBe(400);
+    const malformedLogCursor = await request(`/orgs/${org.id}/usage/log?cursor=garbage`);
+    expect(malformedLogCursor?.status).toBe(400);
+    const zeroUpperBound = await request(`/orgs/${org.id}/usage/log?to=0`);
+    expect(zeroUpperBound?.status).toBe(200);
+    await expect(zeroUpperBound?.json()).resolves.toMatchObject({ org_id: org.id, count: 0, entries: [] });
+    const missingOrgLog = await request(`/orgs/missing-${crypto.randomUUID()}/usage/log`);
+    expect(missingOrgLog?.status).toBe(404);
+    const missingOrgSum = await request(
+      `/orgs/missing-${crypto.randomUUID()}/usage/log/sum?from=${now - 1_000}&to=${now + 1_000}`,
+    );
+    expect(missingOrgSum?.status).toBe(404);
+
+    const cleared = await request(`/orgs/${org.id}/usage/users/${userId}/limits`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ limits: [] }),
+    });
+    await expect(cleared?.json()).resolves.toMatchObject({ limits: [], status: { reason: "no_limits" } });
+  });
+
+  it("accepts contract-valid high-magnitude decimal values", async () => {
+    const { userId } = await createUser(
+      testEnv,
+      `usage-api-precision-${crypto.randomUUID()}@example.test`,
+      "password123",
+      "Usage Precision User",
+    );
+    const { org } = await createOrg(testEnv, "Usage Precision Org", userId);
+    const pricing = await request(`/orgs/${org.id}/usage/pricing`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prices: [{
+        provider: "custom",
+        model: "precision-model",
+        input_usd_per_million: 549225.806759,
+        output_usd_per_million: 1,
+      }] }),
+    });
+    expect(pricing?.status).toBe(200);
+
+    const limits = await request(`/orgs/${org.id}/usage/users/${userId}/limits`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ limits: [{
+        window_hours: 35543.60400583333,
+        limit_usd: 553045650.474688,
+      }] }),
+    });
+    expect(limits?.status).toBe(200);
+  });
+
+  it("preserves the admin wrapper authentication contract", async () => {
+    const openApi = await request("/openapi.json");
+    expect(openApi?.status).toBe(200);
+    const document = await openApi?.json() as { paths?: Record<string, unknown> };
+    expect(document.paths).toHaveProperty("/api/admin/orgs/{id}/usage/users");
+    expect(document.paths).toHaveProperty("/api/admin/orgs/{id}/usage/users/{userId}/limits");
+    expect(document.paths).toHaveProperty("/api/admin/orgs/{id}/usage/pricing");
+
+    const noBearer = new Request("http://example.test/api/admin/orgs/x/usage/pricing");
+    await expect(handleAdminApi({
+      req: noBearer,
+      env: workerEnv(),
+      ctx: {} as ExecutionContext,
+      url: new URL(noBearer.url),
+      match: noBearer.url.match(/^.*$/)!,
+    })).resolves.toBeNull();
+
+    const wrong = await request("/orgs/x/usage/pricing", {
+      headers: { Authorization: "Bearer wrong" },
+    });
+    expect(wrong?.status).toBe(401);
+
+    const missing = await request("/orgs/x/usage/pricing", {}, workerEnv({ ADMIN_API_KEY: undefined }));
+    expect(missing?.status).toBe(503);
+  });
+});

--- a/workers/main/tests/admin-mcp-oauth.test.ts
+++ b/workers/main/tests/admin-mcp-oauth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { env, SELF } from "cloudflare:test";
+import { env, runInDurableObject, SELF } from "cloudflare:test";
 import { AdminMcpOAuthProvider } from "../src/admin-mcp-oauth";
 import { getAppIndexDatabase } from "../src/app-index-db";
 import { handleAdminMcp } from "../src/routes/admin-mcp";
@@ -424,6 +424,9 @@ describe("admin MCP OAuth resource", () => {
           expect.objectContaining({ name: "list_bans" }),
           expect.objectContaining({ name: "grant_org_credits" }),
           expect.objectContaining({ name: "set_user_credits" }),
+          expect.objectContaining({ name: "get_user_llm_limits" }),
+          expect.objectContaining({ name: "set_user_llm_limits" }),
+          expect.objectContaining({ name: "set_llm_usage_pricing" }),
           expect.objectContaining({ name: "admin_js_exec" }),
         ]),
       },
@@ -434,6 +437,83 @@ describe("admin MCP OAuth resource", () => {
     expect(setCreditsTool.description).toContain(
       "without creating a grant ledger row",
     );
+    const usageTool = rpc.result.tools.find(
+      (tool: { name: string }) => tool.name === "get_org_usage",
+    );
+    const usageVariants = usageTool.inputSchema.oneOf as Array<{
+      properties: { view: { const: string } };
+      required: string[];
+    }>;
+    expect(usageVariants.find((variant) => variant.properties.view.const === "users")?.required)
+      .toEqual(expect.arrayContaining(["org_id", "view", "from", "to"]));
+    expect(usageVariants.find((variant) => variant.properties.view.const === "log_sum")?.required)
+      .toEqual(expect.arrayContaining(["org_id", "view", "from", "to"]));
+  });
+
+  it("delegates first-class LLM usage policy tools through the admin REST routes", async () => {
+    const { userId } = await createUser(
+      testEnv,
+      `admin-mcp-usage-${crypto.randomUUID()}@example.com`,
+      "password123",
+      "Usage Policy Admin",
+    );
+    const { org } = await createOrg(testEnv, "MCP Usage Policy Org", userId);
+    await updateUserProfile(testEnv, userId, { is_superuser: true });
+    const token = await issueAdminMcpToken(userId);
+    const call = async (name: string, args: Record<string, unknown>) => {
+      const response = await handleAdminMcp({
+        req: mcpRequest({
+          jsonrpc: "2.0",
+          id: crypto.randomUUID(),
+          method: "tools/call",
+          params: { name, arguments: args },
+        }, token),
+        env: testEnv,
+        ctx: {} as ExecutionContext,
+        url: new URL("https://example.com/api/admin/mcp"),
+        match: [] as unknown as RegExpMatchArray,
+      });
+      expect(response?.status).toBe(200);
+      return parseToolText(await response?.json());
+    };
+
+    await expect(call("set_llm_usage_pricing", {
+      org_id: org.id,
+      prices: [{
+        provider: "custom",
+        model: "mcp-model",
+        input_usd_per_million: 1,
+        output_usd_per_million: 2,
+      }],
+    })).resolves.toMatchObject({
+      status: 200,
+      body_json: { prices: [{ provider: "custom", model: "mcp-model" }] },
+    });
+    await expect(call("set_user_llm_limits", {
+      org_id: org.id,
+      user_id: userId,
+      limits: [{ window_hours: 24, limit_usd: 5, label: "daily" }],
+    })).resolves.toMatchObject({
+      status: 200,
+      body_json: { limits: [{ window_hours: 24, limit_usd: 5, label: "daily" }] },
+    });
+    await expect(call("get_user_llm_limits", {
+      org_id: org.id,
+      user_id: userId,
+    })).resolves.toMatchObject({
+      status: 200,
+      body_json: { status: { reason: "within_limits" } },
+    });
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    await runInDurableObject(orgStub, (_instance, state) => {
+      expect(state.storage.sql.exec<{ updated_by: string }>(
+        "SELECT updated_by FROM llm_model_pricing_overrides WHERE provider = 'custom' AND model = 'mcp-model'",
+      ).one().updated_by).toBe(userId);
+      expect(state.storage.sql.exec<{ updated_by: string }>(
+        "SELECT updated_by FROM user_llm_usage_limits WHERE user_id = ?",
+        userId,
+      ).one().updated_by).toBe(userId);
+    });
   });
 
   it("lets superusers query chat errors through the dedicated MCP tool", async () => {

--- a/workers/main/tests/ai-virtual-binding.test.ts
+++ b/workers/main/tests/ai-virtual-binding.test.ts
@@ -15,6 +15,7 @@ import {
   runViaGatewayHTTP,
 } from "../src/ai-virtual-binding.js";
 import {
+  BedrockPiCompletionError,
   buildBedrockPiModel,
   chatCompletionToPiCall,
   piMessageToChatCompletion,
@@ -354,14 +355,101 @@ describe("resolveRouting", () => {
     expect(routing.model).toBe("anthropic.claude-opus-5");
     expect(routing.awsRegion).toBe("us-east-1");
   });
+
+  it("routes Bedrock BYOK cheap tier to the priced Haiku family id", async () => {
+    const encrypted = await encryptCredentials({ bearer_token: "bedrock-token" }, "secret");
+    const routing = await resolveRouting(
+      {
+        env: {
+          INTEGRATION_SECRET_KEY: "secret",
+          ORG: {
+            idFromName: vi.fn((id: string) => id),
+            get: vi.fn(() => ({
+              getLlmProviderConfig: vi.fn(async () => ({
+                provider: "bedrock",
+                config: JSON.stringify({ aws_region: "us-east-1" }),
+                credentials_encrypted: encrypted,
+              })),
+            })),
+          } as never,
+        },
+        props: { orgId: "org1", workspaceId: "ws1" },
+        waitUntil: vi.fn(),
+      },
+      "cheap",
+    );
+
+    expect(routing.provider).toBe("bedrock");
+    expect(routing.model).toBe("anthropic.claude-haiku-4-5");
+  });
 });
 
 describe("executeVirtualAiRun", () => {
+  it("fails closed before the upstream provider when a user's rolling limit denies the pull", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const checkUserLlmUsageAccess = vi.fn(async () => ({
+      allowed: false,
+      reason: "limit_exceeded" as const,
+      evaluated_at_ms: Date.now(),
+      blocking_limit: {
+        window_hours: 24,
+        label: "daily",
+        limit_usd: 1,
+        spent_usd: 1,
+        remaining_usd: 0,
+        unpriced_requests: 0,
+        exceeded: true,
+        retry_at_ms: Date.now() + 60_000,
+      },
+      limits: [],
+    }));
+    try {
+      await expect(executeVirtualAiRun(
+        {
+          env: {
+            CF_ACCOUNT_ID: "acct_1",
+            CF_GATEWAY_NAME: "gw_1",
+            CF_GATEWAY_TOKEN: "tok_1",
+            ORG: {
+              idFromName: vi.fn((id: string) => id),
+              get: vi.fn(() => ({
+                getLlmProviderConfig: vi.fn(async () => null),
+                getInfo: vi.fn(async () => ({
+                  billing_status: "active",
+                  billing_plan: "payg",
+                  billing_credit_purchase_total_cents: 0,
+                  billing_credit_grant_total_cents: 0,
+                })),
+                checkUserLlmUsageAccess,
+              })),
+            } as never,
+          },
+          props: { orgId: "org1", workspaceId: "ws1", userId: "user1" },
+          waitUntil: vi.fn(),
+        },
+        "deepseek-v4-auto",
+        { messages: [{ role: "user", content: "hello" }] },
+      )).rejects.toMatchObject({ code: "limit_exceeded" });
+      expect(checkUserLlmUsageAccess).toHaveBeenCalledOnce();
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("posts hosted DeepSeek V4 Auto to the compat dynamic route", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({
         id: "chatcmpl_deepseek_auto",
-        usage: { prompt_tokens: 2, completion_tokens: 3 },
+        model: "provider/canonical-response-model",
+        usage: {
+          prompt_tokens: 1_000,
+          completion_tokens: 3,
+          prompt_tokens_details: {
+            cached_tokens: 800,
+            cache_write_tokens: 50,
+          },
+        },
       }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -369,6 +457,13 @@ describe("executeVirtualAiRun", () => {
     );
     const getUsageLogSum = vi.fn(async () => ({ total_cost_usd: 0 }));
     const recordUsage = vi.fn(async () => undefined);
+    const checkUserLlmUsageAccess = vi.fn(async () => ({
+      allowed: true,
+      reason: "no_limits" as const,
+      evaluated_at_ms: Date.now(),
+      blocking_limit: null,
+      limits: [],
+    }));
     const backgroundTasks: Promise<unknown>[] = [];
 
     try {
@@ -389,11 +484,12 @@ describe("executeVirtualAiRun", () => {
                   billing_credit_grant_total_cents: 0,
                 })),
                 getUsageLogSum,
+                checkUserLlmUsageAccess,
                 recordUsage,
               })),
             } as never,
           },
-          props: { orgId: "org1", workspaceId: "ws1" },
+          props: { orgId: "org1", workspaceId: "ws1", userId: "user1" },
           waitUntil: (task) => backgroundTasks.push(task),
         },
         "deepseek-v4-auto",
@@ -411,17 +507,161 @@ describe("executeVirtualAiRun", () => {
       const body = JSON.parse(String(init.body)) as { model: string };
       expect(body.model).toBe("openai/gpt-5.6-luna");
       expect(getUsageLogSum).not.toHaveBeenCalled();
+      expect(checkUserLlmUsageAccess).toHaveBeenCalledOnce();
       await Promise.all(backgroundTasks);
       expect(recordUsage).toHaveBeenCalledWith(
         expect.objectContaining({
           credit_chargeable: false,
-          input_tokens: 2,
+          user_id: "user1",
+          model: "openai/gpt-5.6-luna",
+          usage_kind: "llm",
+          usage_surface: "virtual_ai",
+          input_tokens: 150,
           output_tokens: 3,
+          cache_read_input_tokens: 800,
+          cache_creation_input_tokens: 50,
+          source: "virtual_ai",
+          source_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
         }),
       );
     } finally {
       fetchMock.mockRestore();
     }
+  });
+
+  it("records one attributable streaming usage row with its request id", async () => {
+    const streamBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          'data: {"model":"openai/gpt-5.6-luna","usage":{"prompt_tokens":1000,"completion_tokens":4,"prompt_tokens_details":{"cached_tokens":800,"cache_write_tokens":50}}}\n\n',
+        ));
+        controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(streamBody, { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    );
+    const recordUsage = vi.fn(async () => undefined);
+    const checkUserLlmUsageAccess = vi.fn(async () => ({
+      allowed: true,
+      reason: "within_limits" as const,
+      evaluated_at_ms: Date.now(),
+      blocking_limit: null,
+      limits: [],
+    }));
+    const backgroundTasks: Promise<unknown>[] = [];
+
+    try {
+      const result = await executeVirtualAiRun({
+        env: {
+          CF_ACCOUNT_ID: "acct_1",
+          CF_GATEWAY_NAME: "gw_1",
+          CF_GATEWAY_TOKEN: "tok_1",
+          ORG: {
+            idFromName: vi.fn((id: string) => id),
+            get: vi.fn(() => ({
+              getLlmProviderConfig: vi.fn(async () => null),
+              getInfo: vi.fn(async () => ({
+                billing_status: "active",
+                billing_plan: "payg",
+                billing_credit_purchase_total_cents: 0,
+                billing_credit_grant_total_cents: 0,
+              })),
+              checkUserLlmUsageAccess,
+              recordUsage,
+            })),
+          } as never,
+        },
+        props: { orgId: "org1", workspaceId: "ws1", userId: "user1" },
+        waitUntil: (task) => backgroundTasks.push(task),
+      }, "deepseek-v4-auto", {
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      });
+      expect(result).toBeInstanceOf(ReadableStream);
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(JSON.parse(String(init.body))).toMatchObject({
+        stream: true,
+        stream_options: { include_usage: true },
+      });
+      await new Response(result as ReadableStream).text();
+      await Promise.all(backgroundTasks);
+
+      expect(checkUserLlmUsageAccess).toHaveBeenCalledOnce();
+      expect(recordUsage).toHaveBeenCalledOnce();
+      expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
+        user_id: "user1",
+        input_tokens: 150,
+        output_tokens: 4,
+        cache_read_input_tokens: 800,
+        cache_creation_input_tokens: 50,
+        source: "virtual_ai",
+        source_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      }));
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("records a terminal streaming usage frame even when the stream then errors", async () => {
+    let pull = 0;
+    const streamBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pull++ === 0) {
+          controller.enqueue(new TextEncoder().encode(
+            'data: {"model":"provider/response-alias","usage":{"prompt_tokens":12,"completion_tokens":3}}\n\n',
+          ));
+          return;
+        }
+        controller.error(new Error("provider stream truncated"));
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(streamBody, { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    );
+    const recordUsage = vi.fn(async () => undefined);
+    const backgroundTasks: Promise<unknown>[] = [];
+    const result = await executeVirtualAiRun({
+      env: {
+        CF_ACCOUNT_ID: "acct_1",
+        CF_GATEWAY_NAME: "gw_1",
+        CF_GATEWAY_TOKEN: "tok_1",
+        ORG: {
+          idFromName: vi.fn((id: string) => id),
+          get: vi.fn(() => ({
+            getLlmProviderConfig: vi.fn(async () => null),
+            getInfo: vi.fn(async () => ({
+              billing_status: "active",
+              billing_plan: "payg",
+              billing_credit_purchase_total_cents: 0,
+              billing_credit_grant_total_cents: 0,
+            })),
+            checkUserLlmUsageAccess: vi.fn(async () => ({
+              allowed: true,
+              reason: "within_limits" as const,
+              evaluated_at_ms: Date.now(),
+              blocking_limit: null,
+              limits: [],
+            })),
+            recordUsage,
+          })),
+        } as never,
+      },
+      props: { orgId: "org1", workspaceId: "ws1", userId: "user1" },
+      waitUntil: (task) => backgroundTasks.push(task),
+    }, "deepseek-v4-auto", {
+      stream: true,
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    await expect(new Response(result as ReadableStream).text()).rejects.toThrow("truncated");
+    await expect(Promise.all(backgroundTasks)).resolves.toBeDefined();
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
+      model: "openai/gpt-5.6-luna",
+      input_tokens: 12,
+      output_tokens: 3,
+    }));
   });
 
   it("does not require AI Gateway settings before Bedrock BYOK routing", async () => {
@@ -458,6 +698,74 @@ describe("executeVirtualAiRun", () => {
     } finally {
       fetchMock.mockRestore();
     }
+  });
+
+  it("records nonzero Bedrock usage before propagating a failed completion", async () => {
+    const encrypted = await encryptCredentials({ bearer_token: "bedrock-token" }, "secret");
+    const recordUsage = vi.fn(async () => undefined);
+    const completion = {
+      role: "assistant",
+      content: [],
+      api: "anthropic-messages",
+      provider: "custom",
+      model: "anthropic.claude-haiku-4-5",
+      usage: {
+        input: 100,
+        output: 5,
+        cacheRead: 80,
+        cacheWrite: 12,
+        totalTokens: 197,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "error",
+      errorMessage: "bedrock failed after usage",
+      timestamp: Date.now(),
+    } as AssistantMessage;
+    const runBedrock = vi.fn(async () => {
+      throw new BedrockPiCompletionError("bedrock failed after usage", completion);
+    });
+
+    await expect(executeVirtualAiRun({
+      env: {
+        INTEGRATION_SECRET_KEY: "secret",
+        ORG: {
+          idFromName: vi.fn((id: string) => id),
+          get: vi.fn(() => ({
+            getLlmProviderConfig: vi.fn(async () => ({
+              provider: "bedrock",
+              config: JSON.stringify({ aws_region: "us-east-1" }),
+              credentials_encrypted: encrypted,
+            })),
+            checkUserLlmUsageAccess: vi.fn(async () => ({
+              allowed: true,
+              reason: "within_limits" as const,
+              evaluated_at_ms: Date.now(),
+              blocking_limit: null,
+              limits: [],
+            })),
+            recordUsage,
+          })),
+        } as never,
+      },
+      props: { orgId: "org1", workspaceId: "ws1", userId: "user1" },
+      waitUntil: vi.fn(),
+      runBedrock,
+    }, "cheap", {
+      messages: [{ role: "user", content: "hello" }],
+    })).rejects.toThrow("bedrock failed after usage");
+
+    expect(runBedrock).toHaveBeenCalledOnce();
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: "user1",
+      provider: "bedrock",
+      model: "anthropic.claude-haiku-4-5",
+      usage_kind: "llm",
+      usage_surface: "virtual_ai",
+      input_tokens: 100,
+      output_tokens: 5,
+      cache_read_input_tokens: 80,
+      cache_creation_input_tokens: 12,
+    }));
   });
 });
 
@@ -959,6 +1267,11 @@ describe("piMessageToChatCompletion (Bedrock adapter — output)", () => {
       "model",
     ) as Record<string, unknown>;
     const usage = completion.usage as Record<string, unknown>;
+    expect(usage).toMatchObject({
+      prompt_tokens: 192,
+      completion_tokens: 5,
+      total_tokens: 197,
+    });
     expect(usage.prompt_tokens_details).toEqual({
       cached_tokens: 80,
       cache_write_tokens: 12,

--- a/workers/main/tests/chat-thread-pi-turn.test.ts
+++ b/workers/main/tests/chat-thread-pi-turn.test.ts
@@ -1203,6 +1203,23 @@ describe('ChatThreadDO Pi turn handling', () => {
     expect(fake.appendPiCoreMessagesIfMissing).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves the initiating user when another member steers an active turn', async () => {
+    const fake = makeNewTurnEnqueueFake([]);
+    fake.chatContext = { ...fake.chatContext, userId: 'steering-user' };
+    fake.piSession = { state: { isStreaming: true } };
+    fake.sendRunnerCommand = vi.fn(() => true);
+
+    await expect(ChatThreadDO.prototype['enqueueRunnerUserMessage'].call(
+      fake,
+      { type: 'message', content: 'steer this' },
+    )).resolves.toEqual({ status: 'accepted' });
+
+    expect(fake.setActiveTurnUserId).not.toHaveBeenCalled();
+    expect(fake.sendRunnerCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'steering-user' }),
+    );
+  });
+
   it('does NOT persist the initial user message when the send is rejected (no orphaned first message)', async () => {
     const order: string[] = [];
     const fake = makeNewTurnEnqueueFake(order);
@@ -1666,6 +1683,7 @@ describe('ChatThreadDO Pi turn handling', () => {
       userEmail: 'miguel@example.com',
     };
     fake.chatIsStreaming = true;
+    fake.isThreadStreaming = vi.fn(() => true);
     fake.ctx = {
       storage: { kv: { put: vi.fn(), delete: vi.fn() } },
       waitUntil: vi.fn(),

--- a/workers/main/tests/chat-thread-user-llm-usage.test.ts
+++ b/workers/main/tests/chat-thread-user-llm-usage.test.ts
@@ -1,0 +1,526 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { ChatThreadDO } from "../src/chat-thread-do";
+import { summarizePiMessages } from "../src/chat-thread/pi-compaction";
+import { runPiSubagentTool } from "../src/chat-thread/pi-tools";
+import { UserLlmUsageLimitError } from "../src/user-llm-usage-policy";
+
+const context = {
+  orgId: "org1",
+  workspaceId: "workspace1",
+  threadId: "thread1",
+  userId: "viewer-can-change",
+};
+
+const modelConfig = {
+  model: { id: "claude-sonnet-5", provider: "anthropic" },
+  apiKey: "key",
+  headers: {},
+  provider: "anthropic",
+  modelId: "claude-sonnet-5",
+  billingSource: "byok",
+  creditChargeable: false,
+  usageProvider: "anthropic",
+};
+
+describe("ChatThreadDO user LLM usage gate", () => {
+  it("gates and settles exactly once through an actual main Agent pull", async () => {
+    const checkUserLlmUsageAccess = vi.fn(async () => ({
+      allowed: true,
+      reason: "within_limits" as const,
+      evaluated_at_ms: 1,
+      blocking_limit: null,
+      limits: [],
+    }));
+    const recordUsage = vi.fn(async () => undefined);
+    const waitUntilTasks: Promise<unknown>[] = [];
+    const mainModelConfig = {
+      ...modelConfig,
+      model: {
+        id: "claude-sonnet-5",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        contextWindow: 128_000,
+        maxTokens: 4_096,
+        input: ["text"],
+      },
+    };
+    const streamPiModel = vi.fn(() => {
+      const stream = createAssistantMessageEventStream();
+      const message = {
+        role: "assistant",
+        content: [{ type: "text", text: "main result" }],
+        provider: "anthropic",
+        model: "claude-sonnet-5",
+        responseId: "response-main-lifecycle",
+        stopReason: "stop",
+        usage: { input: 10, output: 2, cacheRead: 0, cacheWrite: 0, totalTokens: 12 },
+        timestamp: Date.now(),
+      } as any;
+      stream.push({ type: "start", partial: { ...message, content: [] } });
+      stream.push({ type: "text_delta", delta: "main result", partial: message });
+      stream.push({ type: "done", reason: "stop", message });
+      stream.end();
+      return stream;
+    });
+    const fake = Object.create(ChatThreadDO.prototype) as any;
+    fake.chatContext = context;
+    fake.env = {
+      ORG: {
+        idFromName: vi.fn((value: string) => value),
+        get: vi.fn(() => ({ checkUserLlmUsageAccess, recordUsage })),
+      },
+    };
+    fake.ctx = { waitUntil: (task: Promise<unknown>) => waitUntilTasks.push(task) };
+    fake.piEventHandlerChain = Promise.resolve();
+    fake.llmUsageSettlementChain = Promise.resolve();
+    fake.pendingLlmUsageSettlements = [];
+    fake.noLlmLimitsCachedUserId = null;
+    fake.resolvePiModel = vi.fn(async () => mainModelConfig);
+    fake.withChatMemoryPhase = vi.fn(async (_phase: string, task: () => unknown) => task());
+    fake.loadPiCoreMessages = vi.fn(async () => []);
+    fake.readPiActiveTurn = vi.fn(() => null);
+    fake.createPiSystemPrompt = vi.fn(() => "system");
+    fake.createPiToolDefinitions = vi.fn(() => []);
+    fake.transformPiProviderContext = vi.fn(async (messages: unknown[]) => messages);
+    fake.refreshPiSessionCapabilitySurface = vi.fn();
+    fake.streamPiModel = streamPiModel;
+    fake.getActiveTurnUserId = vi.fn(() => "initiating-user");
+    fake.touchPiTurnProgress = vi.fn();
+    fake.attachCodeModeArtifactsToToolResult = vi.fn(async (message: unknown) => message);
+    fake.annotatePiProviderErrorMessages = vi.fn((messages: unknown[]) => messages);
+    fake.appendPiCoreMessagesIfMissing = vi.fn(async () => undefined);
+    fake.clearPiTurnJournal = vi.fn();
+    fake.pushPiRuntimeEvent = vi.fn();
+    fake.piRuntimeThreadId = vi.fn(() => "thread1");
+    fake.retryChatDurableObjectRpc = vi.fn(
+      async (_operation: string, task: () => Promise<unknown>) => task(),
+    );
+    fake.piCurrentBillingSource = "byok";
+    fake.piCurrentCreditChargeable = false;
+    fake.piCurrentUsageProvider = "anthropic";
+    fake.piCurrentUsageModel = "subagent-model-must-not-leak";
+    fake.piUserStopRequestedAtMs = 0;
+    fake.piTurnStartedAtMs = Date.now();
+    fake.piSdkTurnIndex = 0;
+    fake.piSdkTurnUsageTotal = null;
+    fake.handlePiSessionEvent = async (event: { type: string }) => {
+      if (event.type !== "turn_end") return;
+      await ChatThreadDO.prototype["handlePiSessionEvent"].call(fake, event);
+    };
+
+    const session = await ChatThreadDO.prototype["createPiSession"].call(
+      fake,
+      context,
+      {},
+    );
+    fake.piSession = session;
+    await session.prompt("answer once");
+    await fake.piEventHandlerChain;
+    await fake.llmUsageSettlementChain;
+    await Promise.all(waitUntilTasks);
+
+    expect(checkUserLlmUsageAccess).toHaveBeenCalledOnce();
+    expect(streamPiModel).toHaveBeenCalledOnce();
+    expect(recordUsage).toHaveBeenCalledOnce();
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: "initiating-user",
+      usage_surface: "agent",
+      input_tokens: 10,
+      output_tokens: 2,
+      source: "pi_assistant",
+    }));
+  });
+
+  it("gates and settles exactly once through an actual child Agent pull", async () => {
+    const gate = vi.fn(async () => undefined);
+    const recordUsage = vi.fn(async () => undefined);
+    const waitUntilTasks: Promise<unknown>[] = [];
+    const modelConfig = {
+      model: {
+        id: "claude-sonnet-5",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        contextWindow: 128_000,
+        maxTokens: 4_096,
+        input: ["text"],
+      },
+      apiKey: "key",
+      headers: {},
+      provider: "anthropic",
+      modelId: "claude-sonnet-5",
+      billingSource: "byok",
+      creditChargeable: false,
+      usageProvider: "anthropic",
+    };
+    const streamPiModel = vi.fn(() => {
+      const stream = createAssistantMessageEventStream();
+      const message = {
+        role: "assistant",
+        content: [{ type: "text", text: "child result" }],
+        provider: "anthropic",
+        model: "claude-sonnet-5",
+        stopReason: "stop",
+        usage: { input: 10, output: 2, cacheRead: 0, cacheWrite: 0, totalTokens: 12 },
+        timestamp: Date.now(),
+      } as any;
+      stream.push({ type: "start", partial: { ...message, content: [] } });
+      stream.push({ type: "text_delta", delta: "child result", partial: message });
+      stream.push({ type: "done", reason: "stop", message });
+      stream.end();
+      return stream;
+    });
+    const deps = {
+      piModelResolver: () => async () => modelConfig,
+      activeTurnUserId: () => "initiating-user",
+      assertUserLlmUsageAccess: gate,
+      createPiSubagentSystemPrompt: vi.fn(async () => "system"),
+      createPiToolDefinitions: vi.fn(() => []),
+      beforePiToolCall: vi.fn(),
+      afterPiToolCall: vi.fn(),
+      streamPiModel,
+      recordPiAssistantUsage: recordUsage,
+      waitUntil: (task: Promise<unknown>) => waitUntilTasks.push(task),
+    } as any;
+
+    await expect(runPiSubagentTool(
+      deps,
+      context as any,
+      "Agent",
+      { prompt: "do one thing" },
+    )).resolves.toMatchObject({ content: expect.any(Array) });
+    await Promise.all(waitUntilTasks);
+    expect(gate).toHaveBeenCalledOnce();
+    expect(streamPiModel).toHaveBeenCalledOnce();
+    expect(recordUsage).toHaveBeenCalledOnce();
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "assistant" }),
+      expect.any(Number),
+      "byok",
+      false,
+      "anthropic",
+      expect.objectContaining({
+        userId: "initiating-user",
+        model: "claude-sonnet-5",
+        usageSurface: "subagent",
+      }),
+    );
+  });
+
+  it("waits for settlement and rechecks no-limits before every later pull", async () => {
+    let release!: () => void;
+    const settlement = new Promise<void>((resolve) => { release = resolve; });
+    const checkUserLlmUsageAccess = vi.fn()
+      .mockResolvedValueOnce({
+        allowed: true,
+        reason: "no_limits" as const,
+        evaluated_at_ms: 1,
+        blocking_limit: null,
+        limits: [],
+      })
+      .mockResolvedValueOnce({
+        allowed: false,
+        reason: "limit_exceeded" as const,
+        evaluated_at_ms: 2,
+        blocking_limit: {
+          window_hours: 24,
+          limit_usd: 1,
+          label: "new policy",
+          spent_usd: 1,
+          remaining_usd: 0,
+          unpriced_requests: 0,
+          exceeded: true,
+          retry_at_ms: 3,
+        },
+        limits: [],
+      });
+    const fake = Object.create(ChatThreadDO.prototype) as any;
+    fake.llmUsageSettlementChain = settlement;
+    fake.noLlmLimitsCachedUserId = null;
+    fake.env = {
+      ORG: {
+        idFromName: vi.fn((value: string) => value),
+        get: vi.fn(() => ({ checkUserLlmUsageAccess })),
+      },
+    };
+
+    const pending = ChatThreadDO.prototype["assertPiUserLlmUsageAccess"].call(
+      fake,
+      context,
+      modelConfig,
+      "initiating-user",
+    );
+    await Promise.resolve();
+    expect(checkUserLlmUsageAccess).not.toHaveBeenCalled();
+    release();
+    await pending;
+    await expect(ChatThreadDO.prototype["assertPiUserLlmUsageAccess"].call(
+      fake, context, modelConfig, "initiating-user",
+    )).rejects.toMatchObject({ code: "limit_exceeded" });
+    expect(checkUserLlmUsageAccess).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { stopReason: "error", stoppedAt: 0 },
+    { stopReason: "aborted", stoppedAt: 1 },
+  ])("meters a billed $stopReason main pull before transcript early-return", async ({
+    stopReason,
+    stoppedAt,
+  }) => {
+    const recordPiAssistantUsage = vi.fn(async () => undefined);
+    const background: Promise<unknown>[] = [];
+    const fake = Object.create(ChatThreadDO.prototype) as any;
+    fake.ctx = { waitUntil: (promise: Promise<unknown>) => background.push(promise) };
+    fake.piTurnStartedAtMs = Date.now() - 10;
+    fake.piCurrentBillingSource = "byok";
+    fake.piCurrentCreditChargeable = false;
+    fake.piCurrentUsageProvider = "anthropic";
+    fake.piCurrentUsageModel = "claude-sonnet-5";
+    fake.piUserStopRequestedAtMs = stoppedAt;
+    fake.getActiveTurnUserId = vi.fn(() => "initiating-user");
+    fake.piRuntimeThreadId = vi.fn(() => "thread1");
+    fake.recordPiAssistantUsage = recordPiAssistantUsage;
+    fake.discardUnpersistedPiSessionMessages = vi.fn();
+    const message = {
+      role: "assistant",
+      content: [],
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      responseId: `response-${stopReason}`,
+      stopReason,
+      usage: { input: 10, output: 2, cacheRead: 0, cacheWrite: 0, totalTokens: 12 },
+      timestamp: Date.now(),
+    } as any;
+
+    await ChatThreadDO.prototype["handlePiSessionEvent"].call(fake, {
+      type: "turn_end",
+      message,
+    });
+    await Promise.all(background);
+
+    expect(recordPiAssistantUsage).toHaveBeenCalledOnce();
+    expect(recordPiAssistantUsage).toHaveBeenCalledWith(
+      message,
+      expect.any(Number),
+      "byok",
+      false,
+      "anthropic",
+      expect.objectContaining({
+        userId: "initiating-user",
+        model: "claude-sonnet-5",
+        usageSurface: "agent",
+      }),
+    );
+  });
+
+  it("does not cache within-limit policies across pulls", async () => {
+    const checkUserLlmUsageAccess = vi.fn(async () => ({
+      allowed: true,
+      reason: "within_limits" as const,
+      evaluated_at_ms: 1,
+      blocking_limit: null,
+      limits: [],
+    }));
+    const fake = Object.create(ChatThreadDO.prototype) as any;
+    fake.llmUsageSettlementChain = Promise.resolve();
+    fake.noLlmLimitsCachedUserId = null;
+    fake.env = {
+      ORG: {
+        idFromName: vi.fn((value: string) => value),
+        get: vi.fn(() => ({ checkUserLlmUsageAccess })),
+      },
+    };
+    await ChatThreadDO.prototype["assertPiUserLlmUsageAccess"].call(fake, context, modelConfig, "user1");
+    await ChatThreadDO.prototype["assertPiUserLlmUsageAccess"].call(fake, context, modelConfig, "user1");
+    expect(checkUserLlmUsageAccess).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces limit denial without entering hosted/free-model fallback", async () => {
+    const fake = Object.create(ChatThreadDO.prototype) as any;
+    fake.llmUsageSettlementChain = Promise.resolve();
+    fake.pendingLlmUsageSettlements = [];
+    fake.noLlmLimitsCachedUserId = null;
+    fake.fallbackThreadToFreeModel = vi.fn();
+    fake.env = {
+      ORG: {
+        idFromName: vi.fn((value: string) => value),
+        get: vi.fn(() => ({
+          checkUserLlmUsageAccess: vi.fn(async () => ({
+            allowed: false,
+            reason: "limit_exceeded" as const,
+            evaluated_at_ms: 1,
+            blocking_limit: {
+              window_hours: 24, limit_usd: 1, label: "daily", spent_usd: 1,
+              remaining_usd: 0, unpriced_requests: 0, exceeded: true, retry_at_ms: 2,
+            },
+            limits: [],
+          })),
+        })),
+      },
+    };
+
+    await expect(ChatThreadDO.prototype["assertPiUserLlmUsageAccess"].call(
+      fake, context, modelConfig, "initiating-user",
+    )).rejects.toMatchObject({ code: "limit_exceeded" });
+    expect(fake.fallbackThreadToFreeModel).not.toHaveBeenCalled();
+  });
+
+  it("retries a failed settlement before policy evaluation and then resumes the queue", async () => {
+    const checkUserLlmUsageAccess = vi.fn(async () => ({
+      allowed: true,
+      reason: "within_limits" as const,
+      evaluated_at_ms: 1,
+      blocking_limit: null,
+      limits: [],
+    }));
+    const settle = vi.fn()
+      .mockRejectedValueOnce(new Error("OrgDO temporarily unavailable"))
+      .mockResolvedValue(undefined);
+    const fake = Object.create(ChatThreadDO.prototype) as any;
+    fake.chatContext = context;
+    fake.llmUsageSettlementChain = Promise.resolve();
+    fake.pendingLlmUsageSettlements = [];
+    fake.noLlmLimitsCachedUserId = null;
+    fake.recordPiAssistantUsageSettled = settle;
+    fake.env = {
+      ORG: {
+        idFromName: vi.fn((value: string) => value),
+        get: vi.fn(() => ({ checkUserLlmUsageAccess })),
+      },
+    };
+    const firstMessage = { role: "assistant", content: [], usage: { input: 1 } } as any;
+    const attribution = {
+      userId: "initiating-user",
+      usageSurface: "agent" as const,
+      sourceScope: "thread1",
+    };
+
+    await expect(ChatThreadDO.prototype["recordPiAssistantUsage"].call(
+      fake, firstMessage, 10, "byok", false, "anthropic", attribution,
+    )).rejects.toThrow("temporarily unavailable");
+    expect(fake.pendingLlmUsageSettlements).toHaveLength(1);
+
+    await ChatThreadDO.prototype["assertPiUserLlmUsageAccess"].call(
+      fake, context, modelConfig, "initiating-user",
+    );
+    expect(settle).toHaveBeenCalledTimes(2);
+    expect(settle.mock.calls[1]).toEqual(settle.mock.calls[0]);
+    expect(checkUserLlmUsageAccess).toHaveBeenCalledOnce();
+    expect(fake.pendingLlmUsageSettlements).toHaveLength(0);
+
+    const secondMessage = { role: "assistant", content: [], usage: { input: 2 } } as any;
+    await ChatThreadDO.prototype["recordPiAssistantUsage"].call(
+      fake, secondMessage, 10, "byok", false, "anthropic", attribution,
+    );
+    expect(settle).toHaveBeenCalledTimes(3);
+    expect(settle.mock.calls[2][0]).toBe(secondMessage);
+    expect(fake.pendingLlmUsageSettlements).toHaveLength(0);
+  });
+
+  it("records the initiating user and context even if mutable chat context changes before settlement", async () => {
+    let release!: () => void;
+    const recordUsage = vi.fn(async () => undefined);
+    const fake = Object.create(ChatThreadDO.prototype) as any;
+    fake.chatContext = context;
+    fake.llmUsageSettlementChain = new Promise<void>((resolve) => { release = resolve; });
+    fake.pendingLlmUsageSettlements = [];
+    fake.env = {
+      ORG: {
+        idFromName: vi.fn((value: string) => value),
+        get: vi.fn(() => ({ recordUsage })),
+      },
+    };
+    const message = {
+      role: "assistant",
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      responseModel: "provider-canonical-model-v2",
+      responseId: "response-immutable-user",
+      content: [],
+      usage: { input: 5, output: 2, cacheRead: 0, cacheWrite: 0, totalTokens: 7 },
+    } as any;
+    const pending = ChatThreadDO.prototype["recordPiAssistantUsage"].call(
+      fake,
+      message,
+      10,
+      "byok",
+      false,
+      "anthropic",
+      {
+        userId: "initiating-user",
+        model: "custom/request-alias",
+        usageSurface: "agent",
+        sourceScope: "thread1",
+      },
+    );
+    fake.chatContext = {
+      orgId: "other-org",
+      workspaceId: "other-workspace",
+      threadId: "other-thread",
+      userId: "later-viewer",
+    };
+    release();
+    await pending;
+
+    expect(fake.env.ORG.idFromName).toHaveBeenCalledWith("org1");
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
+      workspace_id: "workspace1",
+      thread_id: "thread1",
+      user_id: "initiating-user",
+      model: "custom/request-alias",
+    }));
+  });
+
+  it("gates and meters each compaction pull with one stable pull id", async () => {
+    const response = {
+      role: "assistant",
+      content: [{ type: "text", text: "summary" }],
+      usage: { input: 10, output: 2, cacheRead: 0, cacheWrite: 0, totalTokens: 12 },
+      timestamp: 2,
+    };
+    const completeSimple = vi.fn(async () => response);
+    const beforePull = vi.fn(async () => undefined);
+    const afterPull = vi.fn(async () => undefined);
+    const model = {
+      id: "claude-sonnet-5",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      contextWindow: 128_000,
+      maxTokens: 4096,
+    };
+
+    await expect(summarizePiMessages(
+      [{ role: "user", content: "old context", timestamp: 1 }] as any,
+      model as any,
+      "key",
+      completeSimple as any,
+      undefined,
+      undefined,
+      { beforePull, afterPull },
+    )).resolves.toBe("summary");
+    expect(beforePull).toHaveBeenCalledOnce();
+    expect(completeSimple).toHaveBeenCalledOnce();
+    expect(afterPull).toHaveBeenCalledWith(response, beforePull.mock.calls[0][0], expect.any(Number));
+  });
+
+  it("stops compaction before the provider when its access check is denied", async () => {
+    const completeSimple = vi.fn();
+    const denial = new UserLlmUsageLimitError("limit_exceeded");
+    await expect(summarizePiMessages(
+      [{ role: "user", content: "old context", timestamp: 1 }] as any,
+      {
+        id: "claude-sonnet-5", api: "anthropic-messages", provider: "anthropic",
+        contextWindow: 128_000, maxTokens: 4096,
+      } as any,
+      "key",
+      completeSimple as any,
+      undefined,
+      undefined,
+      {
+        beforePull: vi.fn(async () => { throw denial; }),
+        afterPull: vi.fn(),
+      },
+    )).rejects.toBe(denial);
+    expect(completeSimple).not.toHaveBeenCalled();
+  });
+});

--- a/workers/main/tests/org-user-llm-usage-limits.test.ts
+++ b/workers/main/tests/org-user-llm-usage-limits.test.ts
@@ -1,0 +1,516 @@
+import { describe, expect, it, vi } from "vitest";
+import { env, evictDurableObject, runInDurableObject } from "cloudflare:test";
+import { OrgUsageControls } from "../src/identity/org/usage-controls";
+import { createOrg, createUser, type TestEnv } from "./test-helpers";
+
+const testEnv = env as unknown as TestEnv;
+
+function email(label: string): string {
+  return `${label}-${crypto.randomUUID()}@example.test`;
+}
+
+describe("OrgDO per-user LLM usage controls", () => {
+  it("keeps a 1,000-subject report page with multi-window policies to bounded SQL queries", () => {
+    const subjects = Array.from({ length: 1_000 }, (_, index) => ({
+      user_id: `user-${String(index).padStart(4, "0")}`,
+      current_member: 1,
+    }));
+    const limitRows = subjects.slice(0, 3).flatMap(({ user_id }) => [
+      { user_id, window_ms: 3_600_000, limit_microusd: 1_000_000, label: "hourly" },
+      { user_id, window_ms: 86_400_000, limit_microusd: 5_000_000, label: "daily" },
+    ]);
+    const aggregateRows = limitRows.map(({ user_id, window_ms }, index) => ({
+      user_id, window_ms, spent: index === 0 ? 1_000_000 : 0, unpriced: 0,
+    }));
+    const exec = vi.fn((sql: string) => ({
+      toArray: () => {
+        if (sql.includes("WITH subjects(user_id)")) return subjects;
+        if (sql.includes("expiry_candidates")) {
+          return [{ user_id: "user-0000", window_ms: 3_600_000, retry_at_ms: 3_600_001 }];
+        }
+        if (sql.includes("SELECT limits.user_id")) return aggregateRows;
+        if (sql.includes("FROM user_llm_usage_limits") && sql.includes("ORDER BY user_id")) return limitRows;
+        return [];
+      },
+    }));
+    const controls = new OrgUsageControls({
+      sql: { exec } as unknown as SqlStorage,
+      orgId: () => "org-scale",
+      isCurrentMember: () => true,
+      transactionSync: (callback) => callback(),
+    });
+
+    const report = controls.getUserReport({ from: 1, to: 2, limit: 1_000, now_ms: 2 });
+    expect(report.count).toBe(1_000);
+    expect(report.users[0]).toMatchObject({
+      membership_status: "current",
+      totals: { requests: 0 },
+      limit_status: { reason: "limit_exceeded", limits: [{ label: "hourly" }, { label: "daily" }] },
+    });
+    expect(report.users[999].limit_status.reason).toBe("no_limits");
+    expect(exec).toHaveBeenCalledTimes(6);
+    const expirySql = exec.mock.calls.map(([sql]) => sql).find((sql) => sql.includes("expiry_candidates"));
+    expect(expirySql).toContain("GROUP BY user_id, window_ms");
+  });
+
+  it("migrates and idempotently re-enters a real version-51 usage ledger", async () => {
+    const { userId } = await createUser(testEnv, email("migration-owner"), "password123", "Migration Owner");
+    const { org } = await createOrg(testEnv, "Usage Migration", userId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    await orgStub.recordUsage({
+      user_id: userId, provider: "anthropic", model: "claude-sonnet-5",
+      usage_kind: "llm", usage_surface: "agent", cost_usd: 1,
+      source: "pi_assistant", source_id: "legacy-pi",
+    });
+    await orgStub.recordUsage({
+      user_id: userId, provider: "camelai", model: "web-search",
+      usage_kind: "capability", usage_surface: "capability", cost_usd: 2,
+      billing_source: "hosted_capability", source: "web_search", source_id: "legacy-capability",
+    });
+    await orgStub.recordUsage({
+      user_id: userId, provider: "custom", model: "legacy-virtual",
+      usage_kind: "llm", usage_surface: "virtual_ai", cost_usd: 3,
+      thread_id: "virtual-ai", source: "virtual_ai", source_id: "legacy-virtual",
+    });
+    await orgStub.recordUsage({
+      user_id: userId, provider: "openrouter", model: "dynamic/auto_image",
+      usage_kind: "image", usage_surface: "auxiliary", cost_usd: 4,
+      thread_id: "virtual-ai", source: "virtual_ai", source_id: "legacy-auto-image",
+    });
+    await orgStub.recordUsage({
+      user_id: userId, provider: "openrouter", model: "google/gemini-2.5-flash-image-preview",
+      usage_kind: "image", usage_surface: "auxiliary", cost_usd: 5,
+      thread_id: "virtual-ai", source: "virtual_ai", source_id: "legacy-concrete-image-response",
+    });
+    await runInDurableObject(orgStub, (_instance, state) => {
+      const sql = state.storage.sql;
+      sql.exec("DROP TABLE user_llm_usage_limits");
+      sql.exec("DROP TABLE llm_model_pricing_overrides");
+      sql.exec("DROP INDEX idx_usage_log_user_created_at");
+      sql.exec("DROP INDEX idx_usage_log_user_model_created_at");
+      sql.exec("ALTER TABLE usage_log DROP COLUMN usage_kind");
+      sql.exec("ALTER TABLE usage_log DROP COLUMN usage_surface");
+      sql.exec("ALTER TABLE usage_log DROP COLUMN metered_cost_microusd");
+      sql.exec("ALTER TABLE usage_log DROP COLUMN cost_source");
+      state.storage.kv.put("schemaVersion", 51);
+    });
+    await evictDurableObject(orgStub);
+
+    const migrated = await orgStub.getUsageLog({ user_id: userId, limit: 10 });
+    expect(migrated.entries.map((entry) => ({
+      source: entry.source,
+      kind: entry.usage_kind,
+      surface: entry.usage_surface,
+      metered: entry.metered_cost_usd,
+      costSource: entry.cost_source,
+    }))).toEqual([
+      { source: "virtual_ai", kind: "unknown", surface: "virtual_ai", metered: 5, costSource: "legacy_estimate" },
+      { source: "virtual_ai", kind: "image", surface: "auxiliary", metered: 4, costSource: "legacy_estimate" },
+      { source: "virtual_ai", kind: "unknown", surface: "virtual_ai", metered: 3, costSource: "legacy_estimate" },
+      { source: "web_search", kind: "capability", surface: "capability", metered: 2, costSource: "legacy_estimate" },
+      { source: "pi_assistant", kind: "llm", surface: "agent", metered: 1, costSource: "legacy_estimate" },
+    ]);
+    await runInDurableObject(orgStub, (_instance, state) => {
+      const indexes = state.storage.sql.exec<{ name: string }>("PRAGMA index_list(usage_log)").toArray();
+      expect(indexes.map((index) => index.name)).toEqual(expect.arrayContaining([
+        "idx_usage_log_user_created_at",
+        "idx_usage_log_user_model_created_at",
+      ]));
+      expect(state.storage.kv.get("schemaVersion")).toBe(52);
+    });
+    await evictDurableObject(orgStub);
+    const reentered = await orgStub.getUsageLog({ user_id: userId, limit: 10 });
+    expect(reentered.entries).toEqual(migrated.entries);
+  });
+
+  it("enforces settled micro-USD spend, strict pricing, and idempotent rows", async () => {
+    const { userId } = await createUser(testEnv, email("usage-owner"), "password123", "Usage Owner");
+    const { org, defaultWorkspaceId } = await createOrg(testEnv, "Usage Limits", userId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    const now = 1_800_000_000_000;
+
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "custom",
+      model: "acme-code-70b",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: true, reason: "no_limits" });
+
+    await orgStub.setUserLlmUsageLimits(userId, [
+      { window_hours: 24, limit_usd: 1, label: "daily" },
+      { window_hours: 720, limit_usd: 10, label: "30-day" },
+    ]);
+
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "custom",
+      model: "acme-code-70b",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: false, reason: "pricing_unavailable" });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "custom",
+      model: "acme-claude-sonnet-5-local",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: false, reason: "pricing_unavailable" });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "custom",
+      model: "gpt-5.6-terra-finetune",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: false, reason: "pricing_unavailable" });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "openai",
+      model: "acme-claude-sonnet-5-local",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: false, reason: "pricing_unavailable" });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "bedrock",
+      model: "anthropic.claude-haiku-4-5",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: true, reason: "within_limits" });
+    for (const model of ["openai.gpt-5.6-sol", "openai.gpt-5.6-terra"]) {
+      await expect(orgStub.checkUserLlmUsageAccess({
+        user_id: userId,
+        provider: "bedrock",
+        model,
+        now_ms: now,
+      })).resolves.toMatchObject({ allowed: true, reason: "within_limits" });
+    }
+
+    await orgStub.setLlmUsagePricing([{
+      provider: "custom",
+      model: "acme-code-70b",
+      input_usd_per_million: 0,
+      output_usd_per_million: 0,
+    }]);
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "another-provider",
+      model: "acme-code-70b",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: false, reason: "pricing_unavailable" });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "custom",
+      model: "acme-code-70b",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: true, reason: "within_limits" });
+
+    const usage = {
+      workspace_id: defaultWorkspaceId,
+      user_id: userId,
+      thread_id: "thread-1",
+      provider: "custom",
+      model: "acme-code-70b",
+      usage_kind: "llm" as const,
+      usage_surface: "agent" as const,
+      input_tokens: 100,
+      output_tokens: 20,
+      reported_cost_usd: 1.25,
+      created_at_ms: now - 1_000,
+      source: "pi_assistant",
+      source_id: "response-1",
+    };
+    await orgStub.recordUsage(usage);
+    await orgStub.recordUsage(usage);
+
+    const access = await orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "custom",
+      model: "acme-code-70b",
+      now_ms: now,
+    });
+    expect(access).toMatchObject({ allowed: false, reason: "limit_exceeded" });
+    expect(access.blocking_limit).toMatchObject({
+      label: "daily",
+      spent_usd: 1.25,
+      limit_usd: 1,
+      retry_at_ms: now - 1_000 + 24 * 60 * 60 * 1000 + 1,
+    });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "custom",
+      model: "acme-code-70b",
+      now_ms: access.blocking_limit!.retry_at_ms!,
+    })).resolves.toMatchObject({ allowed: true, reason: "within_limits" });
+
+    const aggregate = await orgStub.getUsageLogAggregate({
+      from: now - 10_000,
+      to: now,
+      user_id: userId,
+      usage_kind: "llm",
+    });
+    expect(aggregate).toMatchObject({
+      total_requests: 1,
+      metered_cost_usd: 1.25,
+      unpriced_requests: 0,
+      total_input_tokens: 100,
+      total_output_tokens: 20,
+    });
+  });
+
+  it("excludes capability spend and uses half-open rolling-window boundaries", async () => {
+    const { userId } = await createUser(testEnv, email("boundary-owner"), "password123", "Boundary Owner");
+    const { org } = await createOrg(testEnv, "Usage Boundaries", userId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    const now = 1_805_000_000_000;
+    await orgStub.setUserLlmUsageLimits(userId, [{ window_hours: 1, limit_usd: 1 }]);
+    await orgStub.recordUsage({
+      user_id: userId,
+      provider: "camelai",
+      model: "web-search",
+      usage_kind: "capability",
+      usage_surface: "capability",
+      cost_usd: 100,
+      created_at_ms: now - 100,
+      source: "web_search",
+      source_id: "capability-row",
+    });
+    await orgStub.recordUsage({
+      user_id: userId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      usage_kind: "llm",
+      usage_surface: "agent",
+      reported_cost_usd: 1,
+      created_at_ms: now - 60 * 60 * 1000,
+      source: "pi_assistant",
+      source_id: "boundary-row",
+    });
+
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      now_ms: now,
+    })).resolves.toMatchObject({ allowed: false, reason: "limit_exceeded" });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      now_ms: now + 1,
+    })).resolves.toMatchObject({ allowed: true, reason: "within_limits" });
+  });
+
+  it("reports the latest blocking retry when multiple rolling windows are exceeded", async () => {
+    const { userId } = await createUser(testEnv, email("multi-window-owner"), "password123", "Multi Window Owner");
+    const { org } = await createOrg(testEnv, "Multi Window Limits", userId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    const now = 1_807_000_000_000;
+    const createdAt = now - 1_000;
+    await orgStub.setUserLlmUsageLimits(userId, [
+      { window_hours: 1, limit_usd: 1, label: "hourly" },
+      { window_hours: 24, limit_usd: 2, label: "daily" },
+    ]);
+    await orgStub.recordUsage({
+      user_id: userId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      usage_kind: "llm",
+      usage_surface: "agent",
+      reported_cost_usd: 3,
+      created_at_ms: createdAt,
+      source: "pi_assistant",
+      source_id: "multi-window-row",
+    });
+
+    const access = await orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      now_ms: now,
+    });
+    expect(access).toMatchObject({
+      allowed: false,
+      reason: "limit_exceeded",
+      blocking_limit: {
+        label: "daily",
+        retry_at_ms: createdAt + 24 * 60 * 60 * 1000 + 1,
+      },
+    });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      now_ms: createdAt + 60 * 60 * 1000 + 1,
+    })).resolves.toMatchObject({ allowed: false, reason: "limit_exceeded" });
+    await expect(orgStub.checkUserLlmUsageAccess({
+      user_id: userId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      now_ms: access.blocking_limit!.retry_at_ms!,
+    })).resolves.toMatchObject({ allowed: true, reason: "within_limits" });
+  });
+
+  it("reports current, former, and unattributed subjects and clears removed-member limits", async () => {
+    const { userId: ownerId } = await createUser(testEnv, email("report-owner"), "password123", "Report Owner");
+    const { userId: memberId } = await createUser(testEnv, email("report-member"), "password123", "Report Member");
+    const { org } = await createOrg(testEnv, "Usage Report", ownerId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    const now = 1_810_000_000_000;
+    await orgStub.addMember(memberId, "member", ownerId);
+    await orgStub.setUserLlmUsageLimits(memberId, [{ window_hours: 1, limit_usd: 2 }]);
+    await orgStub.recordUsage({
+      user_id: memberId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      usage_kind: "llm",
+      usage_surface: "subagent",
+      input_tokens: 10,
+      output_tokens: 5,
+      reported_cost_usd: 0.25,
+      created_at_ms: now - 100,
+      source: "pi_assistant",
+      source_id: "member-row",
+    });
+    await orgStub.recordUsage({
+      user_id: "",
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      usage_kind: "llm",
+      usage_surface: "virtual_ai",
+      input_tokens: 3,
+      output_tokens: 2,
+      reported_cost_usd: 0.1,
+      created_at_ms: now - 50,
+      source: "virtual_ai",
+      source_id: "unattributed-row",
+    });
+
+    await orgStub.removeMember(memberId, ownerId);
+    expect((await orgStub.getUserLlmUsageLimits(memberId)).limits).toEqual([]);
+    const report = await orgStub.getUserLlmUsageReport({
+      from: now - 1_000,
+      to: now,
+      now_ms: now,
+    });
+    expect(report.users.map((user) => [user.user_id, user.membership_status])).toEqual([
+      [null, "unattributed"],
+      [ownerId, "current"],
+      [memberId, "former"],
+    ].sort((left, right) => {
+      if (left[0] === null) return -1;
+      if (right[0] === null) return 1;
+      return String(left[0]).localeCompare(String(right[0]));
+    }));
+    expect(report.users.find((user) => user.user_id === ownerId)?.totals.requests).toBe(0);
+    expect(report.users.find((user) => user.user_id === memberId)?.models[0]).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      requests: 1,
+      spend_usd: 0.25,
+    });
+    expect(report.users.find((user) => user.user_id === null)?.totals.requests).toBe(1);
+  });
+
+  it("preserves historical row pricing after override replacement", async () => {
+    const { userId } = await createUser(testEnv, email("validation-owner"), "password123", "Validation Owner");
+    const { org } = await createOrg(testEnv, "Usage Validation", userId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    await orgStub.setLlmUsagePricing([{
+      provider: "custom", model: "snapshot-model",
+      input_usd_per_million: 1, output_usd_per_million: 2,
+    }]);
+    await orgStub.recordUsage({
+      user_id: userId, provider: "custom", model: "snapshot-model",
+      usage_kind: "llm", usage_surface: "agent",
+      input_tokens: 1_000_000, output_tokens: 1_000_000,
+      reported_cost_usd: 0,
+      upstream_inference_cost_usd: 0,
+      source: "pi_assistant", source_id: "snapshot-row",
+    });
+    await orgStub.setLlmUsagePricing([{
+      provider: "custom", model: "snapshot-model",
+      input_usd_per_million: 10, output_usd_per_million: 20,
+    }]);
+    const page = await orgStub.getUsageLog({ user_id: userId, model: "snapshot-model" });
+    expect(page.entries[0]).toMatchObject({
+      metered_cost_usd: 3,
+      cost_source: "org_override",
+      usage_kind: "llm",
+      usage_surface: "agent",
+    });
+  });
+
+  it("treats zero reported-cost placeholders as absent for strict pricing", async () => {
+    const { userId } = await createUser(testEnv, email("zero-cost-owner"), "password123", "Zero Cost Owner");
+    const { org } = await createOrg(testEnv, "Zero Cost Pricing", userId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    await orgStub.recordUsage({
+      user_id: userId,
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      usage_kind: "llm",
+      usage_surface: "agent",
+      input_tokens: 1_000_000,
+      reported_cost_usd: 0,
+      upstream_inference_cost_usd: 0,
+      source: "pi_assistant",
+      source_id: "zero-reported-builtin",
+    });
+
+    const page = await orgStub.getUsageLog({ user_id: userId });
+    expect(page.entries[0].cost_source).toBe("builtin_pricing");
+    expect(page.entries[0].metered_cost_usd).toBeGreaterThan(0);
+  });
+
+  it("uses provider total cost without adding its upstream component", async () => {
+    const { userId } = await createUser(testEnv, email("provider-cost-owner"), "password123", "Provider Cost Owner");
+    const { org } = await createOrg(testEnv, "Provider Cost", userId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    await orgStub.recordUsage({
+      user_id: userId,
+      provider: "openrouter",
+      model: "openai/gpt-5.6-luna",
+      usage_kind: "llm",
+      usage_surface: "agent",
+      input_tokens: 10,
+      reported_cost_usd: 0.0012,
+      upstream_inference_cost_usd: 0.0048,
+      source: "pi_assistant",
+      source_id: "provider-total-not-component-sum",
+    });
+
+    const page = await orgStub.getUsageLog({ user_id: userId });
+    expect(page.entries[0]).toMatchObject({
+      metered_cost_usd: 0.0012,
+      cost_source: "provider_reported",
+    });
+  });
+
+  it("settles Bedrock GPT request ids with built-in pricing", async () => {
+    const { userId } = await createUser(testEnv, email("bedrock-gpt-owner"), "password123", "Bedrock GPT Owner");
+    const { org } = await createOrg(testEnv, "Bedrock GPT Pricing", userId);
+    const orgStub = testEnv.ORG.get(testEnv.ORG.idFromName(org.id));
+    for (const model of ["openai.gpt-5.6-sol", "openai.gpt-5.6-terra"]) {
+      await orgStub.recordUsage({
+        user_id: userId,
+        provider: "bedrock",
+        model,
+        usage_kind: "llm",
+        usage_surface: "agent",
+        input_tokens: 100_000,
+        source: "pi_assistant",
+        source_id: `bedrock-pricing-${model}`,
+      });
+    }
+
+    const page = await orgStub.getUsageLog({ user_id: userId, limit: 10 });
+    expect(page.entries).toHaveLength(2);
+    expect(page.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        model: "openai.gpt-5.6-sol",
+        cost_source: "builtin_pricing",
+        metered_cost_usd: 0.5,
+      }),
+      expect.objectContaining({
+        model: "openai.gpt-5.6-terra",
+        cost_source: "builtin_pricing",
+        metered_cost_usd: 0.2,
+      }),
+    ]));
+  });
+});

--- a/workers/main/tests/pi-stream-retry.test.ts
+++ b/workers/main/tests/pi-stream-retry.test.ts
@@ -13,22 +13,33 @@ const model = {
   baseUrl: "https://bedrock-mantle.us-east-1.api.aws/openai/v1",
 } as any;
 
-function errorStream(message: string) {
+function errorStream(message: string, usage?: Partial<ReturnType<typeof createPiProviderStreamErrorMessage>["usage"]>) {
   const stream = createAssistantMessageEventStream();
+  const error = createPiProviderStreamErrorMessage(model, message, "error");
+  error.usage = {
+    ...error.usage,
+    ...usage,
+    cost: { ...error.usage.cost, ...usage?.cost },
+  };
   stream.push({
     type: "error",
     reason: "error",
-    error: createPiProviderStreamErrorMessage(model, message, "error"),
+    error,
   });
   stream.end();
   return stream;
 }
 
-function successStream() {
+function successStream(usage?: Partial<ReturnType<typeof createPiProviderStreamErrorMessage>["usage"]>) {
   const stream = createAssistantMessageEventStream();
   const message = createPiProviderStreamErrorMessage(model, "", "error");
   message.stopReason = "stop";
   delete message.errorMessage;
+  message.usage = {
+    ...message.usage,
+    ...usage,
+    cost: { ...message.usage.cost, ...usage?.cost },
+  };
   stream.push({ type: "start", partial: message });
   stream.push({ type: "done", reason: "stop", message });
   stream.end();
@@ -80,5 +91,88 @@ describe("Pi provider stream regional retry", () => {
 
     expect(createStream).toHaveBeenCalledOnce();
     expect(events.map((event) => event.type)).toEqual(["error"]);
+  });
+
+  it("merges hidden failed-attempt usage into the one logical completion", async () => {
+    const createStream = vi
+      .fn()
+      .mockImplementationOnce(() => errorStream("network connection lost", {
+        input: 100,
+        cacheRead: 40,
+        totalTokens: 140,
+        cost: { input: 0.1, output: 0, cacheRead: 0.02, cacheWrite: 0, total: 0.12 },
+      }))
+      .mockImplementationOnce(() => successStream({
+        input: 20,
+        output: 5,
+        totalTokens: 25,
+        cost: { input: 0.02, output: 0.01, cacheRead: 0, cacheWrite: 0, total: 0.03 },
+      }));
+    const output = streamPiModelWithTransientRetry(model, {}, createStream, vi.fn());
+
+    const events = [];
+    for await (const event of output) events.push(event);
+
+    expect(events.map((event) => event.type)).toEqual(["start", "done"]);
+    const done = events.find((event) => event.type === "done");
+    expect(done?.message.usage).toMatchObject({
+      input: 120,
+      output: 5,
+      cacheRead: 40,
+      totalTokens: 165,
+    });
+    expect(done?.message.usage.cost.input).toBeCloseTo(0.12);
+    expect(done?.message.usage.cost.output).toBeCloseTo(0.01);
+    expect(done?.message.usage.cost.cacheRead).toBeCloseTo(0.02);
+    expect(done?.message.usage.cost.total).toBeCloseTo(0.15);
+  });
+
+  it("preserves hidden usage when a later attempt throws", async () => {
+    const createStream = vi
+      .fn()
+      .mockImplementationOnce(() => errorStream("network connection lost", {
+        input: 100,
+        cacheRead: 40,
+        totalTokens: 140,
+      }))
+      .mockImplementationOnce(() => {
+        throw new Error("401 authentication_error");
+      });
+    const output = streamPiModelWithTransientRetry(model, {}, createStream, vi.fn());
+
+    const events = [];
+    for await (const event of output) events.push(event);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      error: { usage: { input: 100, cacheRead: 40, totalTokens: 140 } },
+    });
+  });
+
+  it("preserves hidden failed-attempt usage when cancellation interrupts backoff", async () => {
+    const controller = new AbortController();
+    const output = streamPiModelWithTransientRetry(
+      model,
+      { signal: controller.signal },
+      () => errorStream("network connection lost", {
+        input: 100,
+        cacheRead: 40,
+        totalTokens: 140,
+        cost: { input: 0.1, output: 0, cacheRead: 0.02, cacheWrite: 0, total: 0.12 },
+      }),
+      vi.fn(),
+      { onRetry: () => controller.abort() },
+    );
+
+    const events = [];
+    for await (const event of output) events.push(event);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      reason: "aborted",
+      error: { usage: { input: 100, cacheRead: 40, totalTokens: 140, cost: { total: 0.12 } } },
+    });
   });
 });

--- a/workers/main/tests/workspace-cron.test.ts
+++ b/workers/main/tests/workspace-cron.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { env, runInDurableObject } from 'cloudflare:test';
+import { env, evictDurableObject, runInDurableObject } from 'cloudflare:test';
 import type { OrgDO } from '../src/auth';
 import { CodeModeDeterministicAutomations } from '../src/code-mode-deterministic-automations';
 import type { AutomationRunCursor, WorkspaceCronDO } from '../src/workspace-cron';
@@ -96,6 +96,12 @@ export class AutomationWorkflow extends WorkflowEntrypoint {
       ? await orgStub.getThread(run.dispatch.thread_id)
       : null;
     expect(repairedThread?.source).toBe('scheduled');
+    const repairedChatStub = testEnv.CHAT_THREAD.get(
+      testEnv.CHAT_THREAD.idFromName(run!.dispatch.thread_id),
+    );
+    const repairedChatContext = await runInDurableObject(repairedChatStub, (_instance, state) =>
+      state.storage.kv.get<{ userId: string | null }>('chatContext'));
+    expect(repairedChatContext?.userId).toBe(userId);
     const runsAfterStart = await cronStub.listAutomationRuns(workspaceId!, {
       limitPerAutomation: 5,
     });
@@ -142,6 +148,43 @@ export class AutomationWorkflow extends WorkflowEntrypoint {
     expect(listAfterDelete).toHaveLength(0);
     const runsAfterDelete = await cronStub.listAutomationRuns(workspaceId!);
     expect(runsAfterDelete[`scheduled_prompt:${created.id}`]).toBeUndefined();
+  });
+
+  it('attributes a reused scheduled thread to the prompt creator instead of a stale viewer', async () => {
+    const { userId } = await createUser(testEnv, testEmail(), 'password123', 'Cron Attribution Owner');
+    const { org } = await createOrg(testEnv, 'Cron Attribution Org', userId);
+    const workspaces = await listUserWorkspaces(testEnv, userId, org.id);
+    const workspaceId = workspaces[0]!.id;
+    const cronStub = testEnv.WORKSPACE_CRON.get(
+      testEnv.WORKSPACE_CRON.idFromName(workspaceId),
+    ) as DurableObjectStub<WorkspaceCronDO>;
+    const created = await cronStub.createScheduledPrompt({
+      workspaceId,
+      name: 'Attributed digest',
+      prompt: 'Summarize workspace status.',
+      cronExpression: '0 9 * * *',
+      createdBy: userId,
+    });
+    const chatStub = testEnv.CHAT_THREAD.get(
+      testEnv.CHAT_THREAD.idFromName(created.thread_id),
+    );
+    await runInDurableObject(chatStub, (_instance, state) => {
+      state.storage.kv.put('chatContext', {
+        threadId: created.thread_id,
+        workspaceId,
+        orgId: org.id,
+        userId: 'stale-viewer',
+        userName: 'Stale Viewer',
+        userEmail: null,
+      });
+    });
+    await evictDurableObject(chatStub);
+
+    const run = await cronStub.runScheduledPromptNow(workspaceId, created.id);
+    expect(run?.dispatch.thread_id).toBe(created.thread_id);
+    const updatedContext = await runInDurableObject(chatStub, (_instance, state) =>
+      state.storage.kv.get<{ userId: string | null }>('chatContext'));
+    expect(updatedContext?.userId).toBe(userId);
   });
 
   it('does not let an older scheduled prompt completion overwrite the latest run summary', async () => {


### PR DESCRIPTION
## Summary

- add schema v52 per-user LLM usage accounting with strict micro-USD pricing, exact provider/model overrides, rolling limits, filtered per-pull logs, sums, and per-user/model reports
- enforce and settle usage for main agents, child agents, compaction, scheduled prompts, and attributable Virtual AI calls, including failed responses and hidden provider-retry usage
- add bearer admin REST/OpenAPI endpoints and first-class OAuth admin MCP tools without adding product UI
- generate and migrate `ADMIN_API_KEY` safely for self-host installs, wire Compose/workerd/cloud templates, extend doctor checks, and document operator workflows
- add migration, attribution, pricing, concurrency, API, MCP, and self-host regression coverage

## Why

Self-hosted customers need billing-grade visibility into token/model spend per user and a way for an operator or coding agent to configure rolling user limits without exposing a product UI.

## v1 behavior

Limits are settled-usage, stop-new-pull soft caps. An accepted pull can cross a cap, and concurrently accepted pulls can settle afterward. Provider region/transient retries remain one logical pull and one usage row.

Settlement is idempotent and retried in-process. A durable settlement outbox across an accounting outage plus producer-isolate eviction is intentionally deferred.

## Validation

- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- `bun run test:all`
  - 2,644 unit tests passed
  - 2,215 Worker tests passed
  - 36 Discord bridge tests passed
  - 4,895 total tests passed
- `bun run test:selfhost`
  - release/upgrade/cloud-template contracts
  - production build and generated workerd configuration
  - Images, Workers-for-Platforms/facets, and bundled user-worker smoke tests

Three independent review passes covered accounting/pricing, runtime/concurrency, and admin API/self-host behavior; all final passes found no remaining actionable defects.

## Deployment note

Run the final customer-shaped canary with the exact release images on the target x86_64 Linux host and provider configuration before rollout.
