### PR TITLE
Fix self-hosted Settings app URLs

### DIFF
--- a/src/routes/_app.settings.workspace.apps.tsx
+++ b/src/routes/_app.settings.workspace.apps.tsx
@@ -26,6 +26,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ExternalLink, Trash2 } from 'lucide-react';
 import { NoWorkspacesError } from '@/components/no-workspaces-error';
 import { getPreferredAppUrl } from '@/lib/app-url';
+import { getAppUrlContext } from '@/lib/app-url.server';
 import { refreshWorkerScriptCustomDomainStates } from '@/lib/custom-domain.server';
 import { loadUserProfileSummaries } from '@/lib/user-profiles.server';
 import type { WorkerScriptWithCreator } from '@/types';
@@ -113,6 +114,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   await requireOrgAdmin(request, context, authContext.currentOrg.id);
   const env = getEnv(context);
   const authEnv = getAuthEnvFromCloudflare(env);
+  const appUrlContext = getAppUrlContext(env, request);
 
   const url = new URL(request.url);
   const filter = url.searchParams.get('filter') || 'this-workspace';
@@ -127,6 +129,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       filter,
       orgSlug,
       orgCustomDomain: null,
+      appUrlContext,
       selfhostRuntime: isSelfhostRuntime(env),
     };
   }
@@ -177,6 +180,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     filter,
     orgSlug,
     orgCustomDomain: null,
+    appUrlContext,
     selfhostRuntime: isSelfhostRuntime(env),
   };
 }
@@ -187,6 +191,7 @@ export default function WorkspaceAppsPage() {
     hasWorkspace,
     orgSlug,
     orgCustomDomain,
+    appUrlContext,
     selfhostRuntime,
   } = useLoaderData<typeof loader>();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -253,66 +258,74 @@ export default function WorkspaceAppsPage() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {apps.map((app) => (
-              <TableRow key={app.script_name}>
-                <TableCell className="font-medium font-mono text-sm">
-                  <a
-                    href={getPreferredAppUrl(app, { orgSlug, orgCustomDomain })}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="hover:underline"
-                  >
-                    {app.script_name}
-                  </a>
-                </TableCell>
-                {showWorkspaceColumn ? (
+            {apps.map((app) => {
+              const appUrl = getPreferredAppUrl(app, {
+                hostname: appUrlContext,
+                orgSlug,
+                orgCustomDomain,
+              });
+
+              return (
+                <TableRow key={app.script_name}>
+                  <TableCell className="font-medium font-mono text-sm">
+                    <a
+                      href={appUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:underline"
+                    >
+                      {app.script_name}
+                    </a>
+                  </TableCell>
+                  {showWorkspaceColumn ? (
+                    <TableCell className="text-muted-foreground text-sm">
+                      {app.workspace_name}
+                    </TableCell>
+                  ) : null}
                   <TableCell className="text-muted-foreground text-sm">
-                    {app.workspace_name}
+                    {app.creator?.name ?? app.creator?.email ?? '—'}
                   </TableCell>
-                ) : null}
-                <TableCell className="text-muted-foreground text-sm">
-                  {app.creator?.name ?? app.creator?.email ?? '—'}
-                </TableCell>
-                <TableCell className="text-muted-foreground text-sm">
-                  {formatDate(app.created_at)}
-                </TableCell>
-                <TableCell className="text-muted-foreground text-sm">
-                  {formatDate(app.updated_at)}
-                </TableCell>
-                {!selfhostRuntime ? (
+                  <TableCell className="text-muted-foreground text-sm">
+                    {formatDate(app.created_at)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {formatDate(app.updated_at)}
+                  </TableCell>
+                  {!selfhostRuntime ? (
+                    <TableCell>
+                      <Badge variant={app.is_public ? 'secondary' : 'outline'}>
+                        {app.is_public ? 'Public' : 'Private'}
+                      </Badge>
+                    </TableCell>
+                  ) : null}
                   <TableCell>
-                    <Badge variant={app.is_public ? 'secondary' : 'outline'}>
-                      {app.is_public ? 'Public' : 'Private'}
-                    </Badge>
-                  </TableCell>
-                ) : null}
-                <TableCell>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      asChild
-                    >
-                      <a
-                        href={getPreferredAppUrl(app, { orgSlug, orgCustomDomain })}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        title="Open in new tab"
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        asChild
                       >
-                        <ExternalLink className="h-4 w-4" />
-                      </a>
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setDeleteTarget(app)}
-                    >
-                      <Trash2 className="h-4 w-4 text-destructive" />
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
+                        <a
+                          href={appUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title="Open in new tab"
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </a>
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setDeleteTarget(app)}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       )}

--- a/tests/workspace-apps-url.test.tsx
+++ b/tests/workspace-apps-url.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkerScript } from '@/types';
+
+const testState = vi.hoisted(() => ({
+  loaderData: { current: undefined as unknown },
+  requireAuthContext: vi.fn(),
+  requireOrgAdmin: vi.fn(),
+  getEnv: vi.fn(),
+  listWorkerScripts: vi.fn(),
+  refreshWorkerScriptCustomDomainStates: vi.fn(),
+  loadUserProfileSummaries: vi.fn(),
+  setSearchParams: vi.fn(),
+  fetcherSubmit: vi.fn(),
+}));
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
+  return {
+    ...actual,
+    useFetcher: () => ({
+      state: 'idle',
+      data: undefined,
+      submit: testState.fetcherSubmit,
+    }),
+    useLoaderData: () => testState.loaderData.current,
+    useSearchParams: () => [
+      new URLSearchParams(),
+      testState.setSearchParams,
+    ],
+  };
+});
+
+vi.mock('@/lib/auth.server', () => ({
+  requireAuthContext: testState.requireAuthContext,
+  requireOrgAdmin: testState.requireOrgAdmin,
+}));
+
+vi.mock('@/lib/cloudflare.server', () => ({
+  getEnv: testState.getEnv,
+}));
+
+vi.mock('@/lib/auth-do', () => ({
+  deleteWorkerScript: vi.fn(),
+  getWorkerScript: vi.fn(),
+}));
+
+vi.mock('@/lib/custom-domain.server', () => ({
+  refreshWorkerScriptCustomDomainStates:
+    testState.refreshWorkerScriptCustomDomainStates,
+}));
+
+vi.mock('@/lib/deployed-app-delete.server', () => ({
+  deleteDeployedAppRuntime: vi.fn(),
+}));
+
+vi.mock('@/lib/user-profiles.server', () => ({
+  loadUserProfileSummaries: testState.loadUserProfileSummaries,
+}));
+
+const { default: WorkspaceAppsPage, loader } = await import(
+  '@/routes/_app.settings.workspace.apps'
+);
+
+function makeScript(overrides: Partial<WorkerScript> = {}): WorkerScript {
+  return {
+    script_name: 'planthrive-prod',
+    workspace_id: 'workspace_1',
+    created_by: 'user_1',
+    created_at: 1,
+    updated_at: 2,
+    is_public: false,
+    preview_key: null,
+    preview_updated_at: null,
+    preview_status: null,
+    preview_error: null,
+    config_path: null,
+    project_id: null,
+    custom_domain_hostname: null,
+    custom_domain_cf_hostname_id: null,
+    custom_domain_status: null,
+    custom_domain_ssl_status: null,
+    custom_domain_error: null,
+    custom_domain_updated_at: null,
+    ...overrides,
+  };
+}
+
+function makeAuthContext(hasWorkspace = true) {
+  return {
+    user: { id: 'user_1', name: 'Valmark User', email: 'user@valmark.com' },
+    currentOrg: { id: 'org_1', slug: 'koy8lw' },
+    currentWorkspace: hasWorkspace ? { id: 'workspace_1' } : null,
+    workspaces: hasWorkspace
+      ? [{ id: 'workspace_1', name: 'Valmark Workspace' }]
+      : [],
+  };
+}
+
+function makeEnv() {
+  return {
+    CF_ACCOUNT_ID: 'selfhost',
+    LOCAL_APP_VANITY_DOMAIN: 'apps.valmark.com',
+    LOCAL_APP_IFRAME_DOMAIN: 'preview.valmark.com',
+    ORG: {
+      idFromName: vi.fn(() => 'org_1'),
+      get: vi.fn(() => ({
+        listWorkerScripts: testState.listWorkerScripts,
+      })),
+    },
+    USER: {},
+    WORKSPACE: {},
+  };
+}
+
+describe('workspace settings app URLs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.loaderData.current = undefined;
+    testState.requireAuthContext.mockResolvedValue(makeAuthContext());
+    testState.requireOrgAdmin.mockResolvedValue(undefined);
+    testState.getEnv.mockReturnValue(makeEnv());
+    testState.listWorkerScripts.mockResolvedValue([makeScript()]);
+    testState.refreshWorkerScriptCustomDomainStates.mockImplementation(
+      async (_env: unknown, _orgId: string, scripts: WorkerScript[]) => scripts,
+    );
+    testState.loadUserProfileSummaries.mockResolvedValue(new Map([
+      ['user_1', {
+        id: 'user_1',
+        name: 'Valmark User',
+        email: 'user@valmark.com',
+        avatar: null,
+      }],
+    ]));
+  });
+
+  it('uses the configured self-host app domain for both settings links', async () => {
+    const result = await loader({
+      request: new Request('https://vibe.valmark.com/settings/workspace/apps'),
+      context: {},
+      params: {},
+    } as never);
+
+    expect(result.appUrlContext).toEqual({
+      hostname: 'vibe.valmark.com',
+      vanityDomain: 'apps.valmark.com',
+      iframeDomain: 'preview.valmark.com',
+    });
+
+    testState.loaderData.current = result;
+    render(<WorkspaceAppsPage />);
+
+    const expectedUrl = 'https://planthrive-prod-koy8lw.apps.valmark.com';
+    expect(screen.getByRole('link', { name: 'planthrive-prod' }))
+      .toHaveAttribute('href', expectedUrl);
+    expect(screen.getByTitle('Open in new tab'))
+      .toHaveAttribute('href', expectedUrl);
+
+    for (const link of screen.getAllByRole('link')) {
+      expect(link.getAttribute('href')).not.toContain('vibe.valmark.com');
+    }
+  });
+
+  it('retains the app URL context when no workspace is selected', async () => {
+    testState.requireAuthContext.mockResolvedValue(makeAuthContext(false));
+
+    const result = await loader({
+      request: new Request('https://vibe.valmark.com/settings/workspace/apps'),
+      context: {},
+      params: {},
+    } as never);
+
+    expect(result).toMatchObject({
+      hasWorkspace: false,
+      appUrlContext: {
+        hostname: 'vibe.valmark.com',
+        vanityDomain: 'apps.valmark.com',
+        iframeDomain: 'preview.valmark.com',
+      },
+    });
+    expect(testState.listWorkerScripts).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed

- Pass the canonical app URL context from the Settings → Apps loader to the rendered app links.
- Reuse one preferred URL for both the app-name link and external-link action.
- Add route-level regression coverage using distinct control-plane, vanity, and iframe domains.

## Why

Self-hosted deployments can serve the camelAI control plane and published apps on different domains. Settings → Apps omitted the configured app URL context, so browser rendering fell back to the control-plane hostname. For Valmark, this produced `*.vibe.valmark.com` instead of the configured `*.apps.valmark.com` URL already shown correctly on `/apps`.

## Impact

Settings → Apps now follows the same URL selection path as `/apps`, while preserving exact custom-domain precedence, hosted environment behavior, and existing org-slug formatting.

## Validation

- `bun run test:run -- tests/workspace-apps-url.test.tsx tests/app-url.test.ts tests/dispatcher-url-parsing.test.ts` (13 tests)
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- Three independent code reviews; one test-strength suggestion was applied and re-reviewed with no remaining findings.